### PR TITLE
fix: sign repomd.xml with main GPG key instead of subkey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
 
               # Sign the repository metadata (--yes to overwrite existing signature)
               echo "Signing repodata for $arch..."
-              gpg --batch --yes --detach-sign --armor rpm/$arch/repodata/repomd.xml
+              gpg --batch --yes --default-key "${{ steps.import_gpg.outputs.keyid }}" --detach-sign --armor rpm/$arch/repodata/repomd.xml
             fi
           done
 


### PR DESCRIPTION
## Summary

- Explicitly pass `--default-key` to the `gpg --detach-sign` command that signs `repomd.xml`, using the main key ID already captured by the GPG import step
- RPM/DNF doesn't recognize subkey signatures for repository metadata verification, causing "Signing key not found" errors on Fedora 43 with dnf5

Fixes #213

## Changes

One-line change in `.github/workflows/ci.yml`:

```diff
- gpg --batch --yes --detach-sign --armor rpm/$arch/repodata/repomd.xml
+ gpg --batch --yes --default-key "${{ steps.import_gpg.outputs.keyid }}" --detach-sign --armor rpm/$arch/repodata/repomd.xml
```

The key ID is already available from `steps.import_gpg.outputs.keyid` (same value used in `~/.rpmmacros` for RPM package signing). It just wasn't being passed to the standalone GPG signing command for repository metadata.

## Test plan

- [ ] Next release tag triggers CI and signs repomd.xml with the main key
- [ ] Verify with: `curl -s .../repomd.xml.asc | gpg --list-packets 2>/dev/null | grep keyid` shows main key ID
- [ ] `dnf install claude-desktop` works on Fedora 43 without `--nogpgcheck`

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Investigated issue, implemented fix, created PR
Human: Reviewed analysis, directed workflow