### PR TITLE
fix: support $-prefixed electron variable names in build patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Special thanks to:
 - **[jarrodcolburn](https://github.com/jarrodcolburn)** for passwordless sudo support in container/CI environments
 - **[chukfinley](https://github.com/chukfinley)** for experimental Cowork mode support on Linux
 - **[IliyaBrook](https://github.com/IliyaBrook)** for fixing the platform patch for Claude Desktop >= 1.1.3541 arm64 refactor
+- **[MichaelMKenny](https://github.com/MichaelMKenny)** for diagnosing the `$`-prefixed electron variable bug with root cause analysis and workaround
 
 For NixOS users, please refer to [k3d3's repository](https://github.com/k3d3/claude-desktop-linux-flake) for a Nix-specific implementation.
 

--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,7 @@ work_dir=''
 app_staging_dir=''
 chosen_electron_module_path=''
 electron_var=''
+electron_var_re=''
 asar_exec=''
 claude_extract_dir=''
 electron_resources_dest=''
@@ -687,10 +688,10 @@ extract_electron_variable() {
 	echo 'Extracting electron module variable name...'
 	local index_js='app.asar.contents/.vite/build/index.js'
 
-	electron_var=$(grep -oP '\b\w+(?=\s*=\s*require\("electron"\))' \
+	electron_var=$(grep -oP '\$?\w+(?=\s*=\s*require\("electron"\))' \
 		"$index_js" | head -1)
 	if [[ -z $electron_var ]]; then
-		electron_var=$(grep -oP '(?<=new )\w+(?=\.Tray\b)' \
+		electron_var=$(grep -oP '(?<=new )\$?\w+(?=\.Tray\b)' \
 			"$index_js" | head -1)
 	fi
 	if [[ -z $electron_var ]]; then
@@ -698,6 +699,7 @@ extract_electron_variable() {
 		cd "$project_root" || exit 1
 		exit 1
 	fi
+	electron_var_re="${electron_var//\$/\\$}"
 	echo "  Found electron variable: $electron_var"
 	echo '##############################################################'
 }
@@ -708,9 +710,9 @@ fix_native_theme_references() {
 
 	local wrong_refs
 	mapfile -t wrong_refs < <(
-		grep -oP '\b\w+(?=\.nativeTheme)' "$index_js" \
+		grep -oP '\$?\w+(?=\.nativeTheme)' "$index_js" \
 			| sort -u \
-			| grep -v "^${electron_var}$" || true
+			| grep -Fxv "$electron_var" || true
 	)
 
 	if (( ${#wrong_refs[@]} == 0 )); then
@@ -719,11 +721,12 @@ fix_native_theme_references() {
 		return
 	fi
 
-	local ref
+	local ref ref_re
 	for ref in "${wrong_refs[@]}"; do
 		echo "  Replacing: $ref.nativeTheme -> $electron_var.nativeTheme"
+		ref_re="${ref//\$/\\$}"
 		sed -i -E \
-			"s/\b${ref}\.nativeTheme/${electron_var}.nativeTheme/g" \
+			"s/${ref_re}\.nativeTheme/${electron_var_re}.nativeTheme/g" \
 			"$index_js"
 	done
 	echo '##############################################################'
@@ -788,7 +791,7 @@ patch_tray_menu_handler() {
 	echo 'Patching nativeTheme handler for startup delay...'
 	if ! grep -q '_trayStartTime' "$index_js"; then
 		sed -i -E \
-			"s/(${electron_var}\.nativeTheme\.on\(\s*\"updated\"\s*,\s*\(\)\s*=>\s*\{)/let _trayStartTime=Date.now();\1/g" \
+			"s/(${electron_var_re}\.nativeTheme\.on\(\s*\"updated\"\s*,\s*\(\)\s*=>\s*\{)/let _trayStartTime=Date.now();\1/g" \
 			"$index_js"
 		sed -i -E \
 			"s/\((\w+)\(\)\s*,\s*${tray_func}\(\)\s*,/(\1(),Date.now()-_trayStartTime>3e3\&\&${tray_func}(),/g" \
@@ -801,11 +804,11 @@ patch_tray_menu_handler() {
 patch_tray_icon_selection() {
 	echo 'Patching tray icon selection for Linux visibility...'
 	local index_js='app.asar.contents/.vite/build/index.js'
-	local dark_check="$electron_var.nativeTheme.shouldUseDarkColors"
+	local dark_check="${electron_var_re}.nativeTheme.shouldUseDarkColors"
 
-	if grep -qP ':\w="TrayIconTemplate\.png"' "$index_js"; then
+	if grep -qP ':\$?\w="TrayIconTemplate\.png"' "$index_js"; then
 		sed -i -E \
-			"s/:(\w)=\"TrayIconTemplate\.png\"/:\1=${dark_check}?\"TrayIconTemplate-Dark.png\":\"TrayIconTemplate.png\"/g" \
+			"s/:(\\\$?\w)=\"TrayIconTemplate\.png\"/:\1=${dark_check}?\"TrayIconTemplate-Dark.png\":\"TrayIconTemplate.png\"/g" \
 			"$index_js"
 		echo 'Patched tray icon selection for Linux theme support'
 	else


### PR DESCRIPTION
## Summary

Fixes #252. Claude Desktop v1.1.4088 changed the minified electron module variable from a plain identifier like `oe` to `$e`. The `$` character is valid in JavaScript identifiers but `\w` in regex doesn't match it, so `extract_electron_variable()` captured only `e` instead of `$e`. Every downstream sed patch then inserted code between the `$` and `e`, producing syntax like `$let _trayStartTime=Date.now();` — a SyntaxError that broke the build.

I also caught a second related bug during review. The `dark_check` variable in `patch_tray_icon_selection()` expands `$electron_var` inside a sed command, which bash double-expands. That would produce broken output even after fixing the extraction step.

## Changes

- `extract_electron_variable()` grep pattern now uses `\$?` to match an optional leading `$`
- Added `electron_var_re` — a regex-escaped version of `electron_var` with `$` escaped to `\$`
- Switched from `grep -w` to `grep -Fxv` for literal string comparison where the variable name is used as a fixed pattern
- `patch_tray_icon_selection()` now uses `electron_var_re` in the sed command to avoid bash double-expansion
- Sed replacement strings that reference the electron variable now use `electron_var_re` throughout

## Validation

Tested against v1.1.4088. All three checks pass:

1. No stray `$let` in the patched output
2. `_trayStartTime` placement is correct
3. `$e.nativeTheme.shouldUseDarkColors` appears correctly in the tray icon selection code

## Credit

MichaelMKenny filed #252 with a full root cause analysis and a working workaround. The implementation here follows that analysis directly.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Root cause analysis, implementation, code review fixes, validation
Human: Issue triage, plan review, build/test execution