### PR TITLE
feat: Add native window decorations support for Linux

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -113,7 +113,15 @@ if [ "\$IS_WAYLAND" = true ]; then
   ELECTRON_ARGS+=("--ozone-platform=wayland")
   ELECTRON_ARGS+=("--enable-wayland-ime")
   ELECTRON_ARGS+=("--wayland-text-input-version=3")
+else
+  # X11 session - ensure native window decorations
+  echo "AppRun: X11 session detected, enabling native window decorations."
 fi
+
+# Force disable custom titlebar for all sessions
+ELECTRON_ARGS+=("--disable-features=CustomTitlebar")
+# Try to force native frame
+export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 
 # Change to the application resources directory (where app.asar is)
 cd "\$APPDIR/usr/lib" || exit 1

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -152,7 +152,15 @@ if [ "\$IS_WAYLAND" = true ]; then
   ELECTRON_ARGS+=("--enable-wayland-ime")
   ELECTRON_ARGS+=("--wayland-text-input-version=3")
   echo "Enabled native Wayland support with GlobalShortcuts Portal" >> "\$LOG_FILE"
+else
+  # X11 session - ensure native window decorations
+  echo "X11 session detected, enabling native window decorations" >> "\$LOG_FILE"
 fi
+
+# Force disable custom titlebar for all sessions
+ELECTRON_ARGS+=("--disable-features=CustomTitlebar")
+# Try to force native frame
+export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 
 # Change to the application directory
 APP_DIR="/usr/lib/$PACKAGE_NAME"


### PR DESCRIPTION
 Add Native Window Decorations Support for Linux

  ### Problem
  Claude Desktop on Linux displays windows without native window manager decorations (title bar,
  borders, minimize/maximize/close buttons). This makes the application inconsistent with other
  native applications and reduces usability.

  **Before:**
  - Windows appear frameless without borders
  - No native title bar or window controls
  - Inconsistent appearance with desktop environment theme

  **After:**
  - Windows display with native window manager decorations
  - Title bar with system theme and controls
  - Consistent appearance across all window managers (X11 and Wayland)

  ### Solution
  This PR implements a multi-layered approach to force native window decorations:

  1. **JavaScript Code Patching**: Searches and replaces `frame:false` with `frame:true` in all
  BrowserWindow creation code
  2. **Runtime Interception**: Adds a wrapper module that intercepts Electron's BrowserWindow
  constructor
  3. **Electron Flags**: Disables custom titlebar features via `--disable-features=CustomTitlebar`

  ### Changes
  - Modified `build.sh` to patch JavaScript files and inject frame-fix wrapper
  - Updated `scripts/build-deb-package.sh` with additional Electron flags
  - Updated `scripts/build-appimage.sh` with additional Electron flags
  - Enhanced `CLAUDE.md` documentation with implementation details

  ### Testing
  Tested on:
  - **OS**: Linux (Debian-based)
  - **Desktop**: KDE Plasma
  - **Display Server**: Wayland
  - **Package Format**: .deb
  - **Result**: ✅ Native decorations working correctly

  ### Implementation Details
  The fix works by:
  1. During build: Patching all `*.js` files in `.vite/build/` that contain BrowserWindow
  references
  2. At runtime: Intercepting `require('electron')` calls to wrap BrowserWindow class
  3. At launch: Adding Electron command-line flags to disable custom titlebar

  This ensures native frames regardless of how the application creates windows.
