### PR TITLE
Fix missing Dock Icon by adding StartupWMClass to .desktop file

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -284,6 +284,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;
 MimeType=x-scheme-handler/claude;
+StartupWMClass=Claude
 EOF
 
 # Create launcher script


### PR DESCRIPTION
Using Ubuntu 24.02:

1. The default Gear icon was showing up for the Claude Desktop app when running.
![image](https://github.com/user-attachments/assets/7bfca423-f2f2-4de6-8eb3-ec212441b6a8)

2. When the app was pinned to the Dock/Dash, launching the app would create a new slot in the Dock/Dash which used the default Gear icon.
![image](https://github.com/user-attachments/assets/ee727b0b-4b7b-48b3-a512-9c271e6faec4)


Setting StartupWMClass in the .desktop file fixes this

ref: https://ubuntuhandbook.org/index.php/2024/04/missing-icon-dock-ubuntu-2404/