### PR TITLE
feat: add --doctor diagnostic command for troubleshooting

### DIFF
--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -74,6 +74,13 @@ appdir=$(dirname "$(readlink -f "$0")")
 # Source shared launcher library
 source "$appdir/usr/lib/claude-desktop/launcher-common.sh"
 
+# Handle --doctor flag before anything else
+if [[ "${1:-}" == '--doctor' ]]; then
+	electron_path="$appdir/usr/lib/node_modules/electron/dist/electron"
+	run_doctor "$electron_path"
+	exit $?
+fi
+
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -94,6 +94,13 @@ cat > "$install_dir/bin/claude-desktop" << EOF
 # Source shared launcher library
 source "/usr/lib/$package_name/launcher-common.sh"
 
+# Handle --doctor flag before anything else
+if [[ "\${1:-}" == '--doctor' ]]; then
+	local_electron_path="/usr/lib/$package_name/node_modules/electron/dist/electron"
+	run_doctor "\$local_electron_path"
+	exit \$?
+fi
+
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -123,3 +123,234 @@ setup_electron_env() {
 	export ELECTRON_FORCE_IS_PACKAGED=true
 	export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 }
+
+#===============================================================================
+# Doctor Diagnostics
+#===============================================================================
+
+# Color helpers (disabled when stdout is not a terminal)
+_doctor_colors() {
+	if [[ -t 1 ]]; then
+		_green='\033[0;32m'
+		_red='\033[0;31m'
+		_yellow='\033[0;33m'
+		_bold='\033[1m'
+		_reset='\033[0m'
+	else
+		_green='' _red='' _yellow='' _bold='' _reset=''
+	fi
+}
+
+_pass() { echo -e "${_green}[PASS]${_reset} $1"; }
+_fail() { echo -e "${_red}[FAIL]${_reset} $1"; _doctor_failures=$((_doctor_failures + 1)); }
+_warn() { echo -e "${_yellow}[WARN]${_reset} $1"; }
+_info() { echo -e "       $1"; }
+
+# Run all diagnostic checks and print results
+# Arguments: $1 = electron path (optional, for package-specific checks)
+run_doctor() {
+	local electron_path="${1:-}"
+	_doctor_failures=0
+	_doctor_colors
+
+	echo -e "${_bold}Claude Desktop Diagnostics${_reset}"
+	echo '================================'
+	echo
+
+	# -- Installed package version --
+	if command -v dpkg-query &>/dev/null; then
+		local pkg_version
+		pkg_version=$(dpkg-query -W -f='${Version}' claude-desktop 2>/dev/null) || true
+		if [[ -n $pkg_version ]]; then
+			_pass "Installed version: $pkg_version"
+		else
+			_warn 'claude-desktop package not found via dpkg (AppImage or manual install?)'
+		fi
+	fi
+
+	# -- Display server --
+	if [[ -n "${WAYLAND_DISPLAY:-}" ]]; then
+		_pass "Display server: Wayland (WAYLAND_DISPLAY=$WAYLAND_DISPLAY)"
+		local desktop="${XDG_CURRENT_DESKTOP:-unknown}"
+		_info "Desktop: $desktop"
+		if [[ "${CLAUDE_USE_WAYLAND:-}" == '1' ]]; then
+			_info 'Mode: native Wayland (CLAUDE_USE_WAYLAND=1)'
+		else
+			_info 'Mode: X11 via XWayland (default, for global hotkey support)'
+			_info 'Tip: Set CLAUDE_USE_WAYLAND=1 for native Wayland (disables global hotkeys)'
+		fi
+	elif [[ -n "${DISPLAY:-}" ]]; then
+		_pass "Display server: X11 (DISPLAY=$DISPLAY)"
+	else
+		_fail 'No display server detected (DISPLAY and WAYLAND_DISPLAY are unset)'
+		_info 'Fix: Run from within an X11 or Wayland session, not a TTY'
+	fi
+
+	# -- Electron binary --
+	if [[ -n $electron_path && -x $electron_path ]]; then
+		# Use --no-sandbox and strip ANSI/app output to get just the version
+		local electron_version
+		electron_version=$("$electron_path" --no-sandbox --version 2>/dev/null | head -1 | sed 's/\x1b\[[0-9;]*m//g') || true
+		# Only accept version strings that look like "vNN.NN.NN"
+		if [[ $electron_version =~ ^v[0-9]+\.[0-9]+ ]]; then
+			_pass "Electron: $electron_version ($electron_path)"
+		else
+			_pass "Electron: found at $electron_path"
+		fi
+	elif [[ -n $electron_path ]]; then
+		_fail "Electron binary not found at $electron_path"
+		_info 'Fix: Reinstall claude-desktop package'
+	elif command -v electron &>/dev/null; then
+		_pass "Electron: $(electron --version 2>/dev/null || echo 'found') (system)"
+	else
+		_fail 'Electron binary not found'
+		_info 'Fix: Reinstall claude-desktop package'
+	fi
+
+	# -- Chrome sandbox permissions --
+	local sandbox_paths=(
+		'/usr/lib/claude-desktop/node_modules/electron/dist/chrome-sandbox'
+	)
+	# Also check relative to the provided electron path
+	if [[ -n $electron_path ]]; then
+		local electron_dir
+		electron_dir=$(dirname "$electron_path")
+		sandbox_paths+=("$electron_dir/chrome-sandbox")
+	fi
+	local sandbox_checked=false
+	for sandbox_path in "${sandbox_paths[@]}"; do
+		if [[ -f $sandbox_path ]]; then
+			sandbox_checked=true
+			local sandbox_perms sandbox_owner
+			sandbox_perms=$(stat -c '%a' "$sandbox_path" 2>/dev/null) || true
+			sandbox_owner=$(stat -c '%U' "$sandbox_path" 2>/dev/null) || true
+			if [[ $sandbox_perms == '4755' && $sandbox_owner == 'root' ]]; then
+				_pass "Chrome sandbox: permissions OK ($sandbox_path)"
+			else
+				_fail "Chrome sandbox: incorrect permissions (${sandbox_perms:-?}, owner: ${sandbox_owner:-?})"
+				_info "Fix: sudo chown root:root $sandbox_path && sudo chmod 4755 $sandbox_path"
+			fi
+			break
+		fi
+	done
+	if [[ $sandbox_checked == false ]]; then
+		_warn 'Chrome sandbox binary not found (expected for AppImage, may cause issues for deb)'
+	fi
+
+	# -- SingletonLock --
+	local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/Claude"
+	local lock_file="$config_dir/SingletonLock"
+	if [[ -L $lock_file ]]; then
+		local lock_target lock_pid
+		lock_target="$(readlink "$lock_file" 2>/dev/null)" || true
+		lock_pid="${lock_target##*-}"
+		if [[ $lock_pid =~ ^[0-9]+$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
+			_pass "SingletonLock: held by running process (PID $lock_pid)"
+		else
+			_warn "SingletonLock: stale lock found (PID $lock_pid is not running)"
+			_info "Fix: rm '$lock_file'"
+		fi
+	else
+		_pass 'SingletonLock: no lock file (OK)'
+	fi
+
+	# -- MCP config --
+	local mcp_config="$config_dir/claude_desktop_config.json"
+	if [[ -f $mcp_config ]]; then
+		if command -v python3 &>/dev/null; then
+			if python3 -c "import json; json.load(open('$mcp_config'))" 2>/dev/null; then
+				_pass "MCP config: valid JSON ($mcp_config)"
+				# Check if any MCP servers are configured
+				local server_count
+				server_count=$(python3 -c "
+import json
+with open('$mcp_config') as f:
+    cfg = json.load(f)
+servers = cfg.get('mcpServers', {})
+print(len(servers))
+" 2>/dev/null) || server_count='0'
+				_info "MCP servers configured: $server_count"
+			else
+				_fail "MCP config: invalid JSON"
+				_info "Fix: Check $mcp_config for syntax errors"
+				_info "Tip: python3 -c \"import json; json.load(open('$mcp_config'))\" to see the error"
+			fi
+		elif command -v node &>/dev/null; then
+			if node -e "JSON.parse(require('fs').readFileSync('$mcp_config','utf8'))" 2>/dev/null; then
+				_pass "MCP config: valid JSON ($mcp_config)"
+			else
+				_fail "MCP config: invalid JSON"
+				_info "Fix: Check $mcp_config for syntax errors"
+			fi
+		else
+			_warn "MCP config: exists but cannot validate (no python3 or node available)"
+		fi
+	else
+		_info "MCP config: not found at $mcp_config (OK if not using MCP)"
+	fi
+
+	# -- Node.js (needed by MCP servers) --
+	if command -v node &>/dev/null; then
+		local node_version
+		node_version=$(node --version 2>/dev/null) || true
+		local node_major="${node_version#v}"
+		node_major="${node_major%%.*}"
+		if [[ $node_major -ge 20 ]]; then
+			_pass "Node.js: $node_version"
+		elif [[ $node_major -ge 1 ]]; then
+			_warn "Node.js: $node_version (v20+ recommended for MCP servers)"
+			_info 'Fix: Update Node.js to v20 or later'
+		fi
+		_info "Path: $(command -v node)"
+	else
+		_warn 'Node.js: not found (required for MCP servers)'
+		_info 'Fix: Install Node.js v20+ from https://nodejs.org'
+	fi
+
+	# -- Desktop integration --
+	local desktop_file='/usr/share/applications/claude-desktop.desktop'
+	if [[ -f $desktop_file ]]; then
+		_pass "Desktop entry: $desktop_file"
+	else
+		_warn 'Desktop entry not found (expected for AppImage installs)'
+	fi
+
+	# -- Disk space --
+	local config_disk_avail
+	config_disk_avail=$(df -BM --output=avail "$config_dir" 2>/dev/null | tail -1 | tr -d ' M') || true
+	if [[ -n $config_disk_avail ]]; then
+		if [[ $config_disk_avail -lt 100 ]]; then
+			_fail "Disk space: ${config_disk_avail}MB free on config partition"
+			_info 'Fix: Free up disk space'
+		elif [[ $config_disk_avail -lt 500 ]]; then
+			_warn "Disk space: ${config_disk_avail}MB free on config partition (low)"
+		else
+			_pass "Disk space: ${config_disk_avail}MB free"
+		fi
+	fi
+
+	# -- Log file --
+	local log_path="${XDG_CACHE_HOME:-$HOME/.cache}/claude-desktop-debian/launcher.log"
+	if [[ -f $log_path ]]; then
+		local log_size
+		log_size=$(stat -c '%s' "$log_path" 2>/dev/null) || log_size=0
+		local log_size_kb=$((log_size / 1024))
+		if [[ $log_size_kb -gt 10240 ]]; then
+			_warn "Log file: ${log_size_kb}KB (consider clearing: rm '$log_path')"
+		else
+			_pass "Log file: ${log_size_kb}KB ($log_path)"
+		fi
+	else
+		_info 'Log file: not yet created (OK)'
+	fi
+
+	# -- Summary --
+	echo
+	if [[ $_doctor_failures -eq 0 ]]; then
+		echo -e "${_green}${_bold}All checks passed.${_reset}"
+	else
+		echo -e "${_red}${_bold}${_doctor_failures} check(s) failed.${_reset} See above for fixes."
+	fi
+
+	return "$_doctor_failures"
+}


### PR DESCRIPTION
## Summary

- Adds a `claude-desktop --doctor` flag that runs 10 diagnostic checks and prints pass/fail results with suggested fixes
- Implemented in `launcher-common.sh` so it works for both deb and AppImage installs
- Helps users self-diagnose common issues instead of opening GitHub issues

## Checks performed

1. Installed package version
2. Display server (Wayland/X11) and mode detection
3. Electron binary existence
4. Chrome sandbox permissions (4755/root)
5. Stale SingletonLock detection
6. MCP config JSON validity and server count
7. Node.js version (v20+ recommended for MCP)
8. Desktop entry file
9. Disk space
10. Log file size

## Related issues

Helps reduce support burden from recurring issues: #247, #261, #263, #264, #216

## Example output

```
Claude Desktop Diagnostics
================================

[PASS] Installed version: 1.1.4498-1.3.15
[PASS] Display server: Wayland (WAYLAND_DISPLAY=wayland-0)
[PASS] Electron: found at /usr/lib/claude-desktop/node_modules/electron/dist/electron
[PASS] Chrome sandbox: permissions OK
[PASS] SingletonLock: no lock file (OK)
[PASS] MCP config: valid JSON
[PASS] Node.js: v22.14.0
[PASS] Desktop entry: /usr/share/applications/claude-desktop.desktop
[PASS] Disk space: 632284MB free
[PASS] Log file: 1352KB

All checks passed.
```

## Test plan

- [ ] Run `source scripts/launcher-common.sh && run_doctor "/usr/lib/claude-desktop/node_modules/electron/dist/electron"` to verify output
- [ ] Build deb package and test `claude-desktop --doctor`
- [ ] Build AppImage and test `./claude-desktop.AppImage --doctor`
- [ ] Verify normal `claude-desktop` launch is unaffected