### PR TITLE
fix: kill orphaned cowork-vm-service daemon on startup

### DIFF
--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -170,6 +170,7 @@ fi
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env 'nix'
+cleanup_orphaned_cowork_daemon
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 

--- a/scripts/build-appimage.sh
+++ b/scripts/build-appimage.sh
@@ -84,6 +84,7 @@ fi
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env
+cleanup_orphaned_cowork_daemon
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 

--- a/scripts/build-deb-package.sh
+++ b/scripts/build-deb-package.sh
@@ -104,6 +104,7 @@ fi
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env
+cleanup_orphaned_cowork_daemon
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 

--- a/scripts/build-rpm-package.sh
+++ b/scripts/build-rpm-package.sh
@@ -89,6 +89,7 @@ fi
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env
+cleanup_orphaned_cowork_daemon
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -91,6 +91,39 @@ build_electron_args() {
 	fi
 }
 
+# Kill orphaned cowork-vm-service daemon processes.
+# After a crash or unclean shutdown the cowork daemon may outlive the
+# main Electron UI process.  The orphaned daemon holds LevelDB locks
+# in ~/.config/Claude/Local Storage/ which cause new launches to
+# detect a "main instance" and silently quit.
+# Must run BEFORE cleanup_stale_lock / cleanup_stale_cowork_socket
+# so that stale files left behind by the daemon can be cleaned up.
+cleanup_orphaned_cowork_daemon() {
+	local cowork_pids
+	cowork_pids=$(pgrep -f 'cowork-vm-service\.js' 2>/dev/null) \
+		|| return 0
+
+	# Check if a Claude Desktop UI process is also running.
+	# Any claude-desktop electron process that is NOT the cowork
+	# daemon indicates the app is alive and the daemon is expected.
+	local pid cmdline
+	for pid in $(pgrep -f 'claude-desktop' 2>/dev/null); do
+		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
+			|| continue
+		[[ $cmdline == *cowork-vm-service* ]] && continue
+		# Found a non-daemon claude-desktop process — not orphaned
+		return 0
+	done
+
+	# No UI process found — daemon is orphaned, terminate it
+	for pid in $cowork_pids; do
+		kill "$pid" 2>/dev/null || true
+	done
+	log_message \
+		"Killed orphaned cowork-vm-service daemon" \
+		"(PIDs: $cowork_pids)"
+}
+
 # Clean up stale SingletonLock if the owning process is no longer running.
 # Electron uses requestSingleInstanceLock() which silently quits if the lock
 # is held. A stale lock (from a crash or unclean update) blocks all launches
@@ -537,6 +570,28 @@ print(len(servers))
 		cowork_backend='bubblewrap (namespace sandbox)'
 	fi
 	_info "Cowork isolation: $cowork_backend"
+
+	# -- Orphaned cowork daemon --
+	local _cowork_pids
+	_cowork_pids=$(pgrep -f 'cowork-vm-service\.js' 2>/dev/null) \
+		|| true
+	if [[ -n $_cowork_pids ]]; then
+		local _daemon_orphaned=true _pid _cmdline
+		for _pid in $(pgrep -f 'claude-desktop' 2>/dev/null); do
+			_cmdline=$(tr '\0' ' ' \
+				< "/proc/$_pid/cmdline" 2>/dev/null) || continue
+			[[ $_cmdline == *cowork-vm-service* ]] && continue
+			_daemon_orphaned=false
+			break
+		done
+		if [[ $_daemon_orphaned == true ]]; then
+			_warn "Cowork daemon: orphaned (PIDs: $_cowork_pids)"
+			_info 'Fix: Restart Claude Desktop (daemon will be' \
+				'cleaned up automatically)'
+		else
+			_pass 'Cowork daemon: running (parent alive)'
+		fi
+	fi
 
 	# -- Log file --
 	local log_path


### PR DESCRIPTION
## Summary

After a crash or unclean exit, the `cowork-vm-service.js` daemon can outlive the main Electron UI process. The orphaned daemon holds LevelDB locks in `~/.config/Claude/Local Storage/` which cause new launches to detect a "main instance" and silently exit with `Not main instance, returning early from app ready` — the app appears to do nothing when clicked.

- Add `cleanup_orphaned_cowork_daemon()` to `launcher-common.sh` that detects daemon processes without a living parent UI process and terminates them
- Runs **before** `cleanup_stale_lock` / `cleanup_stale_cowork_socket` so stale files left by the daemon are cleaned up next
- Add `--doctor` diagnostic check that warns when an orphaned cowork daemon is detected
- Called from all 4 launcher entry points (deb, rpm, appimage, nix)

## Root Cause

1. Claude Desktop crashes or is killed (e.g., `kill`, OOM, X11 disconnect)
2. `cowork-vm-service.js` daemon survives (separate Electron process)
3. Orphaned daemon holds `~/.config/Claude/Local Storage/leveldb/LOCK`
4. User clicks icon → new Electron starts → detects lock → `Not main instance` → exits silently
5. Existing `cleanup_stale_lock()` doesn't help because there's no `SingletonLock` symlink — the block comes from LevelDB
6. Existing `cleanup_stale_cowork_socket()` thinks socket is valid because the orphaned daemon is still listening

## Detection Logic

```
pgrep cowork-vm-service.js → found?
├── NO → nothing to do
└── YES → any non-daemon claude-desktop process running?
    ├── YES → daemon has living parent, not orphaned
    └── NO → orphaned, kill it
```

## Test plan

- [ ] Simulate: start Claude Desktop, `kill` the main Electron PID (not cowork daemon), verify app won't relaunch
- [ ] Apply fix, repeat above — verify orphaned daemon is killed and app launches successfully
- [ ] Verify `--doctor` shows `[WARN] Cowork daemon: orphaned` when daemon is orphaned
- [ ] Verify `--doctor` shows `[PASS] Cowork daemon: running (parent alive)` during normal operation
- [ ] Verify no false positives when Claude Desktop is running normally
- [ ] `shellcheck scripts/launcher-common.sh` passes clean

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
85% AI / 15% Human
Claude: Root cause analysis, fix implementation, doctor diagnostic, PR
Human: Bug report, testing, review