### PR TITLE
updated path in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cd claude-desktop-debian
 
 # Build the package
 sudo ./build-deb.sh
-sudo dpkg -i ./build/electron-app/claude-desktop_0.8.0_amd64.deb
+sudo dpkg -i ./build/claude-desktop_0.8.1_amd64.deb
 
 # The script will automatically:
 # - Check for and install required dependencies


### PR DESCRIPTION
it doesn't create the deb (anymore?) in build/electron-app/ ... and updated the version number to what's current. 