### PR TITLE
ci: add workflow to clean up non-release runs

### DIFF
--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -1,0 +1,46 @@
+name: Cleanup Workflow Runs
+run-name: |
+  Cleanup: ${{
+    github.event_name == 'schedule' && 'Weekly scheduled cleanup' ||
+    format('Manual cleanup by @{0}', github.actor)
+  }}
+
+on:
+  schedule:
+    # Run every Thursday at midnight UTC
+    - cron: "0 0 * * 4"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    name: Delete Non-Release Runs
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+
+    steps:
+      - name: Delete workflow runs not tied to release tags
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          echo "Fetching workflow runs..."
+
+          # Get all runs where headBranch doesn't start with "v" (release tags)
+          runs_to_delete=$(gh run list --json databaseId,headBranch --limit 1000 -q '.[] | select(.headBranch | startswith("v") | not) | .databaseId')
+
+          if [ -z "$runs_to_delete" ]; then
+            echo "No non-release runs to delete."
+            exit 0
+          fi
+
+          count=$(echo "$runs_to_delete" | wc -l)
+          echo "Found $count runs to delete..."
+
+          # Delete each run
+          echo "$runs_to_delete" | while read -r run_id; do
+            echo "Deleting run $run_id..."
+            gh run delete "$run_id" || echo "Failed to delete run $run_id (may already be deleted)"
+          done
+
+          echo "Cleanup complete!"


### PR DESCRIPTION
## Summary
- Adds a scheduled GitHub Action that runs weekly (Thursday midnight UTC) to delete workflow runs not tied to release tags
- Preserves runs where `headBranch` starts with `v` (release tags like `v1.2.4+claude1.1.381`)
- Can also be triggered manually via `workflow_dispatch`

## Test plan
- [x] Generate test CI runs on the feature branch (`gh workflow run CI --ref feature/174-workflow-cleanup`)
- [ ] Merge this PR to main
- [ ] Run the cleanup action manually (`gh workflow run "Cleanup Workflow Runs"`)
- [ ] Verify only tag-based runs remain

**Note:** `workflow_dispatch` triggers require the workflow to exist on the default branch, so full testing requires merging first.

Fixes #174

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Implemented workflow based on manual cleanup session, created issue, branch, and PR
Human: Identified need, approved approach, directed workflow