### PR TITLE
fix: tray icon visibility on Linux

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -831,12 +831,14 @@ if [ -d "$CLAUDE_LOCALE_SRC" ]; then
         echo "Processing tray icons for Linux visibility (using $MAGICK_CMD)..."
 
         # Process all TrayIconTemplate variants (including @2x, @3x)
-        # Just make them 100% opaque - multiply alpha by 5 and clamp to 100%
+        # Make all non-transparent pixels 100% opaque using threshold approach.
+        # The original icons have anti-aliased edges with very low alpha (5-20 out of 255).
+        # The -fx "a>0?1:0" sets any non-zero alpha to fully opaque.
         for icon_file in "$ELECTRON_RESOURCES_DEST"/TrayIconTemplate*.png; do
             if [ -f "$icon_file" ]; then
                 icon_name=$(basename "$icon_file")
                 "$MAGICK_CMD" "$icon_file" \
-                    -channel A -evaluate multiply 5 -evaluate min 100% +channel \
+                    -channel A -fx "a>0?1:0" +channel \
                     "PNG32:$icon_file" 2>/dev/null && \
                     echo "  ✓ Processed $icon_name (100% opaque)" || \
                     echo "  ⚠️ Failed to process $icon_name"


### PR DESCRIPTION
## Summary

- Adds theme-aware tray icon selection for Linux (dark mode → white icon, light mode → black icon)
- Fixes ImageMagick alpha processing to make icons fully opaque (visible)

## Problem

The tray icon was invisible on Linux because:
1. Claude always used `TrayIconTemplate.png` (black icon) regardless of system theme
2. The original icons are macOS "template" style with ~20% alpha opacity

## Solution

1. **Icon selection patch**: Added `nativeTheme.shouldUseDarkColors` check to select appropriate icon:
   - Dark panels → `TrayIconTemplate-Dark.png` (white icon)
   - Light panels → `TrayIconTemplate.png` (black icon)

2. **Alpha processing fix**: Changed ImageMagick command from multiply approach to threshold:
   - Before: `-evaluate multiply 5` (didn't work for very low alpha values)
   - After: `-fx "a>0?1:0"` (any non-zero alpha becomes 100% opaque)

## Test plan

- [x] Built and tested on KDE Plasma with dark panel
- [x] Verified white tray icon is visible
- [x] CI build passes