### PR TITLE
fix: detect wrapper-only releases by checking immediate predecessor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,14 +190,17 @@ jobs:
             [[ -n "$any_tag" && -n "$upstream_tag" ]] && break
           done < <(gh release list --limit 50 -R "$GITHUB_REPOSITORY" --json tagName -q '.[].tagName')
 
-          if [[ -n "$upstream_tag" ]]; then
-            echo "type=upstream" >> "$GITHUB_OUTPUT"
-            echo "tag=$upstream_tag" >> "$GITHUB_OUTPUT"
-            echo "Upstream change: $upstream_tag -> $current"
-          elif [[ -n "$any_tag" ]]; then
-            echo "type=wrapper" >> "$GITHUB_OUTPUT"
-            echo "tag=$any_tag" >> "$GITHUB_OUTPUT"
-            echo "Wrapper-only update: $any_tag -> $current"
+          if [[ -n "$any_tag" ]]; then
+            any_cv="${any_tag#*+claude}"
+            if [[ "$any_cv" != "$current_cv" && -n "$upstream_tag" ]]; then
+              echo "type=upstream" >> "$GITHUB_OUTPUT"
+              echo "tag=$upstream_tag" >> "$GITHUB_OUTPUT"
+              echo "Upstream change: $upstream_tag -> $current"
+            else
+              echo "type=wrapper" >> "$GITHUB_OUTPUT"
+              echo "tag=$any_tag" >> "$GITHUB_OUTPUT"
+              echo "Wrapper-only update: $any_tag -> $current"
+            fi
           else
             echo "type=none" >> "$GITHUB_OUTPUT"
             echo "::warning::No previous release found"


### PR DESCRIPTION
## Summary

- The release notes workflow was searching all previous tags for a different Claude Desktop version, not just the immediately preceding one
- When a wrapper-only hotfix followed another wrapper release, the workflow would find an older upstream release further back in history and misclassify the new release as upstream
- This triggered the full AI analysis at $60+ per run when it should have just listed commits

## What changed

The fix is in `.github/workflows/ci.yml`. Instead of scanning all previous releases for any version difference, the workflow now checks only the immediately preceding release's Claude version.

If that predecessor has the same Claude version, the release is classified as a wrapper release. The full `compare-releases.py` analysis only runs when the immediately prior tag had a different Claude version.

## Root cause example

The sequence that exposed this:

1. `v1.3.12+claude1.1.4010` — upstream release (Claude version changed)
2. `v1.3.12+claude1.1.4088` — upstream release (Claude version changed)
3. `v1.3.13+claude1.1.4088` — wrapper hotfix (same Claude version as v1.3.12+claude1.1.4088)

The old logic found `v1.3.12+claude1.1.4010` in step 3's history and saw a different Claude version. It classified v1.3.13 as upstream and ran a $63 analysis.

The new logic checks v1.3.12+claude1.1.4088 first. Same version. Wrapper release. Done.

## Test plan

- [ ] Trigger a release that's a wrapper-only change and confirm the workflow skips `compare-releases.py`
- [ ] Trigger a release with an updated Claude Desktop version and confirm the full analysis still runs
- [ ] Verify release notes output looks correct for both cases

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Root cause analysis and implementation
Human: Issue identification and review