### PR TITLE
fix: accept boolean aliases for CLAUDE_MENU_BAR env var

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -14,7 +14,7 @@ Model Context Protocol settings are stored in:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CLAUDE_USE_WAYLAND` | unset | Set to `1` to use native Wayland instead of XWayland. Note: Global hotkeys won't work in native Wayland mode. |
-| `CLAUDE_MENU_BAR` | unset (`auto`) | Controls menu bar behavior: `auto` (hidden, Alt toggles), `visible` (always shown), `hidden` (always hidden, Alt disabled). See [Menu Bar](#menu-bar) below. |
+| `CLAUDE_MENU_BAR` | unset (`auto`) | Controls menu bar behavior: `auto` (hidden, Alt toggles), `visible` / `1` (always shown), `hidden` / `0` (always hidden, Alt disabled). See [Menu Bar](#menu-bar) below. |
 
 ### Wayland Support
 
@@ -37,8 +37,8 @@ By default, the menu bar is hidden but can be toggled with the Alt key (`auto` m
 | Value | Menu visible | Alt toggles | Use case |
 |-------|-------------|-------------|----------|
 | unset / `auto` | No | Yes | Default — hidden, Alt toggles |
-| `visible` | Yes | No | Stable layout, no shift on Alt |
-| `hidden` | No | No | Menu fully disabled, Alt free |
+| `visible` / `1` / `true` / `on` | Yes | No | Stable layout, no shift on Alt |
+| `hidden` / `0` / `false` / `off` | No | No | Menu fully disabled, Alt free |
 
 ```bash
 # Always show the menu bar (no layout shift on Alt)

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -22,11 +22,19 @@ if (derivedResourcesPath !== process.resourcesPath) {
 //   'auto'    - hidden by default, Alt toggles visibility (current default)
 //   'visible' - always visible, Alt does not toggle (stable layout)
 //   'hidden'  - always hidden, Alt does not toggle
+// Also accepts boolean-style aliases: 1/true/yes/on -> visible, 0/false/no/off -> hidden
 const VALID_MENU_BAR_MODES = ['auto', 'visible', 'hidden'];
+const MENU_BAR_ALIASES = {
+  '1': 'visible', 'true': 'visible', 'yes': 'visible', 'on': 'visible',
+  '0': 'hidden', 'false': 'hidden', 'no': 'hidden', 'off': 'hidden',
+};
 const rawMenuBarMode = (process.env.CLAUDE_MENU_BAR || 'auto').toLowerCase();
-const MENU_BAR_MODE = VALID_MENU_BAR_MODES.includes(rawMenuBarMode) ? rawMenuBarMode : 'auto';
-if (rawMenuBarMode !== MENU_BAR_MODE) {
-  console.warn(`[Frame Fix] Unknown CLAUDE_MENU_BAR value '${process.env.CLAUDE_MENU_BAR}', falling back to 'auto'. Valid: ${VALID_MENU_BAR_MODES.join(', ')}`);
+const resolvedMode = MENU_BAR_ALIASES[rawMenuBarMode] || rawMenuBarMode;
+const MENU_BAR_MODE = VALID_MENU_BAR_MODES.includes(resolvedMode) ? resolvedMode : 'auto';
+if (resolvedMode !== rawMenuBarMode) {
+  console.log(`[Frame Fix] CLAUDE_MENU_BAR '${rawMenuBarMode}' resolved to '${resolvedMode}'`);
+} else if (resolvedMode !== MENU_BAR_MODE) {
+  console.warn(`[Frame Fix] Unknown CLAUDE_MENU_BAR value '${process.env.CLAUDE_MENU_BAR}', falling back to 'auto'. Valid: ${VALID_MENU_BAR_MODES.join(', ')}, or 0/1/true/false/yes/no/on/off`);
 }
 console.log(`[Frame Fix] Menu bar mode: ${MENU_BAR_MODE}`);
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -271,14 +271,20 @@ run_doctor() {
 	# -- Menu bar mode --
 	local menu_bar_mode="${CLAUDE_MENU_BAR:-}"
 	if [[ -n $menu_bar_mode ]]; then
-		case "${menu_bar_mode,,}" in
+		local resolved_mode="${menu_bar_mode,,}"
+		# Resolve boolean-style aliases
+		case "$resolved_mode" in
+			1|true|yes|on) resolved_mode='visible' ;;
+			0|false|no|off) resolved_mode='hidden' ;;
+		esac
+		case "$resolved_mode" in
 			auto|visible|hidden)
-				_pass "Menu bar mode: ${menu_bar_mode,,} (CLAUDE_MENU_BAR=$menu_bar_mode)"
+				_pass "Menu bar mode: $resolved_mode (CLAUDE_MENU_BAR=$menu_bar_mode)"
 				;;
 			*)
 				_warn "Unknown CLAUDE_MENU_BAR: '$menu_bar_mode'"
 				_info 'Will fall back to auto'
-				_info "Valid values: auto, visible, hidden"
+				_info "Valid values: auto, visible, hidden (or 0/1/true/false/yes/no/on/off)"
 				;;
 		esac
 	else


### PR DESCRIPTION
## Summary

- Add boolean-style aliases (`0`/`1`/`true`/`false`/`yes`/`no`/`on`/`off`) for `CLAUDE_MENU_BAR`
- `0` → `hidden`, `1` → `visible`, matching `CLAUDE_USE_WAYLAND=1` convention
- Update `--doctor` diagnostics to resolve aliases before validation
- Document aliases in `CONFIGURATION.md`

Fixes #298

## Why

`CLAUDE_USE_WAYLAND=1` establishes a boolean env var convention. Users naturally
try `CLAUDE_MENU_BAR=0` which was silently ignored after 07c1388 added strict
validation. Before that commit, `0` accidentally worked as `hidden`.

## Test plan

- [x] Unit test: 14/14 alias resolution cases pass
- [x] AppImage build: `CLAUDE_MENU_BAR=0` resolves to `hidden`, menu bar stays hidden, Alt disabled
- [x] Log confirms: `[Frame Fix] CLAUDE_MENU_BAR '0' resolved to 'hidden'`
- [x] Named values (`auto`/`visible`/`hidden`) still work as before
- [x] Invalid values still fall back to `auto` with warning
- [x] `--doctor` shows resolved mode correctly

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
60% AI / 40% Human
Claude: upstream analysis, code changes, automated testing
Human: bug report, root cause clue (startup script), CLAUDE_USE_WAYLAND convention insight, issue framing, manual testing, review