### PR TITLE
fix: hide menu bar on Linux by intercepting setApplicationMenu

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -415,6 +415,7 @@ Module.prototype.require = function(id) {
   if (id === 'electron') {
     console.log('[Frame Fix] Intercepting electron module');
     const OriginalBrowserWindow = module.BrowserWindow;
+    const OriginalMenu = module.Menu;
 
     module.BrowserWindow = class BrowserWindowWithFrame extends OriginalBrowserWindow {
       constructor(options) {
@@ -424,12 +425,19 @@ Module.prototype.require = function(id) {
           const originalFrame = options.frame;
           // Force native frame
           options.frame = true;
+          // Hide the menu bar by default (Alt key will toggle it)
+          options.autoHideMenuBar = true;
           // Remove custom titlebar options
           delete options.titleBarStyle;
           delete options.titleBarOverlay;
           console.log(`[Frame Fix] Modified frame from ${originalFrame} to true`);
         }
         super(options);
+        // Hide menu bar after window creation on Linux
+        if (process.platform === 'linux') {
+          this.setMenuBarVisibility(false);
+          console.log('[Frame Fix] Menu bar visibility set to false');
+        }
       }
     };
 
@@ -446,6 +454,21 @@ Module.prototype.require = function(id) {
         }
       }
     }
+
+    // Intercept Menu.setApplicationMenu to hide menu bar on Linux
+    // This catches the app's later calls to setApplicationMenu that would show the menu
+    const originalSetAppMenu = OriginalMenu.setApplicationMenu.bind(OriginalMenu);
+    module.Menu.setApplicationMenu = function(menu) {
+      console.log('[Frame Fix] Intercepting setApplicationMenu');
+      originalSetAppMenu(menu);
+      if (process.platform === 'linux') {
+        // Hide menu bar on all existing windows after menu is set
+        for (const win of module.BrowserWindow.getAllWindows()) {
+          win.setMenuBarVisibility(false);
+        }
+        console.log('[Frame Fix] Menu bar hidden on all windows');
+      }
+    };
   }
 
   return module;


### PR DESCRIPTION
## Summary
- Fixes the visible menu bar (File, Edit, View, Help) that appears on Linux after v1.2.1
- Intercepts `Menu.setApplicationMenu()` to automatically hide the menu bar on all windows after the menu is set
- This catches the app's asynchronous calls to `setApplicationMenu()` that previously caused the menu to reappear

## Changes
- Add `autoHideMenuBar: true` to BrowserWindow options
- Call `setMenuBarVisibility(false)` after window creation
- Intercept `Menu.setApplicationMenu` to hide menu bar on all windows after any menu set call

## Test plan
- [x] Build AppImage with fix
- [x] Verify menu bar is hidden on launch
- [ ] Verify Alt key toggles menu bar visibility
- [ ] Verify dock integration still works (running indicator)

Fixes #155
Fixes #140