### PR TITLE
style: wrap --doctor output lines to fit 80-column limit

### DIFF
--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -219,13 +219,13 @@ _cowork_pkg_hint() {
 	printf '%s' "$pkg_cmd $pkg"
 }
 
-_pass() { echo -e "${_green}[PASS]${_reset} $1"; }
+_pass() { echo -e "${_green}[PASS]${_reset} $*"; }
 _fail() {
-	echo -e "${_red}[FAIL]${_reset} $1"
+	echo -e "${_red}[FAIL]${_reset} $*"
 	_doctor_failures=$((_doctor_failures + 1))
 }
-_warn() { echo -e "${_yellow}[WARN]${_reset} $1"; }
-_info() { echo -e "       $1"; }
+_warn() { echo -e "${_yellow}[WARN]${_reset} $*"; }
+_info() { echo -e "       $*"; }
 
 # Run all diagnostic checks and print results
 # Arguments: $1 = electron path (optional, for package-specific checks)
@@ -265,7 +265,8 @@ run_doctor() {
 	elif [[ -n "${DISPLAY:-}" ]]; then
 		_pass "Display server: X11 (DISPLAY=$DISPLAY)"
 	else
-		_fail 'No display server detected (DISPLAY and WAYLAND_DISPLAY are unset)'
+		_fail "No display server detected" \
+			"(DISPLAY and WAYLAND_DISPLAY are unset)"
 		_info 'Fix: Run from within an X11 or Wayland session, not a TTY'
 	fi
 
@@ -280,12 +281,14 @@ run_doctor() {
 		esac
 		case "$resolved_mode" in
 			auto|visible|hidden)
-				_pass "Menu bar mode: $resolved_mode (CLAUDE_MENU_BAR=$menu_bar_mode)"
+				_pass "Menu bar mode: $resolved_mode" \
+					"(CLAUDE_MENU_BAR=$menu_bar_mode)"
 				;;
 			*)
 				_warn "Unknown CLAUDE_MENU_BAR: '$menu_bar_mode'"
 				_info 'Will fall back to auto'
-				_info 'Valid values: auto, visible, hidden (or 0/1/true/false/yes/no/on/off)'
+				_info 'Valid values: auto, visible, hidden' \
+					'(or 0/1/true/false/yes/no/on/off)'
 				;;
 		esac
 	else
@@ -311,7 +314,9 @@ run_doctor() {
 		_fail "Electron binary not found at $electron_path"
 		_info 'Fix: Reinstall claude-desktop package'
 	elif command -v electron &>/dev/null; then
-		_pass "Electron: $(electron --version 2>/dev/null || echo 'found') (system)"
+		local sys_electron_ver
+		sys_electron_ver=$(electron --version 2>/dev/null) || true
+		_pass "Electron: ${sys_electron_ver:-found} (system)"
 	else
 		_fail 'Electron binary not found'
 		_info 'Fix: Reinstall claude-desktop package'
@@ -359,7 +364,8 @@ run_doctor() {
 		if [[ $lock_pid =~ ^[0-9]+$ ]] && kill -0 "$lock_pid" 2>/dev/null; then
 			_pass "SingletonLock: held by running process (PID $lock_pid)"
 		else
-			_warn "SingletonLock: stale lock found (PID $lock_pid is not running)"
+			_warn "SingletonLock: stale lock found" \
+				"(PID $lock_pid is not running)"
 			_info "Fix: rm '$lock_file'"
 		fi
 	else
@@ -399,7 +405,8 @@ print(len(servers))
 				_info "Fix: Check $mcp_config for syntax errors"
 			fi
 		else
-			_warn "MCP config: exists but cannot validate (no python3 or node available)"
+			_warn "MCP config: exists but cannot validate" \
+				"(no python3 or node available)"
 		fi
 	else
 		_info "MCP config: not found at $mcp_config (OK if not using MCP)"
@@ -440,7 +447,8 @@ print(len(servers))
 			_fail "Disk space: ${config_disk_avail}MB free on config partition"
 			_info 'Fix: Free up disk space'
 		elif ((config_disk_avail < 500)); then
-			_warn "Disk space: ${config_disk_avail}MB free on config partition (low)"
+			_warn "Disk space: ${config_disk_avail}MB free" \
+				"on config partition (low)"
 		else
 			_pass "Disk space: ${config_disk_avail}MB free"
 		fi
@@ -534,7 +542,8 @@ print(len(servers))
 		log_size=$(stat -c '%s' "$log_path" 2>/dev/null) || log_size=0
 		local log_size_kb=$((log_size / 1024))
 		if ((log_size_kb > 10240)); then
-			_warn "Log file: ${log_size_kb}KB (consider clearing: rm '$log_path')"
+			_warn "Log file: ${log_size_kb}KB" \
+				"(consider clearing: rm '$log_path')"
 		else
 			_pass "Log file: ${log_size_kb}KB ($log_path)"
 		fi


### PR DESCRIPTION
## Summary

Addresses the line-length feedback from #267 review.

- Changed `_pass`/`_fail`/`_warn`/`_info` helpers to use `$*` instead of `$1` so messages can be split across multiple arguments
- Wrapped 7 lines in `run_doctor()` that exceeded 80 characters when tabs are expanded to 4 spaces
- Extracted inline `electron --version` subshell into a variable for readability

## Test plan

- [ ] Run `claude-desktop --doctor` and verify output is unchanged
- [ ] Pipe output through `cat` to confirm non-TTY mode still works
- [ ] Verify no lines in the doctor function exceed 80 columns