### PR TITLE
Add node-pty support for Claude Code terminal integration

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -651,17 +651,21 @@ fi
 
 echo -e "\033[1;36m--- Installing node-pty for terminal support ---\033[0m"
 # Install node-pty for Linux terminal support (used by Claude Code)
-cd "$WORK_DIR"
+# Use a separate directory to avoid npm removing other packages from WORK_DIR
+NODE_PTY_BUILD_DIR="$WORK_DIR/node-pty-build"
+mkdir -p "$NODE_PTY_BUILD_DIR"
+cd "$NODE_PTY_BUILD_DIR"
+echo '{"name":"node-pty-build","version":"1.0.0","private":true}' > package.json
 echo "Installing node-pty (this will compile native module for Linux)..."
-if npm install node-pty --no-save 2>&1; then
+if npm install node-pty 2>&1; then
     echo "✓ node-pty installed successfully"
 
     # Copy node-pty JavaScript files into the asar
-    if [ -d "$WORK_DIR/node_modules/node-pty" ]; then
+    if [ -d "$NODE_PTY_BUILD_DIR/node_modules/node-pty" ]; then
         echo "Copying node-pty JavaScript files into app.asar.contents..."
         mkdir -p "$APP_STAGING_DIR/app.asar.contents/node_modules/node-pty"
-        cp -r "$WORK_DIR/node_modules/node-pty/lib" "$APP_STAGING_DIR/app.asar.contents/node_modules/node-pty/"
-        cp "$WORK_DIR/node_modules/node-pty/package.json" "$APP_STAGING_DIR/app.asar.contents/node_modules/node-pty/"
+        cp -r "$NODE_PTY_BUILD_DIR/node_modules/node-pty/lib" "$APP_STAGING_DIR/app.asar.contents/node_modules/node-pty/"
+        cp "$NODE_PTY_BUILD_DIR/node_modules/node-pty/package.json" "$APP_STAGING_DIR/app.asar.contents/node_modules/node-pty/"
         echo "✓ node-pty JavaScript files copied"
     else
         echo "⚠️ node-pty installation directory not found"
@@ -713,10 +717,10 @@ module.exports = {
 EOF
 
 # Copy node-pty native binaries to unpacked directory
-if [ -d "$WORK_DIR/node_modules/node-pty/build/Release" ]; then
+if [ -d "$NODE_PTY_BUILD_DIR/node_modules/node-pty/build/Release" ]; then
     echo "Copying node-pty native binaries to unpacked directory..."
     mkdir -p "$APP_STAGING_DIR/app.asar.unpacked/node_modules/node-pty/build/Release"
-    cp -r "$WORK_DIR/node_modules/node-pty/build/Release/"* "$APP_STAGING_DIR/app.asar.unpacked/node_modules/node-pty/build/Release/"
+    cp -r "$NODE_PTY_BUILD_DIR/node_modules/node-pty/build/Release/"* "$APP_STAGING_DIR/app.asar.unpacked/node_modules/node-pty/build/Release/"
     # Ensure binaries are executable
     chmod +x "$APP_STAGING_DIR/app.asar.unpacked/node_modules/node-pty/build/Release/"* 2>/dev/null || true
     echo "✓ node-pty native binaries copied"


### PR DESCRIPTION
## Summary

Adds Linux-native `node-pty` support to enable terminal/PTY functionality used by Claude Code.

## Background

The macOS version of Claude Desktop includes `node-pty` as an optional dependency for terminal integration. The Windows version doesn't include it (likely uses ConPTY directly). This PR adds node-pty support to the Linux build.

## Changes

- Install `node-pty` during build (compiles native module for target Linux architecture)
- Copy node-pty JavaScript files into `app.asar`
- Copy native binaries (`pty.node`, `spawn-helper`) to `app.asar.unpacked/node_modules/node-pty/build/Release/`
- Add `node-pty` as `optionalDependency` in package.json

## How it works

```
Build process:
  ├── npm install node-pty (compiles for Linux amd64/arm64)
  ├── Copy lib/ and package.json → app.asar.contents/node_modules/node-pty/
  ├── Pack asar
  └── Copy build/Release/*.node → app.asar.unpacked/node_modules/node-pty/
```

## Testing

This should enable Claude Code's terminal features. To test:
1. Build the package
2. Install Claude Desktop
3. Try using Claude Code features that spawn terminal processes

## Notes

- node-pty compilation requires build tools (should already be available from Electron build)
- The feature degrades gracefully - if node-pty fails to install, a warning is shown but the build continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)