### PR TITLE
feat: include SSH helper binaries in Linux packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1296,26 +1296,15 @@ copy_ssh_helpers() {
 	local ssh_dest="$electron_resources_dest/claude-ssh"
 	local binary_name="claude-ssh-linux-$architecture"
 
-	if [[ ! -d $ssh_src ]]; then
+	if [[ ! -d "$ssh_src" ]]; then
 		echo "Warning: SSH helpers not found at $ssh_src"
 		section_footer 'SSH Helpers'
 		return
 	fi
 
 	mkdir -p "$ssh_dest" || exit 1
-
 	cp "$ssh_src/version.txt" "$ssh_dest/" || exit 1
 	cp "$ssh_src/$binary_name" "$ssh_dest/" || exit 1
-
-	if [[ ! -f "$ssh_dest/version.txt" ]]; then
-		echo "Failed to copy version.txt" >&2
-		exit 1
-	fi
-	if [[ ! -f "$ssh_dest/$binary_name" ]]; then
-		echo "Failed to copy $binary_name" >&2
-		exit 1
-	fi
-
 	chmod +x "$ssh_dest/$binary_name"
 
 	echo "Copied SSH helper files:"


### PR DESCRIPTION
## Summary

- Adds `copy_ssh_helpers()` to `build.sh` to copy the upstream SSH helper binary into the Electron resources directory during build
- Only copies the architecture-matching Linux binary + `version.txt`, skipping macOS binaries and the other arch (~12-18MB savings per package)
- Gracefully skips if upstream removes the `claude-ssh/` directory in the future

Fixes #249

## Context

The upstream Claude Desktop (v1.1.4498+) ships SSH helper binaries at `resources/claude-ssh/` that enable SSH remote mode. These binaries are SFTP-uploaded to the remote host and executed there — they are never run locally. Source analysis confirmed no JavaScript patching is needed for Linux; the only requirement is placing the binaries in the Electron resources directory.

## What changed

**`build.sh`** (+37 lines):
- New `copy_ssh_helpers()` function that copies `version.txt` and `claude-ssh-linux-{amd64,arm64}` (matching build arch) from the extracted upstream installer to `$electron_resources_dest/claude-ssh/`
- Called in `main()` after `copy_locale_files`

## Test plan

- [ ] Build locally with `./build.sh --build appimage --clean no`
- [ ] Verify `claude-ssh/` directory exists in built package resources
- [ ] Test SSH mode connects to a remote Linux host

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
90% AI / 10% Human
Claude: PR review of #249, upstream binary analysis, source code investigation, implementation, and PR creation
Human: Direction, review, and approval