### PR TITLE
feat: add NixOS flake with build.sh integration

### DIFF
--- a/.github/workflows/check-claude-version.yml
+++ b/.github/workflows/check-claude-version.yml
@@ -7,6 +7,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: main-branch-auto-update
+  cancel-in-progress: false
+
 jobs:
   check-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-claude-version.yml
+++ b/.github/workflows/check-claude-version.yml
@@ -165,12 +165,19 @@ jobs:
           AMD64_URL="${{ steps.resolve_urls.outputs.amd64_url }}"
           ARM64_URL="${{ steps.resolve_urls.outputs.arm64_url }}"
 
-          # Download and compute SHA256 in SRI format
-          AMD64_HASH=$(curl -fsSL "$AMD64_URL" | sha256sum | awk '{print $1}' | xxd -r -p | base64 -w0)
+          # Download to temp files first so a partial download doesn't
+          # produce a valid-looking but wrong SRI hash.
+          amd64_tmp=$(mktemp)
+          curl -fsSL -o "$amd64_tmp" "$AMD64_URL" || { echo "AMD64 download failed"; exit 1; }
+          AMD64_HASH=$(sha256sum "$amd64_tmp" | awk '{print $1}' | xxd -r -p | base64 -w0)
+          rm "$amd64_tmp"
           echo "amd64_sri=sha256-$AMD64_HASH" >> $GITHUB_OUTPUT
 
           if [ -n "$ARM64_URL" ]; then
-            ARM64_HASH=$(curl -fsSL "$ARM64_URL" | sha256sum | awk '{print $1}' | xxd -r -p | base64 -w0)
+            arm64_tmp=$(mktemp)
+            curl -fsSL -o "$arm64_tmp" "$ARM64_URL" || { echo "ARM64 download failed"; exit 1; }
+            ARM64_HASH=$(sha256sum "$arm64_tmp" | awk '{print $1}' | xxd -r -p | base64 -w0)
+            rm "$arm64_tmp"
             echo "arm64_sri=sha256-$ARM64_HASH" >> $GITHUB_OUTPUT
           fi
 
@@ -189,12 +196,16 @@ jobs:
           sed -i "s/version = \"[^\"]*\"/version = \"$CLAUDE_VERSION\"/" "$NIX_FILE"
 
           # Update amd64 URL and hash
-          sed -i "s|releases/win32/x64/[^\"]*|$(echo "$NEW_AMD64_URL" | sed 's|.*releases/|releases/|')|" "$NIX_FILE"
+          AMD64_PATH=$(echo "$NEW_AMD64_URL" | sed 's|.*releases/|releases/|')
+          sed -i "s|releases/win32/x64/[^\"]*|$AMD64_PATH|" "$NIX_FILE"
+          # Range assumes each arch block (x86_64-linux/aarch64-linux) contains
+          # exactly one `hash = "..."` line before its closing `};`.
           sed -i "/x86_64-linux/,/};/{s|hash = \"[^\"]*\"|hash = \"$AMD64_SRI\"|}" "$NIX_FILE"
 
           # Update arm64 URL and hash
           if [ -n "$NEW_ARM64_URL" ]; then
-            sed -i "s|releases/win32/arm64/[^\"]*|$(echo "$NEW_ARM64_URL" | sed 's|.*releases/|releases/|')|" "$NIX_FILE"
+            ARM64_PATH=$(echo "$NEW_ARM64_URL" | sed 's|.*releases/|releases/|')
+            sed -i "s|releases/win32/arm64/[^\"]*|$ARM64_PATH|" "$NIX_FILE"
             sed -i "/aarch64-linux/,/};/{s|hash = \"[^\"]*\"|hash = \"$ARM64_SRI\"|}" "$NIX_FILE"
           fi
 

--- a/.github/workflows/check-claude-version.yml
+++ b/.github/workflows/check-claude-version.yml
@@ -158,6 +158,49 @@ jobs:
           echo "Updated build.sh:"
           grep "claude_download_url=" build.sh
 
+      - name: Compute SRI hashes for Nix
+        if: steps.check_update.outputs.update_needed == 'true'
+        id: nix_hashes
+        run: |
+          AMD64_URL="${{ steps.resolve_urls.outputs.amd64_url }}"
+          ARM64_URL="${{ steps.resolve_urls.outputs.arm64_url }}"
+
+          # Download and compute SHA256 in SRI format
+          AMD64_HASH=$(curl -fsSL "$AMD64_URL" | sha256sum | awk '{print $1}' | xxd -r -p | base64 -w0)
+          echo "amd64_sri=sha256-$AMD64_HASH" >> $GITHUB_OUTPUT
+
+          if [ -n "$ARM64_URL" ]; then
+            ARM64_HASH=$(curl -fsSL "$ARM64_URL" | sha256sum | awk '{print $1}' | xxd -r -p | base64 -w0)
+            echo "arm64_sri=sha256-$ARM64_HASH" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update Nix package
+        if: steps.check_update.outputs.update_needed == 'true'
+        run: |
+          CLAUDE_VERSION="${{ steps.resolve_urls.outputs.claude_version }}"
+          NEW_AMD64_URL="${{ steps.resolve_urls.outputs.amd64_url }}"
+          NEW_ARM64_URL="${{ steps.resolve_urls.outputs.arm64_url }}"
+          AMD64_SRI="${{ steps.nix_hashes.outputs.amd64_sri }}"
+          ARM64_SRI="${{ steps.nix_hashes.outputs.arm64_sri }}"
+
+          NIX_FILE="nix/claude-desktop.nix"
+
+          # Update version
+          sed -i "s/version = \"[^\"]*\"/version = \"$CLAUDE_VERSION\"/" "$NIX_FILE"
+
+          # Update amd64 URL and hash
+          sed -i "s|releases/win32/x64/[^\"]*|$(echo "$NEW_AMD64_URL" | sed 's|.*releases/|releases/|')|" "$NIX_FILE"
+          sed -i "/x86_64-linux/,/};/{s|hash = \"[^\"]*\"|hash = \"$AMD64_SRI\"|}" "$NIX_FILE"
+
+          # Update arm64 URL and hash
+          if [ -n "$NEW_ARM64_URL" ]; then
+            sed -i "s|releases/win32/arm64/[^\"]*|$(echo "$NEW_ARM64_URL" | sed 's|.*releases/|releases/|')|" "$NIX_FILE"
+            sed -i "/aarch64-linux/,/};/{s|hash = \"[^\"]*\"|hash = \"$ARM64_SRI\"|}" "$NIX_FILE"
+          fi
+
+          echo "Updated $NIX_FILE:"
+          head -30 "$NIX_FILE"
+
       - name: Commit and push changes
         if: steps.check_update.outputs.update_needed == 'true'
         env:
@@ -177,10 +220,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Check if there are changes to commit
-          if git diff --quiet build.sh; then
-            echo "No changes to build.sh"
+          if git diff --quiet build.sh nix/claude-desktop.nix; then
+            echo "No changes to build.sh or nix/claude-desktop.nix"
           else
-            git add build.sh
+            git add build.sh nix/claude-desktop.nix
             git commit -m "$(cat <<COMMIT_MSG
           Update Claude Desktop download URLs to version $CLAUDE_VERSION
 

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -1,0 +1,49 @@
+name: Update Flake Lock
+on:
+  schedule:
+    - cron: "0 2 * * 1"  # Monday 2 AM UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: main-branch-auto-update
+  cancel-in-progress: false
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Update flake.lock
+        run: nix flake update
+
+      - name: Check for changes
+        id: check
+        run: |
+          if git diff --quiet flake.lock; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+            echo "flake.lock is already up to date"
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+            echo "flake.lock has changes:"
+            nix flake metadata --json | jq -r '.locks.nodes | to_entries[] | select(.key != "root") | "\(.key): \(.value.locked.rev[0:8])"'
+          fi
+
+      - name: Commit and push
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add flake.lock
+          git commit -m "chore: update flake.lock"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ test-build/
 
 # Reference files for source inspection
 build-reference/
+
+# Nix build output
+result
+result-*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,6 +303,7 @@ gh run download RUN_ID -n artifact-name
 - `claude-desktop-VERSION-amd64.AppImage` - AppImage for x86_64
 - `claude-desktop-VERSION-arm64.deb` - Debian package for ARM64
 - `claude-desktop-VERSION-arm64.AppImage` - AppImage for ARM64
+- `result/` - Nix build output (symlink, gitignored)
 
 ## Testing
 
@@ -310,6 +311,13 @@ gh run download RUN_ID -n artifact-name
 
 ```bash
 ./build.sh --build appimage --clean no
+```
+
+### Nix Build
+
+```bash
+nix build .#claude-desktop
+nix build .#claude-desktop-fhs
 ```
 
 ### Testing AppImage
@@ -373,6 +381,7 @@ gdbus call --session --dest=org.freedesktop.DBus \
   ```
 - **SingletonLock** - If app won't start, check for stale lock: `~/.config/Claude/SingletonLock`
 - **Node version** - Build requires Node.js; the script downloads its own if needed
+- **Nix hashes** - When Claude Desktop version changes, both `build.sh` URLs and `nix/claude-desktop.nix` (version, URLs, SRI hashes) must be updated. The CI handles this automatically.
 - **Claude Desktop version** - A GitHub Action automatically updates the `CLAUDE_DESKTOP_VERSION` repo variable and the URLs in `build.sh` on main when a new version is detected. Before committing `build.sh`, ensure your branch has the latest URLs:
   ```bash
   # Check repo variable (source of truth)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Desktop for Linux
 
-This project provides build scripts to run Claude Desktop natively on Linux systems. It repackages the official Windows application for Linux distributions, producing `.deb` packages (Debian/Ubuntu), `.rpm` packages (Fedora/RHEL), distribution-agnostic AppImages, and an [AUR package](https://aur.archlinux.org/packages/claude-desktop-appimage) for Arch Linux.
+This project provides build scripts to run Claude Desktop natively on Linux systems. It repackages the official Windows application for Linux distributions, producing `.deb` packages (Debian/Ubuntu), `.rpm` packages (Fedora/RHEL), distribution-agnostic AppImages, an [AUR package](https://aur.archlinux.org/packages/claude-desktop-appimage) for Arch Linux, and a Nix flake for NixOS.
 
 **Note:** This is an unofficial build script. For official support, please visit [Anthropic's website](https://www.anthropic.com). For issues with the build script or Linux implementation, please [open an issue](https://github.com/aaddrick/claude-desktop-debian/issues) in this repository.
 
@@ -80,6 +80,38 @@ paru -S claude-desktop-appimage
 
 The AUR package installs the AppImage build of Claude Desktop.
 
+### Using Nix Flake (NixOS)
+
+Install directly from the flake:
+
+```bash
+# Basic install
+nix profile install github:aaddrick/claude-desktop-debian
+
+# With MCP server support (FHS environment)
+nix profile install github:aaddrick/claude-desktop-debian#claude-desktop-fhs
+```
+
+Or add to your NixOS configuration:
+
+```nix
+# flake.nix
+{
+  inputs.claude-desktop.url = "github:aaddrick/claude-desktop-debian";
+
+  outputs = { nixpkgs, claude-desktop, ... }: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      modules = [
+        ({ pkgs, ... }: {
+          nixpkgs.overlays = [ claude-desktop.overlays.default ];
+          environment.systemPackages = [ pkgs.claude-desktop ];
+        })
+      ];
+    };
+  };
+}
+```
+
 ### Using Pre-built Releases
 
 Download the latest `.deb`, `.rpm`, or `.AppImage` from the [Releases page](https://github.com/aaddrick/claude-desktop-debian/releases).
@@ -138,7 +170,7 @@ Special thanks to:
 - **[daa25209](https://github.com/daa25209)** for detailed root cause analysis of the cowork platform gate crash and patch script
 - **[noctuum](https://github.com/noctuum)** for the `CLAUDE_MENU_BAR` env var for configurable menu bar visibility
 
-For NixOS users, please refer to [k3d3's repository](https://github.com/k3d3/claude-desktop-linux-flake) for a Nix-specific implementation.
+This project includes a NixOS flake inspired by [k3d3's original implementation](https://github.com/k3d3/claude-desktop-linux-flake). See the [NixOS installation section](#using-nix-flake-nixos) above.
 
 ## Sponsorship
 

--- a/build.sh
+++ b/build.sh
@@ -202,7 +202,7 @@ parse_arguments() {
 					-c|--clean) cleanup_action="$2" ;;
 					-e|--exe) local_exe_path="$2" ;;
 					-r|--release-tag) release_tag="$2" ;;
-					-s|--source-dir) project_root="$2" ;;
+					-s|--source-dir) source_dir="$2" ;;
 				esac
 				shift 2
 				;;
@@ -216,7 +216,7 @@ parse_arguments() {
 				echo "           Default: auto-detected based on distro (current: $build_format)"
 				echo '  --clean: Specify whether to clean intermediate build files (yes or no). Default: yes'
 				echo '  --exe:   Use a local Claude installer exe instead of downloading'
-				echo '  --source-dir: Path to repo root for scripts/ and assets (default: cwd)'
+				echo '  --source-dir: Path to repo root for scripts/ and assets (default: project root)'
 				echo '  --release-tag: Release tag (e.g., v1.3.2+claude1.1.799) to append wrapper version to package'
 				echo '  --test-flags: Parse flags, print results, and exit without building.'
 				exit 0
@@ -229,9 +229,8 @@ parse_arguments() {
 		esac
 	done
 
-	# Recalculate paths if --source-dir changed project_root
-	work_dir="$project_root/build"
-	app_staging_dir="$work_dir/electron-app"
+	# source_dir is where scripts/assets live (default: project_root)
+	source_dir="${source_dir:-$project_root}"
 
 	# Validate arguments
 	build_format="${build_format,,}"
@@ -587,7 +586,7 @@ patch_app_asar() {
 	original_main=$(node -e "const pkg = require('./app.asar.contents/package.json'); console.log(pkg.main);")
 	echo "Original main entry: $original_main"
 
-	cp "$project_root/scripts/frame-fix-wrapper.js" app.asar.contents/frame-fix-wrapper.js || exit 1
+	cp "$source_dir/scripts/frame-fix-wrapper.js" app.asar.contents/frame-fix-wrapper.js || exit 1
 
 	cat > app.asar.contents/frame-fix-entry.js << EOFENTRY
 // Load frame fix first
@@ -617,7 +616,7 @@ console.log('Updated package.json: main entry and node-pty dependency');
 	# Create stub native module
 	echo 'Creating stub native module...'
 	mkdir -p app.asar.contents/node_modules/@ant/claude-native || exit 1
-	cp "$project_root/scripts/claude-native-stub.js" \
+	cp "$source_dir/scripts/claude-native-stub.js" \
 		app.asar.contents/node_modules/@ant/claude-native/index.js || exit 1
 
 	mkdir -p app.asar.contents/resources/i18n || exit 1
@@ -652,7 +651,7 @@ console.log('Updated package.json: main entry and node-pty dependency');
 
 	# Copy cowork VM service daemon for Linux Cowork mode
 	echo 'Installing cowork VM service daemon...'
-	cp "$project_root/scripts/cowork-vm-service.js" \
+	cp "$source_dir/scripts/cowork-vm-service.js" \
 		app.asar.contents/cowork-vm-service.js || exit 1
 	echo 'Cowork VM service daemon installed'
 }
@@ -1162,12 +1161,12 @@ finalize_app_asar() {
 	"$asar_exec" pack app.asar.contents app.asar || exit 1
 
 	mkdir -p "$app_staging_dir/app.asar.unpacked/node_modules/@ant/claude-native" || exit 1
-	cp "$project_root/scripts/claude-native-stub.js" \
+	cp "$source_dir/scripts/claude-native-stub.js" \
 		"$app_staging_dir/app.asar.unpacked/node_modules/@ant/claude-native/index.js" || exit 1
 
 	# Copy cowork VM service daemon (must be unpacked for child_process.fork)
 	echo 'Copying cowork VM service daemon to unpacked directory...'
-	cp "$project_root/scripts/cowork-vm-service.js" \
+	cp "$source_dir/scripts/cowork-vm-service.js" \
 		"$app_staging_dir/app.asar.unpacked/cowork-vm-service.js" || exit 1
 	echo 'Cowork VM service daemon copied to unpacked'
 

--- a/build.sh
+++ b/build.sh
@@ -112,6 +112,9 @@ detect_distro() {
 		distro_family='rpm'
 		echo "Detected Red Hat-based distribution"
 		echo "  $(cat /etc/redhat-release)"
+	elif [[ -f /etc/NIXOS ]]; then
+		distro_family='nix'
+		echo "Detected NixOS"
 	else
 		distro_family='unknown'
 		echo "Warning: Could not detect distribution family"
@@ -183,12 +186,13 @@ parse_arguments() {
 	case "$distro_family" in
 		debian) build_format='deb' ;;
 		rpm) build_format='rpm' ;;
+		nix) build_format='nix' ;;
 		*) build_format='appimage' ;;
 	esac
 
 	while (( $# > 0 )); do
 		case "$1" in
-			-b|--build|-c|--clean|-e|--exe|-r|--release-tag)
+			-b|--build|-c|--clean|-e|--exe|-r|--release-tag|-s|--source-dir)
 				if [[ -z ${2:-} || $2 == -* ]]; then
 					echo "Error: Argument for $1 is missing" >&2
 					exit 1
@@ -198,6 +202,7 @@ parse_arguments() {
 					-c|--clean) cleanup_action="$2" ;;
 					-e|--exe) local_exe_path="$2" ;;
 					-r|--release-tag) release_tag="$2" ;;
+					-s|--source-dir) project_root="$2" ;;
 				esac
 				shift 2
 				;;
@@ -206,11 +211,12 @@ parse_arguments() {
 				shift
 				;;
 			-h|--help)
-				echo "Usage: $0 [--build deb|rpm|appimage] [--clean yes|no] [--exe /path/to/installer.exe] [--release-tag TAG] [--test-flags]"
-				echo '  --build: Specify the build format (deb, rpm, or appimage).'
+				echo "Usage: $0 [--build deb|rpm|appimage|nix] [--clean yes|no] [--exe /path/to/installer.exe] [--source-dir /path] [--release-tag TAG] [--test-flags]"
+				echo '  --build: Specify the build format (deb, rpm, appimage, or nix).'
 				echo "           Default: auto-detected based on distro (current: $build_format)"
 				echo '  --clean: Specify whether to clean intermediate build files (yes or no). Default: yes'
 				echo '  --exe:   Use a local Claude installer exe instead of downloading'
+				echo '  --source-dir: Path to repo root for scripts/ and assets (default: cwd)'
 				echo '  --release-tag: Release tag (e.g., v1.3.2+claude1.1.799) to append wrapper version to package'
 				echo '  --test-flags: Parse flags, print results, and exit without building.'
 				exit 0
@@ -223,12 +229,16 @@ parse_arguments() {
 		esac
 	done
 
+	# Recalculate paths if --source-dir changed project_root
+	work_dir="$project_root/build"
+	app_staging_dir="$work_dir/electron-app"
+
 	# Validate arguments
 	build_format="${build_format,,}"
 	cleanup_action="${cleanup_action,,}"
 
-	if [[ $build_format != 'deb' && $build_format != 'rpm' && $build_format != 'appimage' ]]; then
-		echo "Invalid build format specified: '$build_format'. Must be 'deb', 'rpm', or 'appimage'." >&2
+	if [[ $build_format != 'deb' && $build_format != 'rpm' && $build_format != 'appimage' && $build_format != 'nix' ]]; then
+		echo "Invalid build format specified: '$build_format'. Must be 'deb', 'rpm', 'appimage', or 'nix'." >&2
 		exit 1
 	fi
 
@@ -1293,7 +1303,12 @@ copy_ssh_helpers() {
 	section_header 'SSH Helpers'
 
 	local ssh_src="$claude_extract_dir/lib/net45/resources/claude-ssh"
-	local ssh_dest="$electron_resources_dest/claude-ssh"
+	local ssh_dest
+	if [[ $build_format == 'nix' ]]; then
+		ssh_dest="$app_staging_dir/ssh-helpers/claude-ssh"
+	else
+		ssh_dest="$electron_resources_dest/claude-ssh"
+	fi
 	local binary_name="claude-ssh-linux-$architecture"
 
 	if [[ ! -d "$ssh_src" ]]; then
@@ -1320,6 +1335,12 @@ copy_ssh_helpers() {
 
 run_packaging() {
 	section_header 'Call Packaging Script'
+
+	if [[ $build_format == 'nix' ]]; then
+		echo 'Nix build mode - skipping packaging (Nix derivation handles installation)'
+		section_footer 'Call Packaging Script'
+		return 0
+	fi
 
 	local output_path=''
 	local script_name file_pattern pkg_file
@@ -1491,21 +1512,41 @@ main() {
 		exit 0
 	fi
 
-	check_dependencies
+	if [[ $build_format != 'nix' ]]; then
+		check_dependencies
+	fi
 	setup_work_directory
-	setup_nodejs
-	setup_electron_asar
+
+	if [[ $build_format != 'nix' ]]; then
+		setup_nodejs
+		setup_electron_asar
+	else
+		# Nix provides node and asar in PATH
+		asar_exec=$(command -v asar)
+		if [[ -z $asar_exec ]]; then
+			echo 'Error: asar not found in PATH (expected Nix to provide it)' >&2
+			exit 1
+		fi
+	fi
 
 	# Phase 2: Download and extract
+	if [[ $build_format == 'nix' && -z $local_exe_path ]]; then
+		echo 'Error: --exe is required when --build nix is specified' >&2
+		exit 1
+	fi
 	download_claude_installer
 
 	# Phase 3: Patch and prepare
 	patch_app_asar
-	install_node_pty
+	if [[ $build_format != 'nix' ]]; then
+		install_node_pty
+	fi
 	finalize_app_asar
-	stage_electron
+	if [[ $build_format != 'nix' ]]; then
+		stage_electron
+		copy_locale_files
+	fi
 	process_icons
-	copy_locale_files
 	copy_ssh_helpers
 
 	cd "$project_root" || exit 1
@@ -1517,7 +1558,9 @@ main() {
 	cleanup_build
 
 	echo 'Build process finished.'
-	print_next_steps
+	if [[ $build_format != 'nix' ]]; then
+		print_next_steps
+	fi
 }
 
 # Run main with all script arguments

--- a/build.sh
+++ b/build.sh
@@ -240,6 +240,15 @@ parse_arguments() {
 	build_format="${build_format,,}"
 	cleanup_action="${cleanup_action,,}"
 
+	if [[ ! -d $source_dir ]]; then
+		echo "Error: --source-dir path does not exist: $source_dir" >&2
+		exit 1
+	fi
+	if [[ -n $node_pty_dir && ! -d $node_pty_dir ]]; then
+		echo "Error: --node-pty-dir path does not exist: $node_pty_dir" >&2
+		exit 1
+	fi
+
 	if [[ $build_format != 'deb' && $build_format != 'rpm' && $build_format != 'appimage' && $build_format != 'nix' ]]; then
 		echo "Invalid build format specified: '$build_format'. Must be 'deb', 'rpm', 'appimage', or 'nix'." >&2
 		exit 1
@@ -1195,7 +1204,7 @@ finalize_app_asar() {
 	local pty_release_dir=''
 	if [[ -n $node_pty_dir && -d $node_pty_dir/build/Release ]]; then
 		pty_release_dir="$node_pty_dir/build/Release"
-	elif [[ -d $node_pty_build_dir/node_modules/node-pty/build/Release ]]; then
+	elif [[ -n $node_pty_build_dir && -d $node_pty_build_dir/node_modules/node-pty/build/Release ]]; then
 		pty_release_dir="$node_pty_build_dir/node_modules/node-pty/build/Release"
 	fi
 
@@ -1330,12 +1339,7 @@ copy_ssh_helpers() {
 	section_header 'SSH Helpers'
 
 	local ssh_src="$claude_extract_dir/lib/net45/resources/claude-ssh"
-	local ssh_dest
-	if [[ $build_format == 'nix' ]]; then
-		ssh_dest="$app_staging_dir/ssh-helpers/claude-ssh"
-	else
-		ssh_dest="$electron_resources_dest/claude-ssh"
-	fi
+	local ssh_dest="$electron_resources_dest/claude-ssh"
 	local binary_name="claude-ssh-linux-$architecture"
 
 	if [[ ! -d "$ssh_src" ]]; then
@@ -1572,9 +1576,9 @@ main() {
 		copy_locale_files
 	else
 		# Nix installPhase handles Electron staging and locale files.
-		# Set a tray icon destination so process_icons has somewhere to
-		# write them; the Nix installPhase picks them up from here.
-		electron_resources_dest="$app_staging_dir/tray-icons"
+		# Set a resources destination so process_icons and copy_ssh_helpers
+		# have somewhere to write; the Nix installPhase picks them up.
+		electron_resources_dest="$app_staging_dir/nix-resources"
 		mkdir -p "$electron_resources_dest" || exit 1
 	fi
 	process_icons

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,7 @@ cleanup_action='yes'
 perform_cleanup=false
 test_flags_mode=false
 local_exe_path=''
+node_pty_dir=''
 original_user=''
 original_home=''
 project_root=''
@@ -192,7 +193,7 @@ parse_arguments() {
 
 	while (( $# > 0 )); do
 		case "$1" in
-			-b|--build|-c|--clean|-e|--exe|-r|--release-tag|-s|--source-dir)
+			-b|--build|-c|--clean|-e|--exe|-r|--release-tag|-s|--source-dir|--node-pty-dir)
 				if [[ -z ${2:-} || $2 == -* ]]; then
 					echo "Error: Argument for $1 is missing" >&2
 					exit 1
@@ -203,6 +204,7 @@ parse_arguments() {
 					-e|--exe) local_exe_path="$2" ;;
 					-r|--release-tag) release_tag="$2" ;;
 					-s|--source-dir) source_dir="$2" ;;
+					--node-pty-dir) node_pty_dir="$2" ;;
 				esac
 				shift 2
 				;;
@@ -217,6 +219,7 @@ parse_arguments() {
 				echo '  --clean: Specify whether to clean intermediate build files (yes or no). Default: yes'
 				echo '  --exe:   Use a local Claude installer exe instead of downloading'
 				echo '  --source-dir: Path to repo root for scripts/ and assets (default: project root)'
+				echo '  --node-pty-dir: Path to pre-built node-pty package (skips npm install)'
 				echo '  --release-tag: Release tag (e.g., v1.3.2+claude1.1.799) to append wrapper version to package'
 				echo '  --test-flags: Parse flags, print results, and exit without building.'
 				exit 0

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@
 
 # Global variables (set by functions, used throughout)
 architecture=''
-distro_family=''  # debian, rpm, or unknown
+distro_family=''  # debian, rpm, nix, or unknown
 claude_download_url=''
 claude_exe_filename=''
 version=''
@@ -18,6 +18,7 @@ perform_cleanup=false
 test_flags_mode=false
 local_exe_path=''
 node_pty_dir=''
+source_dir=''
 original_user=''
 original_home=''
 project_root=''
@@ -1132,28 +1133,40 @@ COWORK_PATCH
 install_node_pty() {
 	section_header 'Installing node-pty for terminal support'
 
-	node_pty_build_dir="$work_dir/node-pty-build"
-	mkdir -p "$node_pty_build_dir" || exit 1
-	cd "$node_pty_build_dir" || exit 1
-	echo '{"name":"node-pty-build","version":"1.0.0","private":true}' > package.json
+	local pty_src_dir=''
 
-	echo 'Installing node-pty (this will compile native module for Linux)...'
-	if npm install node-pty 2>&1; then
-		echo 'node-pty installed successfully'
-
-		if [[ -d $node_pty_build_dir/node_modules/node-pty ]]; then
-			echo 'Copying node-pty JavaScript files into app.asar.contents...'
-			mkdir -p "$app_staging_dir/app.asar.contents/node_modules/node-pty" || exit 1
-			cp -r "$node_pty_build_dir/node_modules/node-pty/lib" \
-				"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
-			cp "$node_pty_build_dir/node_modules/node-pty/package.json" \
-				"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
-			echo 'node-pty JavaScript files copied'
-		else
-			echo 'node-pty installation directory not found'
-		fi
+	if [[ -n $node_pty_dir ]]; then
+		# Use pre-built node-pty (e.g. from Nix)
+		echo "Using pre-built node-pty from $node_pty_dir"
+		pty_src_dir="$node_pty_dir"
 	else
-		echo 'Failed to install node-pty - terminal features may not work'
+		# Build node-pty from npm
+		node_pty_build_dir="$work_dir/node-pty-build"
+		mkdir -p "$node_pty_build_dir" || exit 1
+		cd "$node_pty_build_dir" || exit 1
+		echo '{"name":"node-pty-build","version":"1.0.0","private":true}' > package.json
+
+		echo 'Installing node-pty (this compiles native module)...'
+		if npm install node-pty 2>&1; then
+			echo 'node-pty installed successfully'
+			pty_src_dir="$node_pty_build_dir/node_modules/node-pty"
+		else
+			echo 'Failed to install node-pty - terminal features may not work'
+		fi
+	fi
+
+	if [[ -n $pty_src_dir && -d $pty_src_dir ]]; then
+		echo 'Copying node-pty JavaScript files into app.asar.contents...'
+		mkdir -p "$app_staging_dir/app.asar.contents/node_modules/node-pty" || exit 1
+		cp -r "$pty_src_dir/lib" \
+			"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
+		cp "$pty_src_dir/package.json" \
+			"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
+		echo 'node-pty JavaScript files copied'
+	elif [[ -z $pty_src_dir ]]; then
+		echo 'node-pty source directory not set'
+	else
+		echo "node-pty directory not found: $pty_src_dir"
 	fi
 
 	cd "$app_staging_dir" || exit 1
@@ -1174,10 +1187,17 @@ finalize_app_asar() {
 	echo 'Cowork VM service daemon copied to unpacked'
 
 	# Copy node-pty native binaries
-	if [[ -d $node_pty_build_dir/node_modules/node-pty/build/Release ]]; then
+	local pty_release_dir=''
+	if [[ -n $node_pty_dir && -d $node_pty_dir/build/Release ]]; then
+		pty_release_dir="$node_pty_dir/build/Release"
+	elif [[ -d $node_pty_build_dir/node_modules/node-pty/build/Release ]]; then
+		pty_release_dir="$node_pty_build_dir/node_modules/node-pty/build/Release"
+	fi
+
+	if [[ -n $pty_release_dir ]]; then
 		echo 'Copying node-pty native binaries to unpacked directory...'
 		mkdir -p "$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release" || exit 1
-		cp -r "$node_pty_build_dir/node_modules/node-pty/build/Release/"* \
+		cp -r "$pty_release_dir/"* \
 			"$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release/" || exit 1
 		chmod +x "$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release/"* 2>/dev/null || true
 		echo 'node-pty native binaries copied'
@@ -1540,13 +1560,17 @@ main() {
 
 	# Phase 3: Patch and prepare
 	patch_app_asar
-	if [[ $build_format != 'nix' ]]; then
-		install_node_pty
-	fi
+	install_node_pty
 	finalize_app_asar
 	if [[ $build_format != 'nix' ]]; then
 		stage_electron
 		copy_locale_files
+	else
+		# Nix installPhase handles Electron staging and locale files.
+		# Set a tray icon destination so process_icons has somewhere to
+		# write them; the Nix installPhase picks them up from here.
+		electron_resources_dest="$app_staging_dir/tray-icons"
+		mkdir -p "$electron_resources_dest" || exit 1
 	fi
 	process_icons
 	copy_ssh_helpers

--- a/build.sh
+++ b/build.sh
@@ -626,6 +626,11 @@ console.log('Updated package.json: main entry and node-pty dependency');
 	mkdir -p app.asar.contents/resources/i18n || exit 1
 	cp "$claude_extract_dir/lib/net45/resources/"*-*.json app.asar.contents/resources/i18n/ || exit 1
 
+	# Copy tray icons into asar so both packaged (process.resourcesPath)
+	# and unpackaged (app.getAppPath()) code paths can find them
+	cp "$claude_extract_dir/lib/net45/resources/Tray"* app.asar.contents/resources/ 2>/dev/null || \
+		echo 'Warning: No tray icon files found for asar inclusion'
+
 	# Patch title bar detection
 	patch_titlebar_detection
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -22,6 +22,7 @@ cd claude-desktop-debian
 ./build.sh --build deb       # Debian/Ubuntu .deb package
 ./build.sh --build rpm       # Fedora/RHEL .rpm package
 ./build.sh --build appimage  # Distribution-agnostic AppImage
+./build.sh --build nix       # Nix derivation (patch only, used by flake)
 
 # Build with custom options
 ./build.sh --build deb --clean no  # Keep intermediate files
@@ -36,6 +37,7 @@ The build script automatically detects your distribution and selects the appropr
 |--------------|----------------|-----------------|
 | Debian, Ubuntu, Mint | `.deb` | apt |
 | Fedora, RHEL, CentOS | `.rpm` | dnf |
+| NixOS | `nix` | nix |
 | Arch Linux | `.AppImage` (via AUR) | yay/paru |
 | Other | `.AppImage` | - |
 
@@ -74,6 +76,23 @@ chmod +x ./claude-desktop-*.AppImage
 
 **Automatic Updates:** AppImages downloaded from GitHub releases include embedded update information and work seamlessly with Gear Lever for automatic updates. Locally-built AppImages can be manually configured for updates in Gear Lever.
 
+### For NixOS
+
+The repository includes a Nix flake. Build and install directly:
+
+```bash
+# Build the package
+nix build .#claude-desktop
+
+# Build the FHS-wrapped variant (for MCP server support)
+nix build .#claude-desktop-fhs
+
+# Run without installing
+nix run .#claude-desktop
+```
+
+For declarative NixOS installation, see the [README](../README.md#using-nix-flake-nixos).
+
 ## Technical Details
 
 ### How It Works
@@ -87,6 +106,7 @@ Claude Desktop is an Electron application distributed for Windows. This project:
    - **Debian package (.deb)**: For Debian, Ubuntu, and derivatives
    - **RPM package (.rpm)**: For Fedora, RHEL, CentOS, and derivatives
    - **AppImage**: Portable, distribution-agnostic executable
+   - **Nix package**: For NixOS, via the included flake
 
 ### Build Process
 
@@ -105,6 +125,7 @@ A GitHub Actions workflow runs daily to check for new Claude Desktop releases:
 2. Compares resolved URLs with those in `build.sh`
 3. If a new version is detected:
    - Updates `build.sh` with new download URLs
+   - Updates `nix/claude-desktop.nix` with new version, URLs, and SRI hashes
    - Creates a new release tag
    - Triggers automated builds for both architectures
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772082373,
+        "narHash": "sha256-wySf8a6hvuqgFdwvvzPPTARBCMLDz7WFAufGkllD1M4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "26eaeac4e409d7b5a6bf6f90a2a2dc223c78d915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "Claude Desktop for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+
+      perSystem = { pkgs, ... }: let
+        claude-desktop = pkgs.callPackage ./nix/claude-desktop.nix { };
+      in {
+        packages = {
+          inherit claude-desktop;
+          claude-desktop-fhs = pkgs.callPackage ./nix/fhs.nix {
+            inherit claude-desktop;
+          };
+          default = claude-desktop;
+        };
+      };
+
+      flake = {
+        overlays.default = final: prev: {
+          claude-desktop = final.callPackage ./nix/claude-desktop.nix { };
+          claude-desktop-fhs = final.callPackage ./nix/fhs.nix {
+            claude-desktop = final.claude-desktop;
+          };
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,12 +10,19 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = [ "x86_64-linux" "aarch64-linux" ];
 
-      perSystem = { pkgs, ... }: let
+      perSystem = { pkgs, system, ... }: let
         node-pty = pkgs.callPackage ./nix/node-pty.nix { };
         claude-desktop = pkgs.callPackage ./nix/claude-desktop.nix {
           inherit node-pty;
         };
       in {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          config.allowUnfreePredicate = pkg: builtins.elem (inputs.nixpkgs.lib.getName pkg) [
+            "claude-desktop"
+          ];
+        };
+
         packages = {
           inherit claude-desktop;
           claude-desktop-fhs = pkgs.callPackage ./nix/fhs.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,9 @@
       };
 
       flake = {
-        overlays.default = final: prev: let 
+        overlays.default = final: prev: let
           node-pty = final.callPackage ./nix/node-pty.nix { };
-        in  {
+        in {
           claude-desktop = final.callPackage ./nix/claude-desktop.nix {
             inherit node-pty;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,10 @@
       systems = [ "x86_64-linux" "aarch64-linux" ];
 
       perSystem = { pkgs, ... }: let
-        claude-desktop = pkgs.callPackage ./nix/claude-desktop.nix { };
+        node-pty = pkgs.callPackage ./nix/node-pty.nix { };
+        claude-desktop = pkgs.callPackage ./nix/claude-desktop.nix {
+          inherit node-pty;
+        };
       in {
         packages = {
           inherit claude-desktop;
@@ -23,8 +26,12 @@
       };
 
       flake = {
-        overlays.default = final: prev: {
-          claude-desktop = final.callPackage ./nix/claude-desktop.nix { };
+        overlays.default = final: prev: let 
+          node-pty = final.callPackage ./nix/node-pty.nix { };
+        in  {
+          claude-desktop = final.callPackage ./nix/claude-desktop.nix {
+            inherit node-pty;
+          };
           claude-desktop-fhs = final.callPackage ./nix/fhs.nix {
             claude-desktop = final.claude-desktop;
           };

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -105,7 +105,7 @@ stdenvNoCC.mkDerivation {
     done
 
     # Install tray icons into resources
-    for tray_icon in build/electron-app/node_modules/electron/dist/resources/Tray*; do
+    for tray_icon in build/electron-app/tray-icons/Tray*; do
       if [ -f "$tray_icon" ]; then
         cp "$tray_icon" $out/lib/claude-desktop/resources/
       fi

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -25,7 +25,7 @@ let
     };
     aarch64-linux = fetchurl {
       url = "https://downloads.claude.ai/releases/win32/arm64/${version}/Claude-d8e39139e1c50f5530ac3da3af80e689710c8ea1.exe";
-      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      hash = "sha256-PvKw6JpfLIhzbcrfogLltHNKyZfJtHOpOrGb+vcOkSM=";
     };
   };
 

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -111,6 +111,14 @@ stdenvNoCC.mkDerivation {
       fi
     done
 
+    # Install locale JSON files into resources (belt-and-suspenders;
+    # they're also packed inside app.asar at resources/i18n/)
+    for locale_json in build/claude-extract/lib/net45/resources/*-*.json; do
+      if [ -f "$locale_json" ]; then
+        cp "$locale_json" $out/lib/claude-desktop/resources/
+      fi
+    done
+
     # Install .desktop file
     mkdir -p $out/share/applications
     install -Dm644 ${desktopItem}/share/applications/* $out/share/applications/

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -17,22 +17,31 @@
 }:
 let
   pname = "claude-desktop";
-  version = "1.1.4328";
+  version = "1.1.4498";
 
   srcs = {
     x86_64-linux = fetchurl {
-      url = "https://downloads.claude.ai/releases/win32/x64/${version}/Claude-d8e39139e1c50f5530ac3da3af80e689710c8ea1.exe";
-      hash = "sha256-ngFY1mYwBIZLOYD5I7Lz/v5OexUKNe4MUHcq8VOejI4=";
+      url = "https://downloads.claude.ai/releases/win32/x64/${version}/Claude-24f7682cc400dec8d91fc28e444aa02743ab79dd.exe";
+      hash = "sha256-4Mp9vYwz9Pp+s1hoor7voJoahBq0AUncRneEZYewpd8=";
     };
     aarch64-linux = fetchurl {
-      url = "https://downloads.claude.ai/releases/win32/arm64/${version}/Claude-d8e39139e1c50f5530ac3da3af80e689710c8ea1.exe";
-      hash = "sha256-PvKw6JpfLIhzbcrfogLltHNKyZfJtHOpOrGb+vcOkSM=";
+      url = "https://downloads.claude.ai/releases/win32/arm64/${version}/Claude-24f7682cc400dec8d91fc28e444aa02743ab79dd.exe";
+      hash = "sha256-YOES86CgNfeJZFoDswZWvgAqG9xzqR2Qb+yu/imi1Ak=";
     };
   };
 
   src = srcs.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
 
-  sourceRoot = ./..;
+  sourceRoot = lib.cleanSourceWith {
+    src = ./..;
+    filter = path: type:
+      let rel = lib.removePrefix (toString ./.. + "/") path;
+      in !(lib.hasPrefix "build-reference" rel)
+      && !(lib.hasPrefix "logs" rel)
+      && !(lib.hasPrefix "test-build" rel)
+      && !(lib.hasPrefix "squashfs-root" rel)
+      && !(lib.hasPrefix "result" rel);
+  };
 
   desktopItem = makeDesktopItem {
     name = "claude-desktop";
@@ -105,11 +114,16 @@ stdenvNoCC.mkDerivation {
     done
 
     # Install tray icons into resources
-    for tray_icon in build/electron-app/tray-icons/Tray*; do
+    for tray_icon in build/electron-app/nix-resources/Tray*; do
       if [ -f "$tray_icon" ]; then
         cp "$tray_icon" $out/lib/claude-desktop/resources/
       fi
     done
+
+    # Install SSH helpers into resources
+    if [ -d build/electron-app/nix-resources/claude-ssh ]; then
+      cp -r build/electron-app/nix-resources/claude-ssh $out/lib/claude-desktop/resources/
+    fi
 
     # Install locale JSON files into resources (belt-and-suspenders;
     # they're also packed inside app.asar at resources/i18n/)

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -13,6 +13,7 @@
   python3,
   bash,
   getent,
+  node-pty,
 }:
 let
   pname = "claude-desktop";
@@ -78,6 +79,7 @@ stdenvNoCC.mkDerivation {
     bash ${sourceRoot}/build.sh \
       --exe "$(pwd)/Claude-Setup.exe" \
       --source-dir "${sourceRoot}" \
+      --node-pty-dir "${node-pty}/lib/node_modules/node-pty" \
       --build nix \
       --clean no
 
@@ -91,9 +93,6 @@ stdenvNoCC.mkDerivation {
     mkdir -p $out/lib/claude-desktop/resources
     cp build/electron-app/app.asar $out/lib/claude-desktop/resources/
     cp -r build/electron-app/app.asar.unpacked $out/lib/claude-desktop/resources/
-
-    # TODO: node-pty is not in nixpkgs; terminal features (Claude Code)
-    # require it. A future improvement could build it with buildNpmPackage.
 
     # Install icons
     for size in 16 24 32 48 64 256; do

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -8,11 +8,11 @@
   imagemagick,
   nodejs,
   nodePackages,
-  node-pty,
   makeDesktopItem,
   makeWrapper,
   python3,
   bash,
+  getent,
 }:
 let
   pname = "claude-desktop";
@@ -21,7 +21,7 @@ let
   srcs = {
     x86_64-linux = fetchurl {
       url = "https://downloads.claude.ai/releases/win32/x64/${version}/Claude-d8e39139e1c50f5530ac3da3af80e689710c8ea1.exe";
-      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+      hash = "sha256-ngFY1mYwBIZLOYD5I7Lz/v5OexUKNe4MUHcq8VOejI4=";
     };
     aarch64-linux = fetchurl {
       url = "https://downloads.claude.ai/releases/win32/arm64/${version}/Claude-d8e39139e1c50f5530ac3da3af80e689710c8ea1.exe";
@@ -58,6 +58,7 @@ stdenvNoCC.mkDerivation {
     makeWrapper
     bash
     python3
+    getent
   ];
 
   # The exe is not a standard archive — use manual unpack
@@ -91,10 +92,8 @@ stdenvNoCC.mkDerivation {
     cp build/electron-app/app.asar $out/lib/claude-desktop/resources/
     cp -r build/electron-app/app.asar.unpacked $out/lib/claude-desktop/resources/
 
-    # Install node-pty from nixpkgs (build.sh skips npm install in nix mode)
-    mkdir -p $out/lib/claude-desktop/resources/app.asar.unpacked/node_modules/node-pty/build/Release
-    cp -r ${node-pty}/lib/node_modules/node-pty/build/Release/* \
-      $out/lib/claude-desktop/resources/app.asar.unpacked/node_modules/node-pty/build/Release/
+    # TODO: node-pty is not in nixpkgs; terminal features (Claude Code)
+    # require it. A future improvement could build it with buildNpmPackage.
 
     # Install icons
     for size in 16 24 32 48 64 256; do

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -1,0 +1,138 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+  electron,
+  p7zip,
+  icoutils,
+  imagemagick,
+  nodejs,
+  nodePackages,
+  node-pty,
+  makeDesktopItem,
+  makeWrapper,
+  python3,
+  bash,
+}:
+let
+  pname = "claude-desktop";
+  version = "1.1.4328";
+
+  srcs = {
+    x86_64-linux = fetchurl {
+      url = "https://downloads.claude.ai/releases/win32/x64/${version}/Claude-d8e39139e1c50f5530ac3da3af80e689710c8ea1.exe";
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+    aarch64-linux = fetchurl {
+      url = "https://downloads.claude.ai/releases/win32/arm64/${version}/Claude-d8e39139e1c50f5530ac3da3af80e689710c8ea1.exe";
+      hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    };
+  };
+
+  src = srcs.${stdenvNoCC.hostPlatform.system} or (throw "Unsupported system: ${stdenvNoCC.hostPlatform.system}");
+
+  sourceRoot = ./..;
+
+  desktopItem = makeDesktopItem {
+    name = "claude-desktop";
+    exec = "claude-desktop %u";
+    icon = "claude-desktop";
+    type = "Application";
+    terminal = false;
+    desktopName = "Claude";
+    genericName = "Claude Desktop";
+    startupWMClass = "Claude";
+    categories = [ "Office" "Utility" ];
+    mimeTypes = [ "x-scheme-handler/claude" ];
+  };
+in
+stdenvNoCC.mkDerivation {
+  inherit pname version src;
+
+  nativeBuildInputs = [
+    p7zip
+    nodejs
+    nodePackages.asar
+    icoutils
+    imagemagick
+    makeWrapper
+    bash
+    python3
+  ];
+
+  # The exe is not a standard archive — use manual unpack
+  dontUnpack = true;
+
+  buildPhase = ''
+    runHook preBuild
+
+    export HOME=$TMPDIR
+
+    # Copy exe to a writable location for build.sh
+    cp $src Claude-Setup.exe
+
+    # Run build.sh in nix mode — it handles extraction, patching, icon
+    # extraction, and asar repacking. --source-dir points at the repo
+    # root so build.sh can find scripts/.
+    bash ${sourceRoot}/build.sh \
+      --exe "$(pwd)/Claude-Setup.exe" \
+      --source-dir "${sourceRoot}" \
+      --build nix \
+      --clean no
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    # Install app.asar and unpacked resources
+    mkdir -p $out/lib/claude-desktop/resources
+    cp build/electron-app/app.asar $out/lib/claude-desktop/resources/
+    cp -r build/electron-app/app.asar.unpacked $out/lib/claude-desktop/resources/
+
+    # Install node-pty from nixpkgs (build.sh skips npm install in nix mode)
+    mkdir -p $out/lib/claude-desktop/resources/app.asar.unpacked/node_modules/node-pty/build/Release
+    cp -r ${node-pty}/lib/node_modules/node-pty/build/Release/* \
+      $out/lib/claude-desktop/resources/app.asar.unpacked/node_modules/node-pty/build/Release/
+
+    # Install icons
+    for size in 16 24 32 48 64 256; do
+      icon_dir=$out/share/icons/hicolor/"$size"x"$size"/apps
+      mkdir -p "$icon_dir"
+      icon=$(find build/ -name "claude_*''${size}x''${size}x32.png" 2>/dev/null | head -1)
+      if [ -n "$icon" ]; then
+        install -Dm644 "$icon" "$icon_dir/claude-desktop.png"
+      fi
+    done
+
+    # Install tray icons into resources
+    for tray_icon in build/electron-app/node_modules/electron/dist/resources/Tray*; do
+      if [ -f "$tray_icon" ]; then
+        cp "$tray_icon" $out/lib/claude-desktop/resources/
+      fi
+    done
+
+    # Install .desktop file
+    mkdir -p $out/share/applications
+    install -Dm644 ${desktopItem}/share/applications/* $out/share/applications/
+
+    # Create wrapper script
+    mkdir -p $out/bin
+    makeWrapper ${electron}/bin/electron $out/bin/claude-desktop \
+      --add-flags "$out/lib/claude-desktop/resources/app.asar" \
+      --add-flags "--disable-features=CustomTitlebar" \
+      --add-flags "\''${NIXOS_OZONE_WL:+\''${WAYLAND_DISPLAY:+--ozone-platform-hint=auto --enable-features=WaylandWindowDecorations}}"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Claude Desktop for Linux";
+    homepage = "https://github.com/aaddrick/claude-desktop-debian";
+    license = licenses.unfree;
+    platforms = [ "x86_64-linux" "aarch64-linux" ];
+    sourceProvenance = with sourceTypes; [ binaryNativeCode ];
+    mainProgram = "claude-desktop";
+  };
+}

--- a/nix/fhs.nix
+++ b/nix/fhs.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildFHSEnv,
+  claude-desktop,
+  nodejs,
+  docker,
+  docker-compose,
+  openssl,
+  glibc,
+  uv,
+}:
+buildFHSEnv {
+  name = "claude-desktop";
+
+  targetPkgs = pkgs: [
+    claude-desktop
+    docker
+    docker-compose
+    glibc
+    nodejs
+    openssl
+    uv
+  ];
+
+  runScript = "${claude-desktop}/bin/claude-desktop";
+
+  extraInstallCommands = ''
+    # Copy desktop file
+    mkdir -p $out/share/applications
+    cp ${claude-desktop}/share/applications/* $out/share/applications/
+
+    # Copy icons
+    mkdir -p $out/share/icons
+    cp -r ${claude-desktop}/share/icons/* $out/share/icons/
+  '';
+
+  meta = claude-desktop.meta // {
+    description = "Claude Desktop for Linux (FHS environment for MCP servers)";
+  };
+}

--- a/nix/fhs.nix
+++ b/nix/fhs.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   buildFHSEnv,
   claude-desktop,
   nodejs,

--- a/nix/node-pty.nix
+++ b/nix/node-pty.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  python3,
+  node-gyp,
+}:
+buildNpmPackage rec {
+  pname = "node-pty";
+  version = "1.1.0";
+
+  src = fetchFromGitHub {
+    owner = "microsoft";
+    repo = "node-pty";
+    rev = "v${version}";
+    hash = "sha256-R0QxTw3tNJvW4aEi+GOF0iZhGgI42HTYJih90CdF18I=";
+  };
+
+  npmDepsHash = "sha256-HRv/4NO7CHkPs7ld8lx61n2cty0EhmWVrpH/1Vqh+Nk=";
+
+  # node-gyp needs python3 for native compilation
+  nativeBuildInputs = [ python3 node-gyp ];
+
+  # chokidar (dev dep) has an optional dep on fsevents (macOS-only).
+  # The Nix npm deps fetcher excludes it, so npm ci sees a lock/json
+  # mismatch. Strip the reference from the lock file to fix the sync.
+  postPatch = ''
+    sed -i '/"fsevents"/d' package-lock.json
+  '';
+
+  # Default npmBuildHook only runs "npm run build" (tsc), but we also
+  # need the native addon. Run both explicitly.
+  buildPhase = ''
+    runHook preBuild
+    npm run build
+    node-gyp rebuild
+    runHook postBuild
+  '';
+
+  # npmInstallHook doesn't copy the native addon — do it ourselves
+  postInstall = ''
+    cp -r build $out/lib/node_modules/node-pty/
+  '';
+
+  meta = with lib; {
+    description = "Fork pseudoterminals in Node.JS";
+    homepage = "https://github.com/microsoft/node-pty";
+    license = licenses.mit;
+    platforms = platforms.linux;
+  };
+}

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -1,8 +1,22 @@
 // Inject frame fix before main app loads
 const Module = require('module');
+const path = require('path');
 const originalRequire = Module.prototype.require;
 
 console.log('[Frame Fix] Wrapper loaded');
+
+// Fix process.resourcesPath to match the actual location of app.asar.
+// In Nix builds, electron is a separate store path so process.resourcesPath
+// points to the Electron package's resources dir, not where our tray icons
+// and app.asar.unpacked live. Deriving from __dirname (the asar root) gives
+// the correct path; for deb/AppImage builds the values already match.
+const derivedResourcesPath = path.dirname(__dirname);
+if (derivedResourcesPath !== process.resourcesPath) {
+  console.log('[Frame Fix] Correcting process.resourcesPath');
+  console.log('[Frame Fix]   Was:', process.resourcesPath);
+  console.log('[Frame Fix]   Now:', derivedResourcesPath);
+  process.resourcesPath = derivedResourcesPath;
+}
 
 // Menu bar visibility mode, controlled by CLAUDE_MENU_BAR env var:
 //   'auto'    - hidden by default, Alt toggles visibility (current default)


### PR DESCRIPTION
## Summary

- Adds a NixOS flake (`flake.nix` + `nix/`) that packages Claude Desktop for NixOS, replacing the unmaintained upstream flake (`claude-desktop-linux-flake`)
- Reuses all existing `build.sh` patches (frame-fix, tray icons, native stubs, cowork, Claude Code support) via a new `--build nix` mode, rather than reimplementing in Nix
- Includes a proper `node-pty` derivation so terminal features (Claude Code) work on NixOS
- Extends the version-check CI workflow to also update the Nix package (version, URLs, SRI hashes) automatically

### New files
- `flake.nix` — flake-parts based, outputs `claude-desktop` and `claude-desktop-fhs` for x86_64-linux and aarch64-linux
- `nix/claude-desktop.nix` — main derivation; fetches the Windows exe, delegates patching to `build.sh --build nix`, wraps Electron
- `nix/fhs.nix` — `buildFHSEnv` wrapper with nodejs, docker, openssl, uv for MCP server support
- `nix/node-pty.nix` — `buildNpmPackage` derivation for node-pty (terminal support for Claude Code)
- `flake.lock` — pins nixpkgs and flake-parts

### Modified files
- `build.sh` — adds `--build nix`, `--source-dir`, `--node-pty-dir` flags; NixOS detection; skips dependency checks, Node/Electron setup, staging, and packaging in nix mode
- `.github/workflows/check-claude-version.yml` — computes SRI hashes and updates `nix/claude-desktop.nix` alongside `build.sh`
- `README.md`, `CLAUDE.md`, `docs/BUILDING.md`, `.gitignore` — documentation and housekeeping

### Usage

```bash
# Basic install
nix profile install github:aaddrick/claude-desktop-debian

# With MCP server support
nix profile install github:aaddrick/claude-desktop-debian#claude-desktop-fhs

# NixOS config overlay
inputs.claude-desktop.url = "github:aaddrick/claude-desktop-debian";
```

## Test plan

- [x] `nix build .#claude-desktop` succeeds on x86_64-linux
- [x] `nix build .#claude-desktop-fhs` succeeds on x86_64-linux
- [x] Output contains app.asar, icons (16-256px), desktop file, electron wrapper, tray icons, locale JSONs
- [x] `./build.sh --build nix --test-flags` parses correctly
- [x] `./build.sh --test-flags` auto-detects NixOS and defaults to nix format
- [ ] `nix build .#claude-desktop` on aarch64-linux (hash computed but not build-tested)
- [x] Run the app from `result/bin/claude-desktop` and verify login/UI works
- [ ] Verify MCP servers work in the FHS variant

Closes #242.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
55% AI / 45% Human
Claude: Implementation plan, Nix derivations, build.sh modifications, CI workflow updates, documentation
Human: Design decisions, --source-dir flag, NixOS detection, systematic sandbox review, node-pty debugging guidance, hash computation, locale files fix