### PR TITLE
fix: update patch_linux_claude_code for Claude >= 1.1.3541

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -849,11 +849,23 @@ patch_quick_window() {
 }
 
 patch_linux_claude_code() {
-	if ! grep -q 'process.arch==="arm64"?"linux-arm64":"linux-x64"' app.asar.contents/.vite/build/index.js; then
-		sed -i 's/if(process.platform==="win32")return"win32-x64";/if(process.platform==="win32")return"win32-x64";if(process.platform==="linux")return process.arch==="arm64"?"linux-arm64":"linux-x64";/' app.asar.contents/.vite/build/index.js
-		echo 'Added support for linux claude code binary'
-	else
+	local index_js='app.asar.contents/.vite/build/index.js'
+	if grep -q 'process.platform==="linux".*linux-arm64.*linux-x64' "$index_js"; then
 		echo 'Linux claude code binary support already present'
+		return
+	fi
+
+	# New format (Claude >= 1.1.3541): getHostPlatform includes arch detection for win32
+	# Pattern: if(process.platform==="win32")return e==="arm64"?"win32-arm64":"win32-x64";throw new Error(...)
+	if grep -qP 'if\(process\.platform==="win32"\)return \w+==="arm64"\?"win32-arm64":"win32-x64";throw' "$index_js"; then
+		sed -i -E 's/if\(process\.platform==="win32"\)return (\w+)==="arm64"\?"win32-arm64":"win32-x64";throw/if(process.platform==="win32")return \1==="arm64"?"win32-arm64":"win32-x64";if(process.platform==="linux")return \1==="arm64"?"linux-arm64":"linux-x64";throw/' "$index_js"
+		echo 'Added linux claude code support (new arch-aware format)'
+	# Old format (Claude <= 1.1.3363): no arch detection for win32
+	elif grep -q 'if(process.platform==="win32")return"win32-x64";' "$index_js"; then
+		sed -i 's/if(process.platform==="win32")return"win32-x64";/if(process.platform==="win32")return"win32-x64";if(process.platform==="linux")return process.arch==="arm64"?"linux-arm64":"linux-x64";/' "$index_js"
+		echo 'Added linux claude code support (legacy format)'
+	else
+		echo 'Warning: Could not find getHostPlatform pattern to patch for Linux claude code support'
 	fi
 }
 


### PR DESCRIPTION
Fixes #241

  ## Problem

  Starting with Claude Desktop v1.1.3541, Anthropic refactored `getHostPlatform()` to add Windows arm64 support. This changed the minified code from:

  ```js
  if(process.platform==="win32")return"win32-x64";

  to:

  if(process.platform==="win32")return e==="arm64"?"win32-arm64":"win32-x64";

  The sed pattern in patch_linux_claude_code() no longer matches, so the Linux platform patch is silently not applied. This completely breaks the Code tab with Error: Unsupported platform: linux-x64.

  Fix

  Updated patch_linux_claude_code() to:
  - Handle the new arch-aware format (Claude >= 1.1.3541) using a regex capture group for the minified variable name
  - Keep the old format as a fallback (Claude <= 1.1.3363)
  - Emit a warning if neither pattern matches (future-proofing)
