### PR TITLE
chore: update claude desktop version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd claude-desktop-linux
 
 # Build the package
 sudo ./build-deb.sh
-sudo dpkg -i ./build/electron-app/claude-desktop_0.7.8_amd64.deb
+sudo dpkg -i ./build/electron-app/claude-desktop_0.7.9_amd64.deb
 
 # The script will automatically:
 # - Check for and install required dependencies

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -83,7 +83,7 @@ if ! check_command "electron"; then
 fi
 
 # Extract version from the installer filename
-VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.7.8/')
+VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.7.9/')
 PACKAGE_NAME="claude-desktop"
 ARCHITECTURE="amd64"
 MAINTAINER="Claude Desktop Linux Maintainers"


### PR DESCRIPTION
Updated version of claude desktop app from `0.7.8` to `0.7.9`.

cc @aaddrick 