### PR TITLE
fix: disable VM file downloads on Linux to prevent checksum loop

### DIFF
--- a/.github/workflows/check-claude-version.yml
+++ b/.github/workflows/check-claude-version.yml
@@ -216,7 +216,7 @@ jobs:
 
       # VM bundle checksums removed — Patch 4 now injects empty linux
       # file arrays since the VM backend is non-functional on Linux.
-      # See: fix/334-empty-vm-manifest for context.
+      # See: #334 for context.
 
       - name: Update Nix package
         if: steps.check_update.outputs.update_needed == 'true'

--- a/build.sh
+++ b/build.sh
@@ -124,7 +124,6 @@ detect_architecture() {
 
 	echo "Target Architecture: $architecture"
 	section_footer 'Architecture Detection'
-
 }
 
 detect_distro() {


### PR DESCRIPTION
## Summary

- **Patch 4** now injects empty file arrays (`linux:{x64:[],arm64:[]}`) instead of copying win32 VM entries with Linux-specific checksums
- Removes all VM checksum infrastructure from `build.sh` and `check-claude-version.yml` (~230 lines deleted)
- Eliminates the entire class of checksum drift bugs (#329, #330, #334)

## Root cause

Patch 1 opens the `yukonSilver` feature gate for Linux, which makes the VM download path (`SBe()`) reachable — even for bwrap users who don't need VM files. The hardcoded checksums then fail validation against CDN content, causing an infinite retry loop.

The triage bot incorrectly concluded bwrap users wouldn't hit this path because it analyzed the *unpatched* upstream code. Confirmed by @cromagnone's logs showing the download loop on a bwrap-only install.

## Why empty arrays are safe

- The VM backend is non-functional on Linux (bwrap is the only working backend)
- `for...of []` is a no-op — no files downloaded
- `[].every()` returns `true` (vacuous truth), so `bO()` reports "Ready" status and `SBe()` short-circuits
- The `linux` key **must exist** to prevent `TypeError` when the app accesses `files["linux"]["x64"]` during cowork status evaluation

## What was removed

| Component | Location | Purpose |
|-----------|----------|---------|
| 6 `vm_checksum_*` variables | `build.sh` `detect_architecture()` | Hardcoded SHA-256 checksums |
| `replaceChecksums()` function | `build.sh` Patch 4 node script | Swapped win32→linux checksums |
| 6 `VM_CS_*` env vars | `build.sh` heredoc invocation | Passed checksums to node |
| "Extract VM bundle SHA" step | `check-claude-version.yml` | Extracted bundle SHA from installer |
| "Compute VM bundle checksums" step | `check-claude-version.yml` | Downloaded ~1GB of VM files to hash |
| "Update build.sh VM checksums" step | `check-claude-version.yml` | Wrote checksums back to build.sh |

## Test plan

- [ ] Verify `shellcheck build.sh` passes clean
- [ ] Verify `actionlint` shows no new warnings on the workflow
- [ ] CI build succeeds
- [ ] On a built package, confirm cowork initializes without download attempts (check `cowork_vm_node.log`)

Fixes #334
Closes #329
Closes #332

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Analysis, implementation, PR
Human: Issue review, direction, approval