### PR TITLE
fix: skip ELECTRON_FORCE_IS_PACKAGED for NixOS builds

### DIFF
--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -169,7 +169,7 @@ fi
 
 # Setup logging and environment
 setup_logging || exit 1
-setup_electron_env
+setup_electron_env 'nix'
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -147,8 +147,21 @@ cleanup_stale_cowork_socket() {
 }
 
 # Set common environment variables
+# Arguments: $1 = package type ("deb", "appimage", "rpm", or "nix")
 setup_electron_env() {
-	export ELECTRON_FORCE_IS_PACKAGED=true
+	local package_type="${1:-deb}"
+
+	# ELECTRON_FORCE_IS_PACKAGED makes app.isPackaged return true, which
+	# causes the Claude app to resolve resources via process.resourcesPath.
+	# On NixOS, Electron is a separate store path so resourcesPath points
+	# to Electron's resources dir, not the app's.  The frame-fix-wrapper
+	# corrects this at JS load time, but some app code may run before the
+	# fix or cache the original value.  Skipping this env var for Nix
+	# keeps isPackaged=false, using development-style fallback paths that
+	# work correctly with NixOS's split-package layout.
+	if [[ $package_type != 'nix' ]]; then
+		export ELECTRON_FORCE_IS_PACKAGED=true
+	fi
 	export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 }
 


### PR DESCRIPTION
## Summary

- Skip `ELECTRON_FORCE_IS_PACKAGED=true` for NixOS builds by parameterizing `setup_electron_env()` to accept a package type
- NixOS launcher now calls `setup_electron_env 'nix'`, which skips the env var
- Deb/AppImage/RPM launchers are unchanged (default to `'deb'`)

Fixes #311

## Root Cause

PR #305 introduced `ELECTRON_FORCE_IS_PACKAGED=true` to NixOS builds via the new launcher script. This env var makes `app.isPackaged` return `true`, which causes Claude's app code to resolve resources via `process.resourcesPath`. On NixOS, Electron is a separate Nix store path, so `process.resourcesPath` points to Electron's resources dir — not the app's.

The `frame-fix-wrapper.js` corrects `process.resourcesPath` at JS load time, but Claude's app code has multiple `isPackaged`-gated paths (i18n resolution, URL validation, MCP host path) that use the wrong path before or independent of the correction, causing a silent startup hang.

**Verified against Electron source:** `ELECTRON_FORCE_IS_PACKAGED` [only affects `app.isPackaged`](https://github.com/electron/electron/blob/main/shell/browser/api/electron_api_app.cc) — it does not change how Electron loads the asar. The issue is entirely in Claude's app-level resource resolution.

## Test plan

- [ ] Verify `shellcheck scripts/launcher-common.sh` passes
- [ ] Verify `nix build .#claude-desktop` succeeds
- [ ] Verify generated NixOS launcher contains `setup_electron_env 'nix'`
- [ ] Verify NixOS launch: window appears, `[Frame Fix]` output present, `isPackaged: false`
- [ ] Verify deb/AppImage/RPM launchers still call `setup_electron_env` without args (unchanged behavior)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
85% AI / 15% Human
Claude: Root cause analysis, Electron source verification, implementation, PR
Human: Issue review direction, contrarian review request, plan approval