### PR TITLE
fix(ci): limit shellcheck to .sh files only

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -29,4 +29,4 @@ jobs:
           sudo apt update && sudo apt install -y shellcheck
       - name: shellcheck
         run: |
-          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' | xargs shellcheck
+          git grep -l '^#\( *shellcheck \|!\(/bin/\|/usr/bin/env \)\(sh\|bash\|dash\|ksh\)\)' -- '*.sh' | xargs shellcheck


### PR DESCRIPTION
The grep pattern was matching STYLEGUIDE.md because it contains shell code examples with shebangs. Changed from matching any file with shell shebangs to only matching .sh files.