### PR TITLE
fix: enable cowork mode on NixOS (isPackaged + resourcesPath + service pre-launch)

### DIFF
--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -157,6 +157,8 @@ stdenvNoCC.mkDerivation {
 # Claude Desktop launcher for NixOS
 
 electron_exec="ELECTRON_PLACEHOLDER"
+electron_resources="ELECTRON_RESOURCES_PLACEHOLDER"
+app_resources="RESOURCES_PLACEHOLDER"
 app_path="RESOURCES_PLACEHOLDER/app.asar"
 
 source "LAUNCHER_LIB_PLACEHOLDER"
@@ -172,6 +174,22 @@ setup_logging || exit 1
 setup_electron_env 'nix'
 cleanup_stale_lock
 cleanup_stale_cowork_socket
+
+# On NixOS, Electron and the app live in separate store paths.
+# Electron hardcodes process.resourcesPath from its binary location,
+# which can't be overridden. Create a merged resources directory
+# with symlinks to both so all file lookups succeed.
+merged_resources="$log_dir/resources"
+mkdir -p "$merged_resources"
+# Symlink Electron's resources (default_app.asar, etc.)
+for f in "$electron_resources"/*; do
+	ln -sf "$f" "$merged_resources/" 2>/dev/null
+done
+# Symlink app resources (overrides Electron's on conflict)
+for f in "$app_resources"/*; do
+	ln -sf "$f" "$merged_resources/" 2>/dev/null
+done
+export CLAUDE_RESOURCES_PATH="$merged_resources"
 
 # Log startup info
 log_message '--- Claude Desktop Launcher Start (NixOS) ---'
@@ -195,6 +213,18 @@ build_electron_args 'nix'
 # Add app path
 electron_args+=("$app_path")
 
+# Pre-launch cowork-vm-service daemon if not already running.
+# The app's auto-launcher only triggers on ECONNREFUSED, not
+# ENOENT, so without a pre-existing socket the service never
+# starts on a fresh install.
+cowork_svc="RESOURCES_PLACEHOLDER/app.asar.unpacked/cowork-vm-service.js"
+cowork_sock="''${XDG_RUNTIME_DIR:-/tmp}/cowork-vm-service.sock"
+if [[ -f "$cowork_svc" && ! -S "$cowork_sock" ]]; then
+	ELECTRON_RUN_AS_NODE=1 "$electron_exec" "$cowork_svc" &
+	disown
+	log_message "Pre-launched cowork-vm-service (PID $!)"
+fi
+
 # Execute Electron
 log_message "Executing: $electron_exec ''${electron_args[*]} $*"
 "$electron_exec" "''${electron_args[@]}" "$@" >> "$log_file" 2>&1
@@ -204,6 +234,7 @@ exit $exit_code
 LAUNCHER
     # Substitute placeholders with Nix store paths
     substituteInPlace $out/bin/claude-desktop \
+      --replace-fail "ELECTRON_RESOURCES_PLACEHOLDER" "${electron}/libexec/electron/resources" \
       --replace-fail "ELECTRON_PLACEHOLDER" "${electron}/bin/electron" \
       --replace-fail "RESOURCES_PLACEHOLDER" "$out/lib/claude-desktop/resources" \
       --replace-fail "LAUNCHER_LIB_PLACEHOLDER" "$out/lib/claude-desktop/launcher-common.sh"

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -8,14 +8,46 @@ console.log('[Frame Fix] Wrapper loaded');
 // Fix process.resourcesPath to match the actual location of app.asar.
 // In Nix builds, electron is a separate store path so process.resourcesPath
 // points to the Electron package's resources dir, not where our tray icons
-// and app.asar.unpacked live. Deriving from __dirname (the asar root) gives
-// the correct path; for deb/AppImage builds the values already match.
-const derivedResourcesPath = path.dirname(__dirname);
-if (derivedResourcesPath !== process.resourcesPath) {
+// and app.asar.unpacked live.
+//
+// The NixOS launcher sets CLAUDE_RESOURCES_PATH to a merged directory
+// containing symlinks to both Electron's and the app's resources. This
+// is the most reliable approach because Electron's internal C++ code and
+// patched fs bindings cache the original resourcesPath before any JS runs.
+const mergedResources = process.env.CLAUDE_RESOURCES_PATH;
+const derivedResourcesPath = mergedResources || path.dirname(__dirname);
+const originalResourcesPath = process.resourcesPath;
+if (derivedResourcesPath !== originalResourcesPath) {
   console.log('[Frame Fix] Correcting process.resourcesPath');
-  console.log('[Frame Fix]   Was:', process.resourcesPath);
+  console.log('[Frame Fix]   Was:', originalResourcesPath);
   console.log('[Frame Fix]   Now:', derivedResourcesPath);
   process.resourcesPath = derivedResourcesPath;
+
+  // Electron's internal fs patches (node:electron/js2c/node_init)
+  // use the original C++-level resourcesPath for file operations.
+  // Monkey-patch the native fs module to redirect any accesses from
+  // the old Electron resources path to the correct merged path.
+  // This must cover both sync and async variants since the minified
+  // app code may use either.
+  const fs = require('fs');
+  const _redirect = (p) => {
+    if (typeof p === 'string' && p.startsWith(originalResourcesPath)) {
+      return derivedResourcesPath + p.slice(originalResourcesPath.length);
+    }
+    return p;
+  };
+  for (const m of [
+    'readFileSync', 'existsSync', 'statSync', 'lstatSync',
+    'readdirSync', 'copyFileSync', 'accessSync',
+    'readFile', 'stat', 'lstat', 'readdir', 'copyFile', 'access',
+    'openSync', 'open', 'createReadStream',
+  ]) {
+    const orig = fs[m];
+    if (!orig) continue;
+    fs[m] = function(p, ...a) {
+      return orig.call(this, _redirect(p), ...a);
+    };
+  }
 }
 
 // Menu bar visibility mode, controlled by CLAUDE_MENU_BAR env var:

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -154,14 +154,12 @@ setup_electron_env() {
 	# ELECTRON_FORCE_IS_PACKAGED makes app.isPackaged return true, which
 	# causes the Claude app to resolve resources via process.resourcesPath.
 	# On NixOS, Electron is a separate store path so resourcesPath points
-	# to Electron's resources dir, not the app's.  The frame-fix-wrapper
-	# corrects this at JS load time, but some app code may run before the
-	# fix or cache the original value.  Skipping this env var for Nix
-	# keeps isPackaged=false, using development-style fallback paths that
-	# work correctly with NixOS's split-package layout.
-	if [[ $package_type != 'nix' ]]; then
-		export ELECTRON_FORCE_IS_PACKAGED=true
-	fi
+	# to Electron's resources dir, not the app's.  The frame-fix-wrapper.js
+	# (loaded as the entry point before any app code) corrects
+	# process.resourcesPath at JS load time, so this is safe for all
+	# package types including Nix.  Without isPackaged=true, cowork mode
+	# code paths are skipped entirely.
+	export ELECTRON_FORCE_IS_PACKAGED=true
 	export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 }
 


### PR DESCRIPTION
On NixOS, cowork mode fails with "VM service not running" immediately
after launch.  Three independent problems combine to cause this:

1. ELECTRON_FORCE_IS_PACKAGED is skipped for NixOS (c3cc5a6), keeping
   app.isPackaged false.  The upstream app gates cowork's VM service
   fork behind isPackaged === true, so the service is never spawned.

2. Re-enabling ELECTRON_FORCE_IS_PACKAGED causes a different failure:
   Electron resolves process.resourcesPath from its real binary path
   (following symlinks), which on NixOS points to Electron's store
   path (/nix/store/...-electron-38/libexec/electron/resources/),
   not the app's resources.  The app then fails to find en-US.json,
   smol-bin.x64.vhdx, and other resources at that path.

   Electron's C++-level resourcesPath is cached before any JS runs
   and cannot be overridden via NODE_OPTIONS (blocked for packaged
   apps) or --require.  The frame-fix-wrapper.js corrects
   process.resourcesPath at JS level, but Electron's internal
   patched fs (node:electron/js2c/node_init) still uses the
   original cached value.

3. The app's auto-launcher for cowork-vm-service.js only triggers on
   ECONNREFUSED, not ENOENT.  On a fresh install where no socket has
   ever been created, the connect() returns ENOENT and the fork path
   is never reached.

Fix all three:

  launcher-common.sh:
  - Re-enable ELECTRON_FORCE_IS_PACKAGED for all package types.

  nix/claude-desktop.nix (launcher script):
  - Create a merged resources directory at runtime
    ($XDG_CACHE_HOME/claude-desktop-debian/resources/) containing
    symlinks to both Electron's and the app's resources.
  - Export CLAUDE_RESOURCES_PATH pointing to the merged directory.
  - Pre-launch cowork-vm-service.js before exec'ing Electron so the
    Unix socket exists when the app tries to connect.

  frame-fix-wrapper.js:
  - Read CLAUDE_RESOURCES_PATH and use it as the corrected
    process.resourcesPath (falls back to path.dirname(__dirname)
    for non-NixOS builds — no behavior change).
  - Monkey-patch fs.readFileSync, existsSync, statSync, and other
    fs methods to redirect any access from Electron's original
    resourcesPath to the merged directory.  This catches lookups
    that go through Electron's internal patched fs bindings before
    the JS-level process.resourcesPath correction takes effect.

Tested on NixOS 25.11 with Electron 38.8.1.  The KVM backend
boots successfully, the guest VM connects via vsock, and the SDK
installs.  The remaining failure (sandbox-helper: /usr/local/bin/
claude: no such file or directory) is inside Anthropic's guest VM
image and is tracked separately in #322.

Relates: #282, #311
Relates: #322 (guest-side /usr/local/bin/claude)
Relates: #237 (alternative pre-launch approach via systemd)