### PR TITLE
fix: use white tray icon on Linux for dark panels

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -635,6 +635,19 @@ fi
 echo "✓ Tray menu handler patched: function=${TRAY_FUNC}, tray_var=${TRAY_VAR}, check_var=${FIRST_CONST}"
 echo "##############################################################"
 
+# Fix tray icon to use white icon on Linux (issue #157)
+echo "Patching tray icon to use white icon on Linux (most Linux desktops have dark panels)..."
+if ! grep -q 'TrayIconTemplate-Dark\.png' app.asar.contents/.vite/build/index.js; then
+    # Pattern: Xs?e=ce.nativeTheme.shouldUseDarkColors?"Tray-Win32-Dark.ico":"Tray-Win32.ico":e="TrayIconTemplate.png"
+    # Replace: Xs?e=ce.nativeTheme.shouldUseDarkColors?"Tray-Win32-Dark.ico":"Tray-Win32.ico":e="TrayIconTemplate-Dark.png"
+    # Use TrayIconTemplate-Dark.png (white icon) by default on Linux since most desktops have dark panels
+    sed -i 's/:e="TrayIconTemplate\.png"/:e="TrayIconTemplate-Dark.png"/g' app.asar.contents/.vite/build/index.js
+    echo "✓ Tray icon patched to use TrayIconTemplate-Dark.png (white icon) on Linux"
+else
+    echo "ℹ️  Tray icon already using TrayIconTemplate-Dark.png"
+fi
+echo "##############################################################"
+
 # Fix quick window submit issue by adding blur() call before hide()
 if ! grep -q 'e.blur(),e.hide()' app.asar.contents/.vite/build/index.js; then
     sed -i 's/e.hide()/e.blur(),e.hide()/' app.asar.contents/.vite/build/index.js


### PR DESCRIPTION
## Summary
- Fixes #157 by using white tray icon by default on Linux
- Previously used black `TrayIconTemplate.png`, making icon invisible on dark panels/taskbars
- Now uses `TrayIconTemplate-Dark.png` (white icon) as default for Linux

## Changes
- Modified `build.sh` to patch tray icon selection in Electron app
- Linux now uses white icon unconditionally (most Linux desktops have dark panels)
- Windows continues to use theme detection via `nativeTheme.shouldUseDarkColors`

## Why not use theme detection on Linux?
Electron's `nativeTheme.shouldUseDarkColors` often returns `false` on Linux even with dark panels, because many distributions (including Ubuntu) don't explicitly set the `color-scheme` gsetting to `'prefer-dark'`. Since the vast majority of modern Linux desktop environments (GNOME, KDE Plasma, etc.) use dark top panels by default, a white icon is the safer choice.

## Testing
- Tested on Ubuntu 24.04 with GNOME and dark panel
- Icon now visible and displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)