### PR TITLE
fix: echo request id in RPC responses for persistent connections

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -2004,6 +2004,11 @@ function startServer() {
             while (parsed) {
                 buffer = parsed.remaining;
                 const response = await handleRequest(parsed.message, socket);
+                // Echo back request id so persistent-connection clients
+                // can match responses to pending requests.
+                if (parsed.message.id !== undefined) {
+                    response.id = parsed.message.id;
+                }
                 writeMessage(socket, response);
 
                 try {


### PR DESCRIPTION
## Summary

- The socket server in `cowork-vm-service.js` did not echo back the `id` field from client requests in responses
- The Claude Desktop client uses a persistent multiplexed connection where responses are matched by `id` — without it, all responses are silently dropped as "orphaned"
- This caused all RPC calls (`configure`, `startVM`, `isGuestConnected`, etc.) to timeout after 30 seconds, completely blocking cowork startup

## Details

The client (`index.js`) sends requests like `{"method": "isGuestConnected", "id": 1}` and expects `{"success": true, "result": {...}, "id": 1}` back. The response handler matches by id:

```js
const a = s.id ?? 0;
const o = Ng.get(a);  // undefined — no pending request has id=0
// → "Orphaned response dropped"
```

The fix echoes `parsed.message.id` back in the response before writing to the socket.

## Test plan

- [x] Verified that `isGuestConnected`, `configure`, `startVM`, and `spawn` all succeed with the fix
- [x] Verified backward compatibility: one-shot connections (no `id` in request) are unaffected
- [x] Tested full cowork session startup end-to-end with bwrap backend

Fixes #312

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Root-caused the bug by tracing minified client code, implemented fix
Human: Tested on live Claude Desktop instance, validated fix works