### PR TITLE
feat: add systemd user service for Cowork VM daemon

### DIFF
--- a/scripts/cowork-vm-service.service
+++ b/scripts/cowork-vm-service.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Claude Desktop Cowork VM Service Daemon
+Documentation=https://github.com/aaddrick/claude-desktop-debian
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/node /usr/lib/claude-desktop/node_modules/electron/dist/resources/app.asar.unpacked/cowork-vm-service.js
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

- Adds a systemd user service to reliably auto-start the `cowork-vm-service.js` daemon
- Fixes Cowork mode ("Code" and "Tasks" tabs) failing with "VM is not running" because the
  in-app `fork()` auto-launch doesn't trigger reliably (see #236)
- The daemon starts on user login and is ready before Claude Desktop opens

## What Changed

### scripts/cowork-vm-service.service (new)

Systemd user service unit file installed to `/usr/lib/systemd/user/`:

```ini
[Unit]
Description=Claude Desktop Cowork VM Service Daemon
Documentation=https://github.com/aaddrick/claude-desktop-debian

[Service]
Type=simple
ExecStart=/usr/bin/node /usr/lib/claude-desktop/node_modules/electron/dist/resources/app.asar.unpacked/cowork-vm-service.js
Restart=on-failure
RestartSec=3

[Install]
WantedBy=default.target
```

### scripts/build-deb-package.sh (modified)

- Copies service file to `/usr/lib/systemd/user/cowork-vm-service.service` during package build
- **postinst**: enables the service globally via `systemctl --global enable`
- **prerm** (new): disables the service on package removal via `systemctl --global disable`
- Adds `chmod 755` for the new prerm script alongside the existing postinst

## Why systemd instead of fixing the fork()

The in-app `fork()` approach (from PR #234) has two issues:

1. **Race condition** — The `CustomPlugins_listAvailablePlugins` handler calls `b_t()` which
   checks VM status and throws before `Ma()` gets a chance to auto-launch the daemon via
   the ENOENT retry path
2. **Silent failure** — The `catch(e){}` in the fork code swallows all errors, making
   debugging impossible

A systemd service avoids both problems: the socket is ready before Claude Desktop starts,
and failures are logged via `journalctl`.

The in-app fork code remains as a fallback — if the systemd service happens to not be
running, the app will still attempt to start the daemon on its own.

## Test plan

- [ ] Build: `.deb` package includes `/usr/lib/systemd/user/cowork-vm-service.service`
- [ ] Install: `sudo dpkg -i claude-desktop_*.deb` enables the service
- [ ] Socket: `/run/user/$UID/cowork-vm-service.sock` exists after login
- [ ] Status: `systemctl --user status cowork-vm-service` shows active
- [ ] Cowork: Open Claude Desktop → click "Code" tab → session starts without errors
- [ ] Tasks: Click "Tasks" tab → Cowork scheduled tasks UI loads
- [ ] Restart: `systemctl --user restart cowork-vm-service` → Cowork reconnects
- [ ] Remove: `sudo apt remove claude-desktop` disables the service cleanly
- [ ] Logs: `journalctl --user -u cowork-vm-service` shows daemon startup messages

---

Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
80% AI / 20% Human
Claude: Root cause analysis, systemd service implementation, build script changes, PR draft
Human: Testing, verification, issue reporting, review