### PR TITLE
Reset launcher log file on each application launch

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -135,9 +135,9 @@ LOG_FILE="\$HOME/claude-desktop-launcher.log"
 cd "\$HOME" || exit 1
 
 # Execute Electron with app path, flags, and script arguments passed to AppRun
-# Redirect stdout and stderr to the log file (append)
-echo "AppRun: Executing \$ELECTRON_EXEC \${ELECTRON_ARGS[@]} \$@ >> \$LOG_FILE 2>&1"
-exec "\$ELECTRON_EXEC" "\${ELECTRON_ARGS[@]}" "\$@" >> "\$LOG_FILE" 2>&1
+# Redirect stdout and stderr to the log file (reset on each launch)
+echo "AppRun: Executing \$ELECTRON_EXEC \${ELECTRON_ARGS[@]} \$@ > \$LOG_FILE 2>&1"
+exec "\$ELECTRON_EXEC" "\${ELECTRON_ARGS[@]}" "\$@" > "\$LOG_FILE" 2>&1
 EOF
 chmod +x "$APPDIR_PATH/AppRun"
 echo "✓ AppRun script created (with logging to \$HOME/claude-desktop-launcher.log, --no-sandbox, and CWD set to \$HOME)"

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -92,7 +92,7 @@ echo "🚀 Creating launcher script..."
 cat > "$INSTALL_DIR/bin/claude-desktop" << EOF
 #!/bin/bash
 LOG_FILE="\$HOME/claude-desktop-launcher.log"
-echo "--- Claude Desktop Launcher Start ---" >> "\$LOG_FILE"
+echo "--- Claude Desktop Launcher Start ---" > "\$LOG_FILE"
 echo "Timestamp: \$(date)" >> "\$LOG_FILE"
 echo "Arguments: \$@" >> "\$LOG_FILE"
 


### PR DESCRIPTION
Changed log file redirection from append (>>) to overwrite (>) to reset claude-desktop-launcher.log on each launch, preventing log files from growing indefinitely and making it easier to debug the most recent session.

Modified:
- scripts/build-deb-package.sh: First log write now uses >
- scripts/build-appimage.sh: Exec redirection now uses >