### PR TITLE
add doctor processing to rpm launch

### DIFF
--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -79,6 +79,13 @@ cat > "$staging_dir/claude-desktop" << EOF
 # Source shared launcher library
 source "/usr/lib/$package_name/launcher-common.sh"
 
+# Handle --doctor flag before anything else
+if [[ "\${1:-}" == '--doctor' ]]; then
+	local_electron_path="/usr/lib/$package_name/node_modules/electron/dist/electron"
+	run_doctor "\$local_electron_path"
+	exit
+fi
+
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env


### PR DESCRIPTION
Adds missing doctor flag processing to rpm launch command.

This work corrects rpm behavior related to #282