### PR TITLE
fix: add shellcheck SC2024 disable directives for log file redirects

### DIFF
--- a/.claude/hooks/install-build-tools.sh
+++ b/.claude/hooks/install-build-tools.sh
@@ -6,6 +6,10 @@
 # packages. Can be run manually via the /setup-build-tools skill or
 # sourced by session-start.sh for full environment setup.
 
+# SC2024: sudo doesn't affect redirects - intentional, log file should be
+# owned by user not root since it's in $HOME/.cache
+# shellcheck disable=SC2024
+
 # Log file for debugging
 log_file="$HOME/.cache/claude-desktop-debian/session-start.log"
 mkdir -p "$(dirname "$log_file")"

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,6 +5,10 @@
 # Ensures jq, shellcheck, actionlint, and gh are available for hooks
 # and development workflows. Primarily targets remote/web sessions.
 
+# SC2024: sudo doesn't affect redirects - intentional, log file should be
+# owned by user not root since it's in $HOME/.cache
+# shellcheck disable=SC2024
+
 # Log file for debugging
 log_file="$HOME/.cache/claude-desktop-debian/session-start.log"
 mkdir -p "$(dirname "$log_file")"


### PR DESCRIPTION
## Summary
- Add shellcheck SC2024 disable directives to hook scripts

The `sudo` commands intentionally redirect output to a user-owned log file 
in `$HOME/.cache`. The log should be owned by the user, not root, so the 
current redirect behavior is correct. Added file-level disable with 
explanation per the project's style guide.

## Test plan
- [x] Verified `shellcheck` passes on both modified scripts
- [x] Verified bash syntax is valid (`bash -n`)
