### PR TITLE
fix: clean up CLAUDE_MENU_BAR boolean alias implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Special thanks to:
 - **[IliyaBrook](https://github.com/IliyaBrook)** for fixing the platform patch for Claude Desktop >= 1.1.3541 arm64 refactor
 - **[MichaelMKenny](https://github.com/MichaelMKenny)** for diagnosing the `$`-prefixed electron variable bug with root cause analysis and workaround
 - **[daa25209](https://github.com/daa25209)** for detailed root cause analysis of the cowork platform gate crash and patch script
-- **[noctuum](https://github.com/noctuum)** for the `CLAUDE_MENU_BAR` env var for configurable menu bar visibility
+- **[noctuum](https://github.com/noctuum)** for the `CLAUDE_MENU_BAR` env var with configurable menu bar visibility and boolean alias support
 - **[typedrat](https://github.com/typedrat)** for the NixOS flake integration with build.sh, node-pty derivation, and CI auto-update
 - **[cbonnissent](https://github.com/cbonnissent)** for reverse-engineering the Cowork VM guest RPC protocol and fixing the KVM startup blocker
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -37,8 +37,8 @@ By default, the menu bar is hidden but can be toggled with the Alt key (`auto` m
 | Value | Menu visible | Alt toggles | Use case |
 |-------|-------------|-------------|----------|
 | unset / `auto` | No | Yes | Default — hidden, Alt toggles |
-| `visible` / `1` / `true` / `on` | Yes | No | Stable layout, no shift on Alt |
-| `hidden` / `0` / `false` / `off` | No | No | Menu fully disabled, Alt free |
+| `visible` / `1` / `true` / `yes` / `on` | Yes | No | Stable layout, no shift on Alt |
+| `hidden` / `0` / `false` / `no` / `off` | No | No | Menu fully disabled, Alt free |
 
 ```bash
 # Always show the menu bar (no layout shift on Alt)

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -32,7 +32,7 @@ const rawMenuBarMode = (process.env.CLAUDE_MENU_BAR || 'auto').toLowerCase();
 const resolvedMode = MENU_BAR_ALIASES[rawMenuBarMode] || rawMenuBarMode;
 const MENU_BAR_MODE = VALID_MENU_BAR_MODES.includes(resolvedMode) ? resolvedMode : 'auto';
 if (resolvedMode !== rawMenuBarMode) {
-  console.log(`[Frame Fix] CLAUDE_MENU_BAR '${rawMenuBarMode}' resolved to '${resolvedMode}'`);
+  console.log(`[Frame Fix] CLAUDE_MENU_BAR '${process.env.CLAUDE_MENU_BAR}' resolved to '${resolvedMode}'`);
 } else if (resolvedMode !== MENU_BAR_MODE) {
   console.warn(`[Frame Fix] Unknown CLAUDE_MENU_BAR value '${process.env.CLAUDE_MENU_BAR}', falling back to 'auto'. Valid: ${VALID_MENU_BAR_MODES.join(', ')}, or 0/1/true/false/yes/no/on/off`);
 }

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -284,7 +284,7 @@ run_doctor() {
 			*)
 				_warn "Unknown CLAUDE_MENU_BAR: '$menu_bar_mode'"
 				_info 'Will fall back to auto'
-				_info "Valid values: auto, visible, hidden (or 0/1/true/false/yes/no/on/off)"
+				_info 'Valid values: auto, visible, hidden (or 0/1/true/false/yes/no/on/off)'
 				;;
 		esac
 	else


### PR DESCRIPTION
## Summary

Quick follow-up to #299 addressing review findings:

- **Log original env var value**: alias-resolution log now shows the original `process.env.CLAUDE_MENU_BAR` value (e.g., `'TRUE'`) instead of the already-lowercased value (`'true'`), matching the warning path's behavior
- **Quote style**: use single quotes for literal string without variable expansion per STYLEGUIDE.md
- **Document `yes`/`no` aliases**: the code accepts them but the CONFIGURATION.md table omitted them
- **Update contributor entry**: noctuum's README entry now reflects the boolean alias work

## Test plan

- [x] Verify log shows original casing in alias resolution path
- [x] Verify shellcheck passes on launcher-common.sh
- [x] Verify CONFIGURATION.md table matches accepted values in code

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Implemented review findings from PR #299
Human: Directed review and cleanup