### PR TITLE
chore: check for presence of dpkg-deb command, instead of dpkg-dev wh…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -156,7 +156,7 @@ check_command() {
 echo "Checking dependencies..."
 DEPS_TO_INSTALL=""
 COMMON_DEPS="p7zip wget wrestool icotool convert npx"
-DEB_DEPS="dpkg-dev"
+DEB_DEPS="dpkg-deb"
 APPIMAGE_DEPS="" 
 ALL_DEPS_TO_CHECK="$COMMON_DEPS"
 if [ "$BUILD_FORMAT" = "deb" ]; then


### PR DESCRIPTION
…ich is a package

The program currently warns that `dpkg-dev` is not installed. I checked, and in my case, I have the package installed. 

I believe the correct behavior should be to check for the presence of the `dpkg-deb` program in the OS, which is installed through the `dpkg-dev` package.