### PR TITLE
fix: debounced jiggle for same-size tiling WM workspace switches

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -264,24 +264,22 @@ Module.prototype.require = function(id) {
               // when fixChildBounds() finds no mismatch (stale
               // compositor cache on same-size workspace switch).
               // Fixes: #323
-              let blurArmed = false;
-              this.on('blur', () => { blurArmed = true; });
+              const armPair = (armEvt, fireEvt) => {
+                let armed = false;
+                this.on(armEvt, () => { armed = true; });
+                this.on(fireEvt, () => {
+                  if (armed) {
+                    armed = false;
+                    jiggleIfStale();
+                  }
+                });
+              };
+
               this.on('focus', () => {
                 this.flashFrame(false); // Fixes: #149
-                if (blurArmed) {
-                  blurArmed = false;
-                  jiggleIfStale();
-                }
               });
-
-              let hideArmed = false;
-              this.on('hide', () => { hideArmed = true; });
-              this.on('show', () => {
-                if (hideArmed) {
-                  hideArmed = false;
-                  jiggleIfStale();
-                }
-              });
+              armPair('blur', 'focus');
+              armPair('hide', 'show');
             }
 
             console.log('[Frame Fix] Linux patches applied');


### PR DESCRIPTION
## Summary

- Fixes the remaining #323 case: Hyprland workspace switches where tile size is unchanged (no `resize` event, only `blur`/`focus`)
- Alternative to #333 with safety measures for stacking WMs
- Adds armed-pair detection (blur→focus, hide→show) with a debounced 1px `setSize` jiggle
- Jiggle only fires when `fixChildBounds()` finds no bounds mismatch (stale compositor cache)

## Changes

- `fixChildBounds()` now returns `boolean` — `true` if it called `setBounds()`, `false` if bounds already matched
- `jiggleIfStale()` — debounced (100ms) 1px width jiggle, only fires when bounds match but cache is stale
- `jiggling` flag suppresses `resize`/`moved` → `fixAfterStateChange` cascade from jiggle's own `setSize` calls
- `will-resize` guard prevents jiggle during interactive drag resize (defense-in-depth)
- Armed-pair handlers for blur→focus (Hyprland) and hide→show (i3, sway) workspace transitions
- Existing `flashFrame(false)` (#149 fix) preserved in focus handler

## Why not PR #333

PR #333 addresses the same gap but has issues:
1. blur/focus jiggle fires on every Alt+Tab on stacking WMs (KDE, GNOME)
2. ~27 timer callbacks per workspace switch (no cascade suppression)
3. Zoom factor hack redundant with setSize jiggle
4. Removes t=0 synchronous call from `fixAfterStateChange`
5. Removes design rationale comments

## Test plan

- [x] Build AppImage and test on KDE Plasma (stacking WM) — no visible flicker on Alt+Tab
- [ ] Test on Hyprland — same-size workspace switch redraws content
- [ ] Test drag resize — no jitter
- [ ] Test maximize/unmaximize — existing behavior preserved

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
90% AI / 10% Human
Claude: Analysis, plan design (with 2 contrarian passes), implementation, PR review of #333
Human: Testing, plan approval, review direction