### PR TITLE
fix: add retry loop for gh-pages push race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || git commit -m "Update APT repository for ${{ github.ref_name }}"
-          git pull --rebase
-          git push
+          # Retry loop to handle concurrent pushes to gh-pages
+          for i in 1 2 3 4 5; do
+            git pull --rebase && git push && break
+            echo "Push failed, retrying in 5 seconds... (attempt $i/5)"
+            sleep 5
+          done
 
   update-dnf-repo:
     name: Update DNF Repository
@@ -279,5 +283,9 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || git commit -m "Update DNF repository for ${{ github.ref_name }}"
-          git pull --rebase
-          git push
+          # Retry loop to handle concurrent pushes to gh-pages
+          for i in 1 2 3 4 5; do
+            git pull --rebase && git push && break
+            echo "Push failed, retrying in 5 seconds... (attempt $i/5)"
+            sleep 5
+          done


### PR DESCRIPTION
Adds retry loop (5 attempts, 5s delay) when pushing to gh-pages to handle concurrent updates.

---
Generated with [Claude Code](https://claude.ai/code)