### PR TITLE
fix: handle resize events for tiling WM workspace switches

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -187,14 +187,10 @@ Module.prototype.require = function(id) {
               });
 
               // Tiling WMs (Hyprland, i3, sway) emit 'resize' on
-              // workspace switches. The upstream layout handler uses
-              // getContentBounds() which returns stale cached values,
-              // setting child views to wrong dimensions. Fix
-              // immediately so we race the upstream handler rather
-              // than arriving late. The fixChildBounds() guard
-              // (cur.width !== cw check) prevents unnecessary
-              // setBounds during drag resize where the cache stays
-              // in sync. Fixes: #323
+              // workspace switches with stale getContentBounds()
+              // cache. The size-change guard in fixChildBounds()
+              // prevents unnecessary work during drag resize.
+              // Fixes: #323
               this.on('resize', fixAfterStateChange);
 
               // ready-to-show fires once per window lifecycle

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -186,6 +186,17 @@ Module.prototype.require = function(id) {
                 }
               });
 
+              // Tiling WMs (Hyprland, i3, sway) emit 'resize' on
+              // workspace switches. The upstream layout handler uses
+              // getContentBounds() which returns stale cached values,
+              // setting child views to wrong dimensions. Fix
+              // immediately so we race the upstream handler rather
+              // than arriving late. The fixChildBounds() guard
+              // (cur.width !== cw check) prevents unnecessary
+              // setBounds during drag resize where the cache stays
+              // in sync. Fixes: #323
+              this.on('resize', fixAfterStateChange);
+
               // ready-to-show fires once per window lifecycle
               this.once('ready-to-show', () => {
                 if (MENU_BAR_MODE !== 'visible') {


### PR DESCRIPTION
## Summary

- Fixes #323. On tiling WMs (Hyprland, i3, sway), switching workspaces changes the window frame size but the rendered content doesn't redraw to match.
- The upstream layout handler calls `getContentBounds()`, which returns stale values from Chromium's cache after a tiling resize.
- Our `fixChildBounds()` already corrects this using `getContentSize()`, but it only fired on `maximize`, `unmaximize`, `fullscreen`, and `moved` events.
- Adds `this.on('resize', fixAfterStateChange)` so the fix also fires on resize.
- This is distinct from the old resize handler removed in 8bf10dc. That handler caused jitter because it used a "jiggle" approach (resize by 1px then back). `fixChildBounds()` has a guard that only acts when there's a genuine mismatch between frame and content size, so it's safe to call on every resize.
- One file changed, one line added.

## Test plan

- [ ] Build the .deb or AppImage from `fix/323-tiling-wm-resize`
- [ ] On a tiling WM (Hyprland, sway, or i3), open Claude Desktop
- [ ] Switch to another workspace, then switch back. Confirm the content redraws correctly and fills the window
- [ ] Move the window to a differently-sized tile. Confirm content resizes to match
- [ ] On a stacking WM (GNOME, KDE), manually resize the window by dragging edges. Confirm no jitter or flicker during the resize
- [ ] Maximize, unmaximize, and fullscreen the window. Confirm existing fix behavior is unchanged

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
85% AI / 15% Human
Claude: Root cause analysis, patch implementation
Human: Direction, plan review, contrarian review