### PR TITLE
fix: force layout recalculation on tiling WM workspace switches

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -203,44 +203,35 @@ Module.prototype.require = function(id) {
               // fires — only 'show'. Fixes: #323
               this.on('show', fixAfterStateChange);
 
-              // Jiggle on show-after-hide: 1px setSize forces
-              // Electron's LayoutManagerBase to fully recalculate,
-              // resetting stale cache. Only fires once per cycle.
-              // Fixes: #323
-              let wasHidden = false;
-              this.on('hide', () => { wasHidden = true; });
-              this.on('show', () => {
-                if (wasHidden) {
-                  wasHidden = false;
-                  const [w, h] = this.getSize();
-                  this.setSize(w + 1, h);
-                  setTimeout(() => {
-                    if (!this.isDestroyed()) {
-                      this.setSize(w, h);
-                      fixAfterStateChange();
-                    }
-                  }, 50);
-                }
-              });
+              // 1px setSize jiggle forces Electron's LayoutManagerBase
+              // to fully recalculate, resetting stale cache. Fixes: #323
+              const jiggleSize = () => {
+                if (this.isDestroyed()) return;
+                const [w, h] = this.getSize();
+                this.setSize(w + 1, h);
+                setTimeout(() => {
+                  if (!this.isDestroyed()) {
+                    this.setSize(w, h);
+                    fixAfterStateChange();
+                  }
+                }, 50);
+              };
 
-              // Jiggle on focus-after-blur: Hyprland and similar
-              // WMs emit blur/focus (not hide/show) on workspace
-              // switches. Same 1px jiggle technique. Fixes: #323
-              let wasBlurred = false;
-              this.on('blur', () => { wasBlurred = true; });
-              this.on('focus', () => {
-                if (wasBlurred) {
-                  wasBlurred = false;
-                  const [w, h] = this.getSize();
-                  this.setSize(w + 1, h);
-                  setTimeout(() => {
-                    if (!this.isDestroyed()) {
-                      this.setSize(w, h);
-                      fixAfterStateChange();
-                    }
-                  }, 50);
-                }
-              });
+              // Tiling WMs signal workspace switches via hide/show
+              // or blur/focus pairs. Track each transition and jiggle
+              // once per cycle to reset the layout cache.
+              const addJigglePair = (offEvent, onEvent) => {
+                let armed = false;
+                this.on(offEvent, () => { armed = true; });
+                this.on(onEvent, () => {
+                  if (armed) {
+                    armed = false;
+                    jiggleSize();
+                  }
+                });
+              };
+              addJigglePair('hide', 'show');
+              addJigglePair('blur', 'focus');
 
               // ready-to-show fires once per window lifecycle
               this.once('ready-to-show', () => {


### PR DESCRIPTION
## Summary

- Fixes #323 — content not redrawing on tiling WM workspace switches (Hyprland, i3, sway)
- PR #331 added resize/show handlers but the bug persisted because Hyprland emits `blur`/`focus` (not `hide`/`show`) and `setBounds()` alone doesn't force Chromium to repaint

## Changes

- Add 1px `setSize` jiggle on **focus-after-blur** to force Electron's `LayoutManagerBase` to fully recalculate stale cache (the key fix for Hyprland)
- Add 1px `setSize` jiggle on **show-after-hide** for WMs that use hide/show on workspace switches
- Toggle zoom factor (1.0001→1.0) after `setBounds()` to force Chromium re-composite
- Adjust `fixAfterStateChange` timing from `[0, 16, 150]ms` to `[8, 32, 150]ms` — the t=0 check never catches mismatches on tiling WMs

## Test plan

- [x] Tested on Hyprland with HiDPI 2x — content fills frame on every workspace switch
- [ ] Test on i3/sway workspace switches
- [ ] Test drag-resize on stacking WMs (KDE/GNOME) — no jitter
- [ ] Test maximize/unmaximize/fullscreen — unchanged behavior

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
90% AI / 10% Human
Claude: investigated root cause via debug logging, designed and implemented fix, cleaned up code
Human: reported bug, tested each iteration, confirmed fix works