### PR TITLE
fix: complete cowork KVM backend (bundlePath, hardening)

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -908,7 +908,9 @@ class KvmBackend extends BackendBase {
         // Ensure VM directory exists
         fs.mkdirSync(VM_BASE_DIR, { recursive: true });
 
-        // Convert VHDX to qcow2 if needed
+        // Convert VHDX to qcow2 if present in VM_BASE_DIR (manual
+        // placement). The main conversion happens in startVM() using
+        // the app-provided bundlePath.
         const vhdxPath = path.join(VM_BASE_DIR, 'rootfs.vhdx');
         const qcow2Path = path.join(VM_BASE_DIR, 'rootfs.qcow2');
         if (fs.existsSync(vhdxPath) && !fs.existsSync(qcow2Path)) {
@@ -950,7 +952,7 @@ class KvmBackend extends BackendBase {
             return {};
         }
 
-        this.bundlePath = params.bundlePath;
+        this.bundlePath = params.bundlePath || VM_BASE_DIR;
         const memoryGB = params.memoryGB ||
             Math.ceil(this.config.memoryMB / 1024);
         const cpuCount = this.config.cpuCount;
@@ -960,6 +962,38 @@ class KvmBackend extends BackendBase {
             step: 'prepare_session', status: 'running',
         });
 
+        // The app downloads VM images (rootfs.vhdx, vmlinuz, initrd)
+        // to bundlePath (~/.config/Claude/vm_bundles/claudevm.bundle/).
+        // Convert VHDX to qcow2 if needed (the app downloads VHDX
+        // format using the win32 manifest entries).
+        const bundleDir = this.bundlePath;
+        const vhdxPath = path.join(bundleDir, 'rootfs.vhdx');
+        const qcow2Path = path.join(bundleDir, 'rootfs.qcow2');
+        if (fs.existsSync(vhdxPath) && !fs.existsSync(qcow2Path)) {
+            log('KvmBackend: converting rootfs.vhdx to qcow2...');
+            try {
+                execFileSync('qemu-img', [
+                    'convert', '-f', 'vhdx', '-O', 'qcow2',
+                    vhdxPath, qcow2Path
+                ], { stdio: 'pipe', timeout: 300000 });
+                log('KvmBackend: rootfs conversion complete');
+            } catch (e) {
+                logError('KvmBackend: rootfs conversion failed:',
+                    e.message);
+                throw new Error(
+                    `rootfs conversion failed: ${e.message}`);
+            }
+        }
+
+        // Fall back: check VM_BASE_DIR if bundle has no rootfs
+        const basePath = fs.existsSync(qcow2Path)
+            ? qcow2Path
+            : path.join(VM_BASE_DIR, 'rootfs.qcow2');
+        if (!fs.existsSync(basePath)) {
+            throw new Error(
+                `rootfs not found in ${bundleDir} or ${VM_BASE_DIR}`);
+        }
+
         // Create session directory
         const sessionId = crypto.randomUUID();
         this.sessionDir = path.join(VM_SESSION_DIR, sessionId);
@@ -967,7 +1001,6 @@ class KvmBackend extends BackendBase {
 
         // Create overlay disk
         const overlayPath = path.join(this.sessionDir, 'overlay.qcow2');
-        const basePath = path.join(VM_BASE_DIR, 'rootfs.qcow2');
         try {
             execFileSync('qemu-img', [
                 'create', '-f', 'qcow2', '-b', basePath,
@@ -983,8 +1016,8 @@ class KvmBackend extends BackendBase {
         this.monitorSock = path.join(this.sessionDir, 'qmp.sock');
         this.bridgeSock = path.join(this.sessionDir, 'bridge.sock');
 
-        const vmlinuzPath = path.join(VM_BASE_DIR, 'vmlinuz');
-        const initrdPath = path.join(VM_BASE_DIR, 'initrd');
+        const vmlinuzPath = path.join(bundleDir, 'vmlinuz');
+        const initrdPath = path.join(bundleDir, 'initrd');
 
         // Start virtiofsd for home directory share (if available)
         const virtiofsSock = path.join(this.sessionDir, 'virtiofs.sock');
@@ -1065,15 +1098,22 @@ class KvmBackend extends BackendBase {
             logError('KvmBackend: session disk creation failed:', e.message);
         }
 
-        // smol-bin disk (contains SDK binaries → /dev/vdc, detected by guest via blkid)
-        const smolBinPath = path.join(VM_BASE_DIR, 'smol-bin.qcow2');
-        if (fs.existsSync(smolBinPath)) {
+        // smol-bin disk (contains SDK binaries → /dev/vdc, detected
+        // by guest via blkid). Check bundle dir first, then VM_BASE_DIR.
+        // Not fatal if missing — SDK can be accessed via virtiofs.
+        const smolBinPath =
+            [bundleDir, VM_BASE_DIR]
+                .map(d => path.join(d, 'smol-bin.qcow2'))
+                .find(p => fs.existsSync(p));
+        if (smolBinPath) {
             qemuArgs.push(
-                '-drive', `file=${smolBinPath},format=qcow2,if=virtio,readonly=on`
+                '-drive',
+                `file=${smolBinPath},format=qcow2,if=virtio,readonly=on`
             );
             log(`KvmBackend: smol-bin attached from ${smolBinPath}`);
         } else {
-            logError('KvmBackend: smol-bin.qcow2 not found — guest sdk-daemon will fail');
+            log('KvmBackend: smol-bin.qcow2 not found — ' +
+                'SDK will be accessed via virtiofs if available');
         }
 
         // vsock
@@ -1682,14 +1722,14 @@ function detectBackend(emitEvent) {
         }
     }
 
-    // Auto-detect: try KVM first, then bwrap, then host
+    // Auto-detect: try KVM first, then bwrap, then host.
+    // Note: rootfs is NOT checked here — the app downloads it to
+    // bundlePath which isn't known until startVM(). The rootfs
+    // check happens at startVM time instead.
     try {
         fs.accessSync('/dev/kvm', fs.constants.R_OK | fs.constants.W_OK);
         execFileSync('which', ['qemu-system-x86_64'], { stdio: 'pipe' });
         fs.accessSync('/dev/vhost-vsock', fs.constants.R_OK);
-        fs.accessSync(
-            path.join(VM_BASE_DIR, 'rootfs.qcow2'), fs.constants.R_OK
-        );
         log('Backend: kvm (all requirements met)');
         return new KvmBackend(emitEvent);
     } catch (e) {


### PR DESCRIPTION
## Summary

Follow-up to #300, which fixed the guest RPC protocol and got the VM past "starting up." This PR addresses the remaining gaps I found by extracting the built AppImage, prettifying `index.js`, and tracing the app's actual RPC calls and startup flow.

### The big fix: bundlePath

The app downloads VM images (`rootfs.vhdx`, `vmlinuz`, `initrd`) to `~/.config/Claude/vm_bundles/claudevm.bundle/` and passes this path as `bundlePath` in the `startVM` params. Our KVM backend was ignoring it entirely. It hardcoded `~/.local/share/claude-desktop/vm/` as the rootfs location, so it could never find the disk image.

This was the exact error @ecrevisseMiroir reported in #288.

The fix:

- Read `bundlePath` from `startVM` params and use it for rootfs, vmlinuz, initrd
- Convert VHDX to qcow2 at `startVM` time (the app downloads VHDX format from the Windows manifest)
- Fall back to `VM_BASE_DIR` if the bundle directory doesn't contain a rootfs
- Remove the rootfs existence check from backend detection. The rootfs location isn't known until `startVM`, and the app may not have downloaded it yet

I also confirmed that `smol-bin.qcow2` ships only in the Windows installer. It's never downloaded separately. With virtiofs active (the default KVM path), the guest accesses the host SDK binary through the mount. So a missing smol-bin is expected and fine.

### Other fixes

- **`setDebugLogging` handler**: the app calls this method and was getting "Unknown method" back. Added the handler.
- **`_ensureSdkInstall` retry bug**: `_pendingSdkInstall` was only cleared on success. Every subsequent `spawn()` call re-attempted the failed install forever.
- **Path traversal guard**: `path.relative()` can produce `../..` paths if the SDK binary ends up outside `$HOME`. Added a check.
- **`startupStep` events**: added emissions at key KVM boot phases so the app's progress UI advances properly.
- **Log formatting cleanup**: minor template literal consistency in KVM `installSdk`.

### Not addressed (separate work)

- `cowork-plugin-shim.sh` for MCP plugin sandboxing. Needed for full plugin support but not core cowork functionality.

## Test plan

- [x] Build AppImage with `./build.sh --build appimage --clean no`
- [x] Extracted built AppImage and confirmed all changes present in asar and unpacked copies
- [x] Verified Linux platform patches and bundle manifest entries intact after rebuild
- [x] Clean build with `./build.sh --build appimage --clean yes` — verified
- [ ] Verify KVM backend reads rootfs.vhdx from `~/.config/Claude/vm_bundles/claudevm.bundle/` and converts to qcow2
- [ ] Verify `setDebugLogging` no longer produces "Unknown method" in daemon logs
- [ ] Confirm KVM backend emits `startupStep` events during boot

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Extracted AppImage, analyzed upstream source, identified bundlePath mismatch and other gaps, implemented fixes, verified builds
Human: Directed analysis, reviewed approach, asked about holistic solution prompting bundlePath discovery