### PR TITLE
fix: add --yes flag to gpg to overwrite existing signature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,9 +254,9 @@ jobs:
               echo "Generating repodata for $arch..."
               createrepo_c --update rpm/$arch/
 
-              # Sign the repository metadata
+              # Sign the repository metadata (--yes to overwrite existing signature)
               echo "Signing repodata for $arch..."
-              gpg --batch --detach-sign --armor rpm/$arch/repodata/repomd.xml
+              gpg --batch --yes --detach-sign --armor rpm/$arch/repodata/repomd.xml
             fi
           done
 


### PR DESCRIPTION
Fixes 'gpg: signing failed: File exists' error when repomd.xml.asc already exists.

---
Generated with [Claude Code](https://claude.ai/code)