### PR TITLE
fix: add wrapper version suffix to package versions for unique releases

### DIFF
--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -12,6 +12,11 @@ on:
         description: "Suffix for the artifact name (e.g., deb, appimage, rpm)"
         required: true
         type: string
+      release_tag:
+        description: "Optional release tag (e.g., v1.3.2+claude1.1.799) to derive wrapper version"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -38,7 +43,11 @@ jobs:
 
       - name: Run build script
         run: |
-          ./build.sh ${{ inputs.build_flags }}
+          TAG_FLAG=""
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            TAG_FLAG="--release-tag ${{ inputs.release_tag }}"
+          fi
+          ./build.sh ${{ inputs.build_flags }} $TAG_FLAG
 
       - name: Upload AMD64 Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -12,6 +12,11 @@ on:
         description: "Suffix for the artifact name (e.g., deb, appimage, rpm)"
         required: true
         type: string
+      release_tag:
+        description: "Optional release tag (e.g., v1.3.2+claude1.1.799) to derive wrapper version"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build:
@@ -38,7 +43,11 @@ jobs:
 
       - name: Run build script
         run: |
-          ./build.sh ${{ inputs.build_flags }}
+          TAG_FLAG=""
+          if [[ -n "${{ inputs.release_tag }}" ]]; then
+            TAG_FLAG="--release-tag ${{ inputs.release_tag }}"
+          fi
+          ./build.sh ${{ inputs.build_flags }} $TAG_FLAG
 
       - name: Upload ARM64 Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     with:
       build_flags: ${{ matrix.flags }}
       artifact_suffix: ${{ matrix.artifact_suffix }}
+      release_tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
   build-arm64:
     name: Build Packages (arm64 - ${{ matrix.artifact_suffix }})
@@ -70,6 +71,7 @@ jobs:
     with:
       build_flags: ${{ matrix.flags }}
       artifact_suffix: ${{ matrix.artifact_suffix }}
+      release_tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
   release:
     name: Create Release


### PR DESCRIPTION
The APT repository update was failing with exit code 254 because
reprepro rejected duplicate packages. When multiple releases use the
same Claude Desktop version (e.g., v1.3.0, v1.3.1, v1.3.2 all using
claude1.1.799), the packages had identical versions causing conflicts.

Changes:
- Add --release-tag flag to build.sh to accept the full release tag
- Extract wrapper version from tag (v1.3.2+claude1.1.799 -> 1.3.2)
- Append wrapper version as Debian revision suffix (1.1.799-1.3.2)
- Update CI workflows to pass release tag on tag builds

This ensures each release produces packages with unique versions that
APT can properly handle for upgrades (1.1.799-1.3.2 > 1.1.799-1.3.1).

Fixes workflow failure in run #21318689829

Co-Authored-By: Claude <claude@anthropic.com>