### PR TITLE
fix: use regex extraction for electron variable in tray patches

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -625,37 +625,10 @@ console.log('Updated package.json: main entry and node-pty dependency');
 	patch_titlebar_detection
 
 	# Extract electron module variable name for tray patches
-	echo 'Extracting electron module variable name from minified source...'
-	electron_var=$(grep -oP '\b\w+(?=\s*=\s*require\("electron"\))' \
-		app.asar.contents/.vite/build/index.js | head -1)
-	if [[ -z $electron_var ]]; then
-		# Fallback: extract from Tray constructor
-		electron_var=$(grep -oP '(?<=new )\w+(?=\.Tray\b)' \
-			app.asar.contents/.vite/build/index.js | head -1)
-	fi
-	if [[ -z $electron_var ]]; then
-		echo 'Failed to extract electron module variable name' >&2
-		cd "$project_root" || exit 1
-		exit 1
-	fi
-	echo "  Found electron variable: $electron_var"
+	extract_electron_variable
 
-	# Fix upstream minifier bug: incorrect variable references to nativeTheme
-	echo 'Fixing any incorrect nativeTheme variable references...'
-	local wrong_refs
-	wrong_refs=$(grep -oP '\b\w+(?=\.nativeTheme)' \
-		app.asar.contents/.vite/build/index.js | sort -u \
-		| grep -v "^${electron_var}$" || true)
-	if [[ -n $wrong_refs ]]; then
-		local wrong_ref
-		for wrong_ref in $wrong_refs; do
-			echo "  Replacing incorrect reference: ${wrong_ref}.nativeTheme -> ${electron_var}.nativeTheme"
-			sed -i -E "s/\b${wrong_ref}\.nativeTheme/${electron_var}.nativeTheme/g" \
-				app.asar.contents/.vite/build/index.js
-		done
-	else
-		echo '  All nativeTheme references are correct'
-	fi
+	# Fix incorrect nativeTheme variable references
+	fix_native_theme_references
 
 	# Patch tray menu handler
 	patch_tray_menu_handler
@@ -710,11 +683,59 @@ patch_titlebar_detection() {
 	echo '##############################################################'
 }
 
+extract_electron_variable() {
+	echo 'Extracting electron module variable name...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	electron_var=$(grep -oP '\b\w+(?=\s*=\s*require\("electron"\))' \
+		"$index_js" | head -1)
+	if [[ -z $electron_var ]]; then
+		electron_var=$(grep -oP '(?<=new )\w+(?=\.Tray\b)' \
+			"$index_js" | head -1)
+	fi
+	if [[ -z $electron_var ]]; then
+		echo 'Failed to extract electron variable name' >&2
+		cd "$project_root" || exit 1
+		exit 1
+	fi
+	echo "  Found electron variable: $electron_var"
+	echo '##############################################################'
+}
+
+fix_native_theme_references() {
+	echo 'Fixing incorrect nativeTheme variable references...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	local wrong_refs
+	mapfile -t wrong_refs < <(
+		grep -oP '\b\w+(?=\.nativeTheme)' "$index_js" \
+			| sort -u \
+			| grep -v "^${electron_var}$" || true
+	)
+
+	if (( ${#wrong_refs[@]} == 0 )); then
+		echo '  All nativeTheme references are correct'
+		echo '##############################################################'
+		return
+	fi
+
+	local ref
+	for ref in "${wrong_refs[@]}"; do
+		echo "  Replacing: $ref.nativeTheme -> $electron_var.nativeTheme"
+		sed -i -E \
+			"s/\b${ref}\.nativeTheme/${electron_var}.nativeTheme/g" \
+			"$index_js"
+	done
+	echo '##############################################################'
+}
+
 patch_tray_menu_handler() {
-	echo 'Patching tray menu handler function to prevent concurrent calls and add DBus cleanup delay...'
+	echo 'Patching tray menu handler...'
+	local index_js='app.asar.contents/.vite/build/index.js'
 
 	local tray_func tray_var first_const
-	tray_func=$(grep -oP 'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' app.asar.contents/.vite/build/index.js)
+	tray_func=$(grep -oP \
+		'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' "$index_js")
 	if [[ -z $tray_func ]]; then
 		echo 'Failed to extract tray menu function name' >&2
 		cd "$project_root" || exit 1
@@ -722,7 +743,9 @@ patch_tray_menu_handler() {
 	fi
 	echo "  Found tray function: $tray_func"
 
-	tray_var=$(grep -oP "\}\);let \K\w+(?==null;(?:async )?function ${tray_func})" app.asar.contents/.vite/build/index.js)
+	tray_var=$(grep -oP \
+		"\}\);let \K\w+(?==null;(?:async )?function ${tray_func})" \
+		"$index_js")
 	if [[ -z $tray_var ]]; then
 		echo 'Failed to extract tray variable name' >&2
 		cd "$project_root" || exit 1
@@ -730,43 +753,60 @@ patch_tray_menu_handler() {
 	fi
 	echo "  Found tray variable: $tray_var"
 
-	sed -i "s/function ${tray_func}(){/async function ${tray_func}(){/g" app.asar.contents/.vite/build/index.js
+	sed -i "s/function ${tray_func}(){/async function ${tray_func}(){/g" \
+		"$index_js"
 
-	first_const=$(grep -oP "async function ${tray_func}\(\)\{.*?const \K\w+(?==)" app.asar.contents/.vite/build/index.js | head -1)
+	first_const=$(grep -oP \
+		"async function ${tray_func}\(\)\{.*?const \K\w+(?==)" \
+		"$index_js" | head -1)
 	if [[ -z $first_const ]]; then
-		echo 'Failed to extract first const variable name in function' >&2
+		echo 'Failed to extract first const in function' >&2
 		cd "$project_root" || exit 1
 		exit 1
 	fi
 	echo "  Found first const variable: $first_const"
 
-	if ! grep -q "${tray_func}._running" app.asar.contents/.vite/build/index.js; then
-		sed -i "s/async function ${tray_func}(){/async function ${tray_func}(){if(${tray_func}._running)return;${tray_func}._running=true;setTimeout(()=>${tray_func}._running=false,1500);/g" app.asar.contents/.vite/build/index.js
+	# Add mutex guard to prevent concurrent tray rebuilds
+	if ! grep -q "${tray_func}._running" "$index_js"; then
+		sed -i "s/async function ${tray_func}(){/async function ${tray_func}(){if(${tray_func}._running)return;${tray_func}._running=true;setTimeout(()=>${tray_func}._running=false,1500);/g" \
+			"$index_js"
 		echo "  Added mutex guard to ${tray_func}()"
 	fi
 
-	if ! grep -q "await new Promise.*setTimeout" app.asar.contents/.vite/build/index.js | grep -q "${tray_var}"; then
-		sed -i "s/${tray_var}\&\&(${tray_var}\.destroy(),${tray_var}=null)/${tray_var}\&\&(${tray_var}.destroy(),${tray_var}=null,await new Promise(r=>setTimeout(r,250)))/g" app.asar.contents/.vite/build/index.js
-		echo "  Added DBus cleanup delay after ${tray_var}.destroy()"
+	# Add DBus cleanup delay after tray destroy
+	if ! grep -q "await new Promise.*setTimeout" "$index_js" \
+		| grep -q "$tray_var"; then
+		sed -i "s/${tray_var}\&\&(${tray_var}\.destroy(),${tray_var}=null)/${tray_var}\&\&(${tray_var}.destroy(),${tray_var}=null,await new Promise(r=>setTimeout(r,250)))/g" \
+			"$index_js"
+		echo "  Added DBus cleanup delay after $tray_var.destroy()"
 	fi
 
 	echo 'Tray menu handler patched'
 	echo '##############################################################'
 
-	# Patch nativeTheme handler
-	echo 'Patching nativeTheme handler to skip tray updates during startup...'
-	if ! grep -q '_trayStartTime' app.asar.contents/.vite/build/index.js; then
-		sed -i -E "s/(${electron_var}\.nativeTheme\.on\(\s*\"updated\"\s*,\s*\(\)\s*=>\s*\{)/let _trayStartTime=Date.now();\1/g" app.asar.contents/.vite/build/index.js
-		sed -i -E "s/\((\w+)\(\)\s*,\s*${tray_func}\(\)\s*,/(\1(),Date.now()-_trayStartTime>3e3\&\&${tray_func}(),/g" app.asar.contents/.vite/build/index.js
-		echo '  Added startup delay check to nativeTheme handler (3 second window)'
+	# Skip tray updates during startup (3 second window)
+	echo 'Patching nativeTheme handler for startup delay...'
+	if ! grep -q '_trayStartTime' "$index_js"; then
+		sed -i -E \
+			"s/(${electron_var}\.nativeTheme\.on\(\s*\"updated\"\s*,\s*\(\)\s*=>\s*\{)/let _trayStartTime=Date.now();\1/g" \
+			"$index_js"
+		sed -i -E \
+			"s/\((\w+)\(\)\s*,\s*${tray_func}\(\)\s*,/(\1(),Date.now()-_trayStartTime>3e3\&\&${tray_func}(),/g" \
+			"$index_js"
+		echo '  Added startup delay check (3 second window)'
 	fi
 	echo '##############################################################'
 }
 
 patch_tray_icon_selection() {
 	echo 'Patching tray icon selection for Linux visibility...'
-	if grep -qP ':\w="TrayIconTemplate\.png"' app.asar.contents/.vite/build/index.js; then
-		sed -i -E "s/:(\w)=\"TrayIconTemplate\.png\"/:\1=${electron_var}.nativeTheme.shouldUseDarkColors?\"TrayIconTemplate-Dark.png\":\"TrayIconTemplate.png\"/g" app.asar.contents/.vite/build/index.js
+	local index_js='app.asar.contents/.vite/build/index.js'
+	local dark_check="$electron_var.nativeTheme.shouldUseDarkColors"
+
+	if grep -qP ':\w="TrayIconTemplate\.png"' "$index_js"; then
+		sed -i -E \
+			"s/:(\w)=\"TrayIconTemplate\.png\"/:\1=${dark_check}?\"TrayIconTemplate-Dark.png\":\"TrayIconTemplate.png\"/g" \
+			"$index_js"
 		echo 'Patched tray icon selection for Linux theme support'
 	else
 		echo 'Tray icon selection pattern not found or already patched'
@@ -776,11 +816,12 @@ patch_tray_icon_selection() {
 
 patch_menu_bar_default() {
 	echo 'Patching menuBarEnabled to default to true when unset...'
+	local index_js='app.asar.contents/.vite/build/index.js'
 
-	# Extract the variable name assigned from the menuBarEnabled config getter
 	local menu_bar_var
-	menu_bar_var=$(grep -oP 'const \K\w+(?=\s*=\s*\w+\("menuBarEnabled"\))' \
-		app.asar.contents/.vite/build/index.js | head -1)
+	menu_bar_var=$(grep -oP \
+		'const \K\w+(?=\s*=\s*\w+\("menuBarEnabled"\))' \
+		"$index_js" | head -1)
 	if [[ -z $menu_bar_var ]]; then
 		echo '  Could not extract menuBarEnabled variable name'
 		echo '##############################################################'
@@ -788,11 +829,11 @@ patch_menu_bar_default() {
 	fi
 	echo "  Found menuBarEnabled variable: $menu_bar_var"
 
-	# The tray creation check uses a comma operator: ...,!!t){
-	# Change !!t to t!==false so undefined (missing config) defaults to true
-	if grep -qP ",\s*!!${menu_bar_var}\s*\)" app.asar.contents/.vite/build/index.js; then
-		sed -i -E "s/,\s*!!${menu_bar_var}\s*\)/,${menu_bar_var}!==false)/g" \
-			app.asar.contents/.vite/build/index.js
+	# Change !!var to var!==false so undefined defaults to true
+	if grep -qP ",\s*!!${menu_bar_var}\s*\)" "$index_js"; then
+		sed -i -E \
+			"s/,\s*!!${menu_bar_var}\s*\)/,${menu_bar_var}!==false)/g" \
+			"$index_js"
 		echo '  Patched menuBarEnabled to default to true'
 	else
 		echo '  menuBarEnabled pattern not found or already patched'


### PR DESCRIPTION
## Summary

The tray icon patches in `build.sh` were hardcoding `oe` as the electron module variable name. Since variable names change between releases due to minification, this broke the tray on v1.1.2321 where the actual variable is `Ae`. This also adds a fix for `menuBarEnabled` defaulting to disabled when the config key gets removed during updates.

- Dynamically extract the electron module variable from `require("electron")` in the minified source
- Replace hardcoded `oe` in `patch_tray_menu_handler()` and `patch_tray_icon_selection()` with the extracted variable
- Auto-detect and fix any upstream minifier bugs where the wrong variable references `.nativeTheme`
- Patch `menuBarEnabled` check from `!!t` to `t!==false` so missing config defaults to tray enabled

Fixes #218
Fixes #219

## Test plan

- [x] `shellcheck` passes clean
- [x] Full AppImage build completes successfully
- [x] Ran `prettier` on extracted asar — all 7 `nativeTheme` references use correct `Ae`, zero `oe`
- [x] Verified `t!==false` replaces `!!t` in tray creation conditional
- [x] Verified `_trayStartTime` startup delay applied with correct variable
- [ ] Manual test: run AppImage and confirm tray icon appears
- [ ] Manual test: remove `menuBarEnabled` from config.json and confirm tray still works

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
70% AI / 30% Human
Claude: investigated issues, implemented regex extraction, wrote patches, verified build output
Human: directed approach, tested build, reviewed results, approved changes