### PR TITLE
fix: replace build-time deps with runtime deps in deb package

### DIFF
--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -200,10 +200,10 @@ echo "✓ Launcher script created"
 
 # --- Create Control File ---
 echo "📄 Creating control file..."
-# Determine dependencies based on whether electron was packaged
-DEPENDS="nodejs, npm, p7zip-full" # Base dependencies
-# Electron is now always packaged locally, so it's not listed as an external dependency.
-echo "Electron is packaged locally; not adding to external Depends list."
+# Runtime dependencies - Electron is bundled, so nodejs/npm are NOT needed at runtime
+# These are common libs needed by Electron/Chromium that may not be present on minimal systems
+DEPENDS="libnss3, libatk1.0-0, libatk-bridge2.0-0, libcups2, libgtk-3-0, libgbm1, libasound2"
+echo "Using runtime dependencies: $DEPENDS"
 
 cat > "$PACKAGE_ROOT/DEBIAN/control" << EOF
 Package: $PACKAGE_NAME


### PR DESCRIPTION
## Summary
- Remove `nodejs`, `npm`, and `p7zip-full` from deb package Depends field
- Add actual Electron/Chromium runtime dependencies that may be needed on minimal systems

## Problem
The current deb package declares `nodejs, npm, p7zip-full` as dependencies, but:
1. These are **build-time** dependencies, not runtime dependencies
2. Electron is bundled - the app doesn't invoke system `node` or `npm` at runtime
3. Users with NVM-installed Node.js can't install the package because apt doesn't recognize NVM installations

## Solution
Replace with actual runtime dependencies needed by bundled Electron/Chromium:
- `libnss3` - NSS crypto libraries
- `libatk1.0-0`, `libatk-bridge2.0-0` - Accessibility toolkit
- `libcups2` - Printing support
- `libgtk-3-0` - GTK3
- `libgbm1` - Graphics buffer management
- `libasound2` - Audio

Most desktop Linux systems already have these, but they ensure the app works on minimal installations.

## Test plan
- [ ] CI builds successfully for both deb and appimage
- [ ] Verify the generated deb package has correct Depends field
- [ ] Test installation on a system without nodejs package

Fixes #160