### PR TITLE
Add automatic version detection to build-deb.sh

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -83,7 +83,7 @@ if ! check_command "electron"; then
 fi
 
 # Extract version from the installer filename
-VERSION=$(basename "$CLAUDE_DOWNLOAD_URL" | grep -oP 'Claude-Setup-x64\.exe' | sed 's/Claude-Setup-x64\.exe/0.8.0/')
+VERSION=$(7z l "$CLAUDE_EXE" | grep "Comment" | grep -oP "FileVersion: \K[0-9\.]+")
 PACKAGE_NAME="claude-desktop"
 ARCHITECTURE="amd64"
 MAINTAINER="Claude Desktop Linux Maintainers"


### PR DESCRIPTION
Closing this PR as automatic version detection has been implemented in the main branch (see commit 520be5ce5d515a6ec3b6d866882bdfc6bc3bc34d and related changes). Thank you for the contribution!