### PR TITLE
Bumping Claude Desktop version to 0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd claude-desktop-debian
 
 # Build the package
 sudo ./build-deb.sh
-sudo dpkg -i ./build/electron-app/claude-desktop_0.8.0_amd64.deb
+sudo dpkg -i ./build/electron-app/claude-desktop_0.8.1_amd64.deb
 
 # The script will automatically:
 # - Check for and install required dependencies

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -83,7 +83,7 @@ if ! check_command "electron"; then
 fi
 
 # Extract version from the installer filename
-VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.8.0/')
+VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.8.1/')
 PACKAGE_NAME="claude-desktop"
 ARCHITECTURE="amd64"
 MAINTAINER="Claude Desktop Linux Maintainers"


### PR DESCRIPTION
Closing this PR as the build script now detects the version automatically, superseding manual version bumps (see commit 520be5ce5d515a6ec3b6d866882bdfc6bc3bc34d and related changes). Thank you for the contribution!