### PR TITLE
fix: bwrap backend mounts at guest paths and uses minimal sandbox root

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -581,6 +581,7 @@ class LocalBackend extends BackendBase {
 
         return {
             id,
+            name,
             actualCommand: resolved.command,
             cleanArgs: cleanSpawnArgs(args || [], mountMap),
             mergedEnv: buildSpawnEnv(env, mountMap),
@@ -774,17 +775,46 @@ class BwrapBackend extends LocalBackend {
         const prepared = this._prepareSpawn(params);
         if (!prepared) return {};
 
-        const { id, actualCommand, cleanArgs, mergedEnv,
-            workDir } = prepared;
+        const { id, name, actualCommand } = prepared;
+        const { additionalMounts } = params;
+        const mountMap = this.lastMountMap || {};
 
-        // Build bwrap arguments
+        // Guest paths (/sessions/...) exist inside our bwrap sandbox,
+        // so pass args and env through as-is (no guest->host translation).
+        const rawArgs = params.args || [];
+        const mergedEnv = {
+            ...filterEnv(process.env, ['CLAUDE_CODE_']),
+            ...filterEnv(params.env || {}),
+            TERM: 'xterm-256color',
+        };
+
+        // Build a minimal sandbox: empty tmpfs root with only the
+        // necessary system paths bound in read-only. This avoids
+        // exposing the real home directory and allows creating the
+        // /sessions/ guest path structure that claude-code-vm expects.
         const bwrapArgs = [
-            '--ro-bind', '/', '/',
+            '--tmpfs', '/',
+            '--ro-bind', '/usr', '/usr',
+            '--ro-bind', '/etc', '/etc',
             '--dev', '/dev',
             '--proc', '/proc',
             '--tmpfs', '/tmp',
             '--tmpfs', '/run',
         ];
+
+        // Handle /bin, /lib, /lib64, /sbin: on merged-usr distros
+        // (Fedora, recent Debian/Ubuntu) these are symlinks into /usr.
+        // On others they are real directories needing separate mounts.
+        for (const dir of ['/bin', '/lib', '/lib64', '/sbin']) {
+            try {
+                const target = fs.readlinkSync(dir);
+                bwrapArgs.push('--symlink', target, dir);
+            } catch (_) {
+                if (fs.existsSync(dir)) {
+                    bwrapArgs.push('--ro-bind', dir, dir);
+                }
+            }
+        }
 
         // Preserve DNS resolution: /etc/resolv.conf is often a symlink
         // to /run/systemd/resolve/stub-resolv.conf which --tmpfs /run
@@ -796,31 +826,27 @@ class BwrapBackend extends LocalBackend {
                 bwrapArgs.push('--ro-bind', resolvedDir, resolvedDir);
             }
         } catch (e) {
-            // resolv.conf missing or unresolvable — DNS may not work
             log('BwrapBackend: could not resolve /etc/resolv.conf:', e.message);
         }
 
-        // Home is read-only; only workDir and explicit mounts are writable.
-        // This prevents the sandbox from writing to ~/.ssh, ~/.gnupg, etc.
+        // Bind the SDK binary read-only
+        const sdkDir = path.dirname(actualCommand);
+        bwrapArgs.push('--ro-bind', sdkDir, sdkDir);
+
+        // Create home directory (needed for ~ expansion) but don't
+        // expose real home contents.
         const homeDir = os.homedir();
-        bwrapArgs.push('--ro-bind', homeDir, homeDir);
-        bwrapArgs.push('--bind', workDir, workDir);
+        bwrapArgs.push('--dir', homeDir);
 
-        // Apply stored mount binds (from mountPath() calls) as writable
-        const boundPaths = new Set([workDir]);
-        for (const [, hostPath] of this.mountBinds) {
-            if (fs.existsSync(hostPath) && !boundPaths.has(hostPath)) {
-                bwrapArgs.push('--bind', hostPath, hostPath);
-                boundPaths.add(hostPath);
-            }
-        }
+        // Create /sessions/<name>/mnt/ guest path structure and mount
+        // host directories at guest paths, matching the KVM backend
+        // layout. The claude-code-vm binary translates all paths to
+        // /sessions/ internally, so these must exist inside the sandbox.
+        const sessionMnt = `/sessions/${name}/mnt`;
+        bwrapArgs.push('--dir', `/sessions/${name}`);
+        bwrapArgs.push('--dir', sessionMnt);
 
-        // Bind-mount additional directories from mountMap (already
-        // validated to stay within home by buildMountMap).
-        const { additionalMounts } = params;
-        const mountMap = this.lastMountMap || {};
         for (const [mountName, hostPath] of Object.entries(mountMap)) {
-            if (boundPaths.has(hostPath)) continue;
             try {
                 if (!fs.existsSync(hostPath)) {
                     fs.mkdirSync(hostPath, { recursive: true });
@@ -829,11 +855,11 @@ class BwrapBackend extends LocalBackend {
                 log(`BwrapBackend spawn: could not create ${hostPath}: ${e.message}`);
                 continue;
             }
+            const guestPath = `${sessionMnt}/${mountName}`;
             const mode = additionalMounts?.[mountName]?.mode;
             const bindType = mode === 'ro' ? '--ro-bind' : '--bind';
-            bwrapArgs.push(bindType, hostPath, hostPath);
-            boundPaths.add(hostPath);
-            log(`BwrapBackend spawn: mount ${mountName} -> ${hostPath} (${mode || 'rw'})`);
+            bwrapArgs.push(bindType, hostPath, guestPath);
+            log(`BwrapBackend spawn: mount ${mountName}: ${hostPath} -> ${guestPath} (${mode || 'rw'})`);
         }
 
         // Namespace isolation + actual command
@@ -843,13 +869,25 @@ class BwrapBackend extends LocalBackend {
             '--new-session',
             '--',
             actualCommand,
-            ...cleanArgs,
+            ...rawArgs,
         );
 
-        log(`BwrapBackend spawn: bwrap args=${JSON.stringify(bwrapArgs)}`);
-        log(`BwrapBackend spawn: cwd=${workDir}`);
+        // Use the primary user mount as cwd (first non-dotfile, non-uploads mount)
+        const primaryMount = Object.keys(mountMap).find(
+            n => !n.startsWith('.') && n !== 'uploads',
+        );
+        const guestWorkDir = primaryMount
+            ? `${sessionMnt}/${primaryMount}`
+            : sessionMnt;
 
-        this._spawnLocal(id, 'bwrap', bwrapArgs, workDir, mergedEnv);
+        log(`BwrapBackend spawn: bwrap args=${JSON.stringify(bwrapArgs)}`);
+        log(`BwrapBackend spawn: cwd=${guestWorkDir}`);
+
+        // Use host-side cwd for Node's spawn (guest paths don't exist
+        // on host). bwrap --chdir sets the actual cwd inside the sandbox.
+        this._spawnLocal(id, 'bwrap',
+            ['--chdir', guestWorkDir, ...bwrapArgs],
+            os.homedir(), mergedEnv);
         return {};
     }
 


### PR DESCRIPTION
## Summary

The BwrapBackend had two compounding issues:

### 1. Security: workDir fell back to $HOME, making entire home writable

The spawn `cwd` arrives as `/sessions/<name>` (a session root without the `/mnt/<mount>` suffix). `resolveWorkDir` could not translate this pattern via `translateGuestPath` and fell back to `os.homedir()`. This caused `--bind $HOME $HOME` to override the preceding `--ro-bind $HOME $HOME`, making the **entire home directory writable** inside the sandbox — defeating the read-only home protection for `~/.ssh`, `~/.gnupg`, etc.

### 2. Broken paths: /sessions/ guest paths don't exist inside bwrap

There are two layers of path translation:

- **cowork-vm-service.js** translates guest paths at spawn time — `cleanSpawnArgs` converts `--add-dir /sessions/.../mnt/project` to `--add-dir /home/user/project`, and `buildSpawnEnv` does the same for `CLAUDE_CONFIG_DIR`.
- **claude-code-vm** (the binary running inside the sandbox) appears to perform its own runtime path translation between host paths and `/sessions/` guest paths.

Since `/sessions/` did not exist inside the bwrap namespace, **all file operations on the working directory failed** regardless of which path form was used.

#### Example: reproducing the issue

When telling cowork to "ls the working directory" with a folder mounted, the agent would attempt:

```
bash
ls /sessions/trusting-jolly-ritchie/mnt/my-project
```

And get:

```
Exit code 2
ls: cannot access '/home/user/my-project': No such file or directory
```

The error shows the host path instead of the guest path. `cowork-vm-service.js` only translates at spawn time (startup args/env), not runtime Bash commands — stdout/stderr from the sandboxed process are piped through unmodified. This indicates `claude-code-vm` itself translates paths at runtime, and always resolves to `/sessions/` guest paths internally.

### Screenshot
#### read working directory
<img width="1048" height="1208" alt="Screenshot From 2026-03-20 10-12-25 (Edit)" src="https://github.com/user-attachments/assets/0d7add45-9494-4760-82ff-072825e24998" />



#### Create a file (Cowork decided to create it in `~/mnt` as a fallback after having a lack of permission. This is unsafe and moreover the desktop app does not allow its visualization because it's outside allowed folders).
<img width="1454" height="1426" alt="Screenshot From 2026-03-20 10-15-20 (Edit)" src="https://github.com/user-attachments/assets/c48eec99-2d7b-4027-a8c5-771b57e11367" />


### Fix

Replaces the `--ro-bind / /` full-root approach with a minimal tmpfs-based sandbox:

- `--tmpfs /` as an empty root (nothing exposed by default)
- `/usr`, `/etc`, `/dev`, `/proc` bound read-only for system tools
- System directories (`/bin`, `/lib`, `/lib64`, `/sbin`) are detected at runtime: symlinks on merged-usr distros, separate bind mounts on others — works across Fedora, Debian, Ubuntu, Arch, etc.
- SDK binary directory bound read-only
- `/sessions/<name>/mnt/` created via `--dir`, with host directories bind-mounted at guest paths (matching the KVM backend layout)
- `--chdir` sets the cwd inside the sandbox to the guest working directory
- Guest-to-host path translation in cowork-vm-service is skipped entirely for bwrap (args and env passed through as-is), since the guest paths now exist natively inside the sandbox

#### Screenshots after fix
##### Implicitly mentioning the working dir
<img width="1027" height="669" alt="Screenshot From 2026-03-20 10-23-20 (Edit) (Edit)" src="https://github.com/user-attachments/assets/538d1195-7874-4819-93a7-3c9c3b307d8c" />

#### Creating a file in the work dir and _outputting_ it:
<img width="1559" height="844" alt="Screenshot From 2026-03-20 10-31-40 (Edit)" src="https://github.com/user-attachments/assets/26dccf7d-e3dc-44e0-b1a7-88ae99b004e9" />




## Test plan

- [x] Verified `bwrap --tmpfs / ...` approach works with bind mounts at guest paths
- [x] Confirmed `--chdir /sessions/<name>/mnt/<mount>` sets correct cwd
- [x] Tested `ls`, file creation, and `pwd` all work inside the sandbox
- [x] Verified home directory is not exposed (only an empty `--dir`)
- [ ] Test with plugins that use `--plugin-dir`
- [ ] Test on non-merged-usr distro (e.g., older Debian)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
90% AI / 10% Human
Claude: Investigated the root cause across path translation, bwrap mount setup, and claude-code-vm bidirectional path mapping; implemented the fix
Human: Identified the security concern, guided debugging, caught hardcoded paths, and validated the fix on a live cowork session