### PR TITLE
fix: update cowork platform gate patch for v1.1.4173

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -899,7 +899,7 @@ let patchCount = 0;
 const platformGateRe = /(\w+)(\s*!==\s*"darwin"\s*&&\s*)\1(\s*!==\s*"win32")/g;
 const origCode = code;
 code = code.replace(platformGateRe, (match, varName, mid, end) => {
-    // Only patch the instance near the "Unsupported platform" error
+    // Only patch the instance near the "unsupported_platform" code value
     const matchIdx = origCode.indexOf(match);
     const nearbyText = origCode.substring(matchIdx, matchIdx + 200);
     if (nearbyText.includes('unsupported_platform') || nearbyText.includes('Unsupported platform')) {


### PR DESCRIPTION
## Summary

- Updates the cowork Patch 1 disambiguation check to match the new `unsupported_platform` anchor string used in v1.1.4173 (in addition to the old `Unsupported platform` string)
- Increases the fallback regex search distance from 50 to 200 chars to match the new code layout
- Makes Patch 1 failure a hard build error (`process.exit(1)`) so we never ship a package that crashes at startup
- Fixes the tray startup delay sed pattern to handle function calls with arguments (e.g. `B1(bm-1)` instead of `B1()`)

## Test plan

- [x] Verified cowork platform gate patch applies to v1.1.4173 index.js — `&&t!=="linux"` present
- [x] Verified tray startup delay patch applies — both `_trayStartTime` declaration and guard present
- [x] `node -c` syntax check passes on patched output
- [x] `shellcheck build.sh` passes clean
- [x] Full AppImage build succeeds: `./build.sh --build appimage --clean no`

Fixes #259

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: investigated root cause, implemented all three fixes, ran verification
Human: identified the issue, provided direction and plan approval