### PR TITLE
Fix Quick Entry window frame on KDE Plasma Wayland

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -846,6 +846,11 @@ patch_quick_window() {
 		sed -i 's/e.hide()/e.blur(),e.hide()/' app.asar.contents/.vite/build/index.js
 		echo 'Added blur() call to fix quick window submit issue'
 	fi
+
+	if ! grep -q 'frame:!1.*e\.hide()' app.asar.contents/.vite/build/index.js; then
+		sed -i 's/frame:true\(.*e\.hide()\)/frame:!1\1/' app.asar.contents/.vite/build/index.js
+		echo 'Restored frameless for Quick Entry window'
+	fi
 }
 
 patch_linux_claude_code() {


### PR DESCRIPTION
## Summary

Fixes the unwanted window frame on Quick Entry popup (Ctrl+Alt+Space) on KDE Plasma with Wayland by extending the existing `patch_quick_window()` function.

## Problem
The global frame patching in build.sh forces `frame:true` on all BrowserWindows to enable native decorations, but this inadvertently affects the Quick Entry popup which should remain frameless for optimal UX.

<img width="634" height="550" alt="Image" src="https://github.com/user-attachments/assets/1dfb548e-a8a2-4584-a3f6-85a4b0b99479" />

## Solution
- Extend `patch_quick_window()` function with second sed pattern
- Restore `frame:!1` specifically for Quick Entry window
- Uses existing proven `e.hide()` pattern matching approach
- **Tested and confirmed working on AppImage build**

## Changes
- Add second sed operation to revert `frame:true` to `frame:!1` for Quick Entry window
- Maintains native frames for main application windows
- Zero risk of side effects due to precise pattern matching

## Testing
- ✅ Built and tested on AppImage format
- ✅ Quick Entry window now appears frameless as expected  
- ✅ Main application windows retain native frames
- ✅ No regression in existing functionality

## Environment Tested
- **OS**: Arch Linux + KDE Plasma 6.5.91-1 + Wayland
- **Package**: AppImage 
- **Hardware**: NVIDIA GeForce RTX 3060 Laptop GPU

Fixes #223