### PR TITLE
fix: prevent duplicate tray icons on KDE systems

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -138,6 +138,16 @@ else
   echo "AppRun: X11 session detected"
 fi
 
+# Fix for KDE duplicate tray icons (issue #163)
+# When xembedsniproxy is running (standard KDE component), Electron registers tray icons
+# via both StatusNotifierItem (SNI) and XEmbed protocols. xembedsniproxy then bridges
+# the XEmbed icon to SNI, creating a duplicate. Disabling UseStatusIconLinuxDbus
+# prevents the dual registration.
+if pgrep -x xembedsniproxy > /dev/null 2>&1; then
+  echo "AppRun: xembedsniproxy detected - disabling SNI to prevent duplicate tray icons"
+  ELECTRON_ARGS+=("--disable-features=UseStatusIconLinuxDbus")
+fi
+
 # Force disable custom titlebar for all sessions
 ELECTRON_ARGS+=("--disable-features=CustomTitlebar")
 # Try to force native frame

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -175,6 +175,16 @@ else
   echo "X11 session detected" >> "\$LOG_FILE"
 fi
 
+# Fix for KDE duplicate tray icons (issue #163)
+# When xembedsniproxy is running (standard KDE component), Electron registers tray icons
+# via both StatusNotifierItem (SNI) and XEmbed protocols. xembedsniproxy then bridges
+# the XEmbed icon to SNI, creating a duplicate. Disabling UseStatusIconLinuxDbus
+# prevents the dual registration.
+if pgrep -x xembedsniproxy > /dev/null 2>&1; then
+  echo "xembedsniproxy detected - disabling SNI to prevent duplicate tray icons" >> "\$LOG_FILE"
+  ELECTRON_ARGS+=("--disable-features=UseStatusIconLinuxDbus")
+fi
+
 # Force disable custom titlebar for all sessions
 ELECTRON_ARGS+=("--disable-features=CustomTitlebar")
 # Try to force native frame


### PR DESCRIPTION
## Summary

Fixes the duplicate tray icon issue on KDE Plasma systems reported in #163.

**Root cause:** Electron 37.x registers tray icons via both StatusNotifierItem (SNI) and XEmbed protocols. On KDE systems, `xembedsniproxy` (a standard Plasma component) bridges XEmbed icons to SNI for compatibility. This creates a duplicate: one from Electron's direct SNI registration, and another from xembedsniproxy converting the XEmbed icon.

**Solution:** Detect `xembedsniproxy` at runtime and add `--disable-features=UseStatusIconLinuxDbus` to prevent dual registration.

## Testing

Tested on KDE Plasma 6.x (Wayland + XWayland):

| Test | Tray Icons | Result |
|------|------------|--------|
| Baseline (no fix) | 2 (electron + xembedsniproxy) | ❌ Duplicate |
| With fix | 1 (electron only) | ✅ Fixed |

## Changes

- `scripts/build-deb-package.sh`: Added xembedsniproxy detection to launcher script
- `scripts/build-appimage.sh`: Added xembedsniproxy detection to AppRun script

## Related Issues

- Fixes #163 (duplicate tray icons)
- May help with #161 (startup crashes potentially related to DBus tray conflicts)