### PR TITLE
fix: Quick Entry uses last-selected model instead of defaulting to Sonnet

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -885,11 +885,22 @@ patch_quick_entry_model() {
 	echo 'Patching Quick Entry to use last-selected model...'
 	local index_js='app.asar.contents/.vite/build/index.js'
 
+	if grep -q '__quickEntryModelFixApplied' "$index_js"; then
+		echo '  Quick Entry model fix already applied'
+		return
+	fi
+
 	# Quick Entry creates conversations without a model field, causing
 	# the server to default to Sonnet regardless of user preference.
 	# This patch injects a fetch interceptor that reads the user's
 	# last-selected model from localStorage ("sticky-model-selector")
 	# and adds it to the POST /chat_conversations request body.
+	#
+	# Note: "sticky-model-selector" is a localStorage key set by the
+	# claude.ai web frontend, not by the asar code. Anthropic could
+	# rename it or change its format at any time. The code degrades
+	# gracefully (falls back to server default) if the key is missing
+	# or its format changes.
 	#
 	# Anchor: the dom-ready handler on the mainView webContents,
 	# identified by the unique pattern of calling a function then
@@ -924,6 +935,8 @@ if (!nearby.includes('findInPage')) {
 const funcCall = match[2];
 const patchJs = [
 	'(function(){',
+	'if(window.__quickEntryModelFixApplied)return;',
+	'window.__quickEntryModelFixApplied=true;',
 	'const _f=window.fetch;',
 	'window.fetch=async function(u,o){',
 	'if(typeof u==="string"',
@@ -939,11 +952,13 @@ const patchJs = [
 	'const m=typeof p==="string"?p:p.model||p.value||null;',
 	'if(m){b.model=m;',
 	'b.include_conversation_preferences=true;',
-	'o.body=JSON.stringify(b);',
+	'o=Object.assign({},o,{body:JSON.stringify(b)});',
 	'console.log("[QuickEntryModelFix] Using model:",m)',
 	'}}catch(pe){b.model=s;',
 	'b.include_conversation_preferences=true;',
-	'o.body=JSON.stringify(b)}}}}catch(e){}}',
+	'o=Object.assign({},o,{body:JSON.stringify(b)});',
+	'console.warn("[QuickEntryModelFix] parse error, using raw:",pe)',
+	'}}}}catch(e){console.warn("[QuickEntryModelFix]",e)}}',
 	'return _f.call(this,u,o)}})()',
 ].join('');
 
@@ -960,7 +975,7 @@ const finalReplacement =
 	fullRef +
 	'.webContents.executeJavaScript(`' +
 	patchJs +
-	'`).catch(function(){})}';
+	'`).catch(function(e){console.warn("[QuickEntryModelFix] inject failed:",e)})}';
 
 code = code.replace(match[0], finalReplacement);
 


### PR DESCRIPTION
## Summary

- Quick Entry (Ctrl+Alt+Space) creates conversations without a `model` field in the `POST /chat_conversations` request, causing the server to default to Sonnet regardless of the user's last-selected model
- This patch adds a fetch interceptor on the mainView's `dom-ready` event that reads the user's model preference from `localStorage` (`sticky-model-selector`) and injects it into conversation-creation requests that are missing one
- The fix is version-agnostic: uses regex anchoring on the `dom-ready` handler near the `findInPage` preload setup, and extracts variable names dynamically

### Root cause analysis

Captured HAR files from both the web UI and Quick Entry to compare:

**Web UI** (works correctly):
```json
POST /chat_conversations
{"uuid": "...", "name": "", "model": "claude-opus-4-6", "include_conversation_preferences": true}
```

**Quick Entry** (broken):
```json
POST /chat_conversations
{"uuid": "...", "name": ""}
```

The Electron app's Quick Entry IPC payload schema (`{text, chatId?, images}`) has no model field. The claude.ai frontend handler for `onQuickEntrySubmit` creates the conversation without passing the user's selected model, so the server defaults to Sonnet.

### How the fix works

1. On `dom-ready`, injects a `fetch` monkey-patch into the webview via `executeJavaScript`
2. The interceptor catches `POST /chat_conversations` requests (excluding `/completion`, `/title`, `/tree`)
3. If the request body has no `model` field, reads `sticky-model-selector` from `localStorage` (where claude.ai stores the user's last-selected model)
4. Injects the model and `include_conversation_preferences: true` into the request body

### Related issues

Fixes #108

## Test plan

- [x] `node --check` on patched index.js — syntax clean
- [x] Tested patch script against extracted app.asar — applies cleanly
- [x] Built patched AppImage and tested Quick Entry — HAR confirms `"model": "claude-opus-4-6"` present in conversation creation
- [x] Verified model follows user selection (switching model in main chat changes what Quick Entry uses)
- [x] Build via `./build.sh --build appimage --clean no`

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
80% AI / 20% Human
Claude: Root cause analysis, HAR inspection, patch implementation, testing
Human: Bug discovery, HAR capture, testing direction, review