### PR TITLE
bug: it can't type language in ibus, fcitx5 and add text input version Electron argments

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -107,7 +107,7 @@ ELECTRON_ARGS=("--no-sandbox" "\$APP_PATH")
 # Add Wayland flags if Wayland is detected
 if [ "\$IS_WAYLAND" = true ]; then
   echo "AppRun: Wayland detected, adding flags."
-  ELECTRON_ARGS+=("--enable-features=UseOzonePlatform,WaylandWindowDecorations" "--ozone-platform=wayland")
+  ELECTRON_ARGS+=("--enable-features=UseOzonePlatform,WaylandWindowDecorations" "--ozone-platform=wayland" "--enable-wayland-ime" "--wayland-text-input-version=3")
 fi
 
 # Change to the application resources directory (where app.asar is)

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -128,7 +128,7 @@ ELECTRON_ARGS=("\$APP_PATH")
 # Add Wayland flags if Wayland is detected
 if [ "\$IS_WAYLAND" = true ]; then
   echo "Adding Wayland flags" >> "\$LOG_FILE"
-  ELECTRON_ARGS+=("--enable-features=UseOzonePlatform,WaylandWindowDecorations" "--ozone-platform=wayland")
+  ELECTRON_ARGS+=("--enable-features=UseOzonePlatform,WaylandWindowDecorations" "--ozone-platform=wayland" "--enable-wayland-ime" "--wayland-text-input-version=3")
 fi
 
 # Change to the application directory


### PR DESCRIPTION
i can't type korean ibus, fctix5 ime in ubuntu
there are same problems in [Electron Issue](https://github.com/electron/electron/issues/33662#issuecomment-2299180561)
the argument `--ozone-platform-hint=auto --enable-wayland-ime --wayland-text-input-version=3`  is well done