### PR TITLE
fix: propagate run_doctor exit code in all launchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Special thanks to:
 - **[noctuum](https://github.com/noctuum)** for the `CLAUDE_MENU_BAR` env var with configurable menu bar visibility and boolean alias support
 - **[typedrat](https://github.com/typedrat)** for the NixOS flake integration with build.sh, node-pty derivation, and CI auto-update
 - **[cbonnissent](https://github.com/cbonnissent)** for reverse-engineering the Cowork VM guest RPC protocol and fixing the KVM startup blocker
+- **[joekale-pp](https://github.com/joekale-pp)** for adding `--doctor` support to the RPM launcher
 
 ## Sponsorship
 

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -78,7 +78,7 @@ source "$appdir/usr/lib/claude-desktop/launcher-common.sh"
 if [[ "${1:-}" == '--doctor' ]]; then
 	electron_path="$appdir/usr/lib/node_modules/electron/dist/electron"
 	run_doctor "$electron_path"
-	exit
+	exit $?
 fi
 
 # Setup logging and environment

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -98,7 +98,7 @@ source "/usr/lib/$package_name/launcher-common.sh"
 if [[ "\${1:-}" == '--doctor' ]]; then
 	local_electron_path="/usr/lib/$package_name/node_modules/electron/dist/electron"
 	run_doctor "\$local_electron_path"
-	exit
+	exit \$?
 fi
 
 # Setup logging and environment

--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -83,7 +83,7 @@ source "/usr/lib/$package_name/launcher-common.sh"
 if [[ "\${1:-}" == '--doctor' ]]; then
 	local_electron_path="/usr/lib/$package_name/node_modules/electron/dist/electron"
 	run_doctor "\$local_electron_path"
-	exit
+	exit \$?
 fi
 
 # Setup logging and environment


### PR DESCRIPTION
## Summary

All three launchers (deb, RPM, AppImage) used bare `exit` after `run_doctor`, discarding the return code. Scripts or CI checking `--doctor` exit status always saw success even when diagnostics found failures.

- `scripts/build-deb-package.sh`: `exit` → `exit $?`
- `scripts/build-rpm-package.sh`: `exit` → `exit $?`
- `scripts/build-appimage.sh`: `exit` → `exit $?`

Also adds joekale-pp to README contributors for RPM doctor support (#295).

## Test plan

- [ ] `claude-desktop --doctor` returns non-zero when a check fails
- [ ] `echo $?` after `--doctor` reflects actual diagnostic result

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Identified pre-existing bug during PR #295 review, implemented fix across all launchers
Human: Directed the fix after reviewing PR #295