### PR TITLE
fix: add --batch flag to gpg for non-interactive CI signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,7 @@ jobs:
 
               # Sign the repository metadata
               echo "Signing repodata for $arch..."
-              gpg --detach-sign --armor rpm/$arch/repodata/repomd.xml
+              gpg --batch --detach-sign --armor rpm/$arch/repodata/repomd.xml
             fi
           done
 


### PR DESCRIPTION
## Summary
- Add `--batch` flag to `gpg --detach-sign` command in DNF repo update job
- Fixes CI failure: `gpg: cannot open '/dev/tty': No such device or address`

## Test plan
- [ ] DNF repo update job completes successfully

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>