### PR TITLE
fix: add git pull --rebase before pushing to gh-pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || git commit -m "Update APT repository for ${{ github.ref_name }}"
+          git pull --rebase
           git push
 
   update-dnf-repo:
@@ -278,4 +279,5 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || git commit -m "Update DNF repository for ${{ github.ref_name }}"
+          git pull --rebase
           git push


### PR DESCRIPTION
Fixes race condition when APT and DNF repo update jobs push simultaneously.

---
Generated with [Claude Code](https://claude.ai/code)