### PR TITLE
fix: improve Linux UX - popup detection, functional stubs, Wayland compositor support

### DIFF
--- a/scripts/claude-native-stub.js
+++ b/scripts/claude-native-stub.js
@@ -1,6 +1,17 @@
 // Stub implementation of claude-native for Linux
+// Uses Electron's native Linux support where possible instead of no-ops
 const KeyboardKey = { Backspace: 43, Tab: 280, Enter: 261, Shift: 272, Control: 61, Alt: 40, CapsLock: 56, Escape: 85, Space: 276, PageUp: 251, PageDown: 250, End: 83, Home: 154, LeftArrow: 175, UpArrow: 282, RightArrow: 262, DownArrow: 81, Delete: 79, Meta: 187 };
 Object.freeze(KeyboardKey);
+
+// Helper: get the focused BrowserWindow (lazy-loaded to avoid circular deps)
+function getWindow() {
+  try {
+    const { BrowserWindow } = require('electron');
+    return BrowserWindow.getFocusedWindow() || BrowserWindow.getAllWindows()[0] || null;
+  } catch {
+    return null;
+  }
+}
 
 // AuthRequest stub - not available on Linux, will cause fallback to system browser
 class AuthRequest {
@@ -21,12 +32,38 @@ module.exports = {
   getWindowsVersion: () => "10.0.0",
   setWindowEffect: () => {},
   removeWindowEffect: () => {},
-  getIsMaximized: () => false,
-  flashFrame: () => {},
-  clearFlashFrame: () => {},
+
+  // Functional on Linux via Electron's native support
+  getIsMaximized: () => {
+    const win = getWindow();
+    return win ? win.isMaximized() : false;
+  },
+
+  // Fixes: #149 - KDE Plasma: Window demands attention
+  // flashFrame is natively supported on Linux Electron
+  flashFrame: (flash) => {
+    const win = getWindow();
+    if (win) win.flashFrame(typeof flash === 'boolean' ? flash : true);
+  },
+  clearFlashFrame: () => {
+    const win = getWindow();
+    if (win) win.flashFrame(false);
+  },
+
   showNotification: () => {},
-  setProgressBar: () => {},
-  clearProgressBar: () => {},
+
+  // Progress bar is natively supported on Linux (Unity/KDE/GNOME)
+  setProgressBar: (progress) => {
+    const win = getWindow();
+    if (win && typeof progress === 'number') {
+      win.setProgressBar(Math.max(0, Math.min(1, progress)));
+    }
+  },
+  clearProgressBar: () => {
+    const win = getWindow();
+    if (win) win.setProgressBar(-1);
+  },
+
   setOverlayIcon: () => {},
   clearOverlayIcon: () => {},
   KeyboardKey,


### PR DESCRIPTION
## Summary

- **frame-fix-wrapper.js**: Popup/Quick Entry window detection (#223), CSS injection for scrollbar styling + font rendering, persistent menu bar hiding (#172), KDE attention flash fix (#149), content resize fix (#84)
- **claude-native-stub.js**: Make `getIsMaximized`, `flashFrame`, `setProgressBar` functional via Electron's native Linux support instead of no-ops
- **launcher-common.sh**: Auto-detect Niri/Sway/Hyprland compositors and force native Wayland (#226), safe `${VAR:-}` expansion

## Issues Addressed

- #84 - Content not sized correctly for window unless resized
- #149 - KDE Plasma 6 + Wayland: Window demands attention on Alt+Tab
- #172 - Menu bar still visible despite disabling flags on Linux Mint
- #223 - Quick Entry window shows unwanted frame on KDE Plasma Wayland
- #226 - AppImage crashes on Niri compositor due to missing Wayland flags

## Test plan

- [ ] Verify main window has native frame and hidden menu bar
- [ ] Verify Quick Entry popup remains frameless
- [ ] Verify scrollbar styling appears (light + dark themes)
- [ ] Test on KDE Plasma 6 + Wayland: Alt+Tab no longer causes persistent attention state
- [ ] Test on Linux Mint: menu bar stays hidden after window show events
- [ ] Test content sizing: window content fills correctly on first launch without manual resize
- [ ] Test on Niri: app launches with native Wayland flags automatically
- [ ] Test on Sway: app launches with native Wayland flags automatically
- [ ] Verify `getIsMaximized` returns correct state when window is maximized
- [ ] Verify progress bar appears in taskbar during long operations (KDE/GNOME)

🤖 Generated with [Claude Code](https://claude.com/claude-code)