### PR TITLE
chore: fix typo in stdout message

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -173,7 +173,7 @@ for cmd in $ALL_DEPS_TO_CHECK; do
             "wrestool"|"icotool") DEPS_TO_INSTALL="$DEPS_TO_INSTALL icoutils" ;;
             "convert") DEPS_TO_INSTALL="$DEPS_TO_INSTALL imagemagick" ;;
             "npx") DEPS_TO_INSTALL="$DEPS_TO_INSTALL nodejs npm" ;;
-            "dpkg-deb") DEPS_TO_INSTALL="$DEPS_TO_INSTALL dpkg-dev" ;;
+            "dpkg-deb") DEPS_TO_INSTALL="$DEPS_TO_INSTALL dpkg-deb" ;;
         esac
     fi
 done


### PR DESCRIPTION
The program is checking for the presence of `dpkg-deb`. If the package is not found, the message printed to the console says `dpkg-dev` is missing, instead of `dpkg-deb`.