### PR TITLE
fix: resolve duplicate tray icons on KDE systems

### DIFF
--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -147,10 +147,16 @@ else
     fi
 fi
 
-# Base command arguments array, starting with app path
 # App is now in Electron's resources directory
 APP_PATH="/usr/lib/$PACKAGE_NAME/node_modules/electron/dist/resources/app.asar"
-ELECTRON_ARGS=("\$APP_PATH")
+
+# Build Chromium flags array - flags MUST come before app path
+ELECTRON_ARGS=()
+
+# Disable CustomTitlebar for better Linux integration
+# Note: The duplicate tray icon fix (issue #163) is handled via app.asar patching
+# (increased delays in tray creation to allow DBus cleanup between destroy/create cycles)
+ELECTRON_ARGS+=("--disable-features=CustomTitlebar")
 
 # Add compatibility flags based on display backend
 if [ "\$IS_WAYLAND" = true ]; then
@@ -175,18 +181,8 @@ else
   echo "X11 session detected" >> "\$LOG_FILE"
 fi
 
-# Fix for KDE duplicate tray icons (issue #163)
-# When xembedsniproxy is running (standard KDE component), Electron registers tray icons
-# via both StatusNotifierItem (SNI) and XEmbed protocols. xembedsniproxy then bridges
-# the XEmbed icon to SNI, creating a duplicate. Disabling UseStatusIconLinuxDbus
-# prevents the dual registration.
-if pgrep -x xembedsniproxy > /dev/null 2>&1; then
-  echo "xembedsniproxy detected - disabling SNI to prevent duplicate tray icons" >> "\$LOG_FILE"
-  ELECTRON_ARGS+=("--disable-features=UseStatusIconLinuxDbus")
-fi
-
-# Force disable custom titlebar for all sessions
-ELECTRON_ARGS+=("--disable-features=CustomTitlebar")
+# Add app path LAST - Chromium flags must come before this
+ELECTRON_ARGS+=("\$APP_PATH")
 # Try to force native frame
 export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 


### PR DESCRIPTION
## Summary

Fixes the duplicate tray icon issue on KDE Plasma systems.

**Root cause:** The previous fix (PR #164) used `--disable-features=UseStatusIconLinuxDbus` which doesn't exist in Electron/Chromium. The actual issue is a race condition where `Tray.destroy()` returns before DBus fully unregisters, causing the next `new Tray()` to fall back to XEmbed (which xembedsniproxy then bridges to SNI, creating a duplicate).

**Solution:** Increase timing delays in the app.asar tray patch to allow DBus cleanup:
- Post-destroy delay: 50ms → 250ms
- Mutex timeout: 500ms → 1500ms

## Changes

### build.sh
- Increased mutex timeout from 500ms to 1500ms
- Increased post-destroy delay from 50ms to 250ms for DBus cleanup

### scripts/build-appimage.sh
- Removed ineffective xembedsniproxy detection and `UseStatusIconLinuxDbus` flag
- Fixed APPDIR to use absolute path (was breaking after `cd $HOME`)
- Fixed flag ordering: Chromium flags now come before app path

### scripts/build-deb-package.sh
- Same fixes as AppImage script

## Testing

Verified locally on KDE Plasma 6.x (Fedora/Nobara):

| Check | Before | After |
|-------|--------|-------|
| Tray registrations from electron | 2 (electron + xembedsniproxy) | 1 (electron only) |
| "already exported" DBus errors | Yes | None |
| xembedsniproxy duplicates | Yes | None |

## Related

- Fixes #163
- Supersedes ineffective fix from PR #164