### PR TITLE
fix: extract minified vars dynamically in cowork patch 9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -371,6 +371,30 @@ gdbus call --session --dest=org.freedesktop.DBus \
 - SingletonLock: `~/.config/Claude/SingletonLock`
 - Launcher log: `~/.cache/claude-desktop-debian/launcher.log`
 
+## Versioning
+
+Release versions are managed via two GitHub Actions repository variables (not files):
+
+- **`REPO_VERSION`** - The project's own version (e.g., `1.3.23`). Bump this manually via `gh variable set REPO_VERSION --body "X.Y.Z"` when shipping project changes.
+- **`CLAUDE_DESKTOP_VERSION`** - The upstream Claude Desktop version (e.g., `1.1.8629`). Updated automatically by the `check-claude-version` workflow when a new upstream release is detected.
+
+### Tag format
+
+Tags follow the pattern `v{REPO_VERSION}+claude{CLAUDE_DESKTOP_VERSION}`, e.g., `v1.3.23+claude1.1.7714`. Pushing a tag triggers the CI release build.
+
+```bash
+# Check current values
+gh variable get REPO_VERSION
+gh variable get CLAUDE_DESKTOP_VERSION
+
+# Bump repo version and tag a release
+gh variable set REPO_VERSION --body "1.3.24"
+git tag "v1.3.24+claude$(gh variable get CLAUDE_DESKTOP_VERSION)"
+git push origin "v1.3.24+claude$(gh variable get CLAUDE_DESKTOP_VERSION)"
+```
+
+When upstream Claude Desktop updates, the `check-claude-version` workflow automatically updates `CLAUDE_DESKTOP_VERSION`, patches `build.sh` URLs, and creates a new tag — no manual intervention needed.
+
 ## Common Gotchas
 
 - **`.zsync` files** - Used for delta updates, can be ignored/deleted

--- a/build.sh
+++ b/build.sh
@@ -1316,7 +1316,6 @@ if (serviceErrorIdx !== -1) {
             // stream/pipeline var: VAR.pipeline(
             const streamMatch = region.match(/(\w+)\.pipeline\(/);
             // arch function: const VAR=FUNC(), used in smol-bin
-            // Pattern: const LOCALVAR=ARCHFUNC(),LOCALVAR2=PATH.join
             const archMatch = region.match(
                 /const\s+(\w+)\s*=\s*(\w+)\(\)\s*,\s*\w+\s*=\s*\w+\.join/
             );
@@ -1358,13 +1357,8 @@ if (serviceErrorIdx !== -1) {
                 code = code.substring(0, closingBrace + 1) +
                     linuxBlock +
                     code.substring(closingBrace + 1);
-                console.log('  Injected Linux smol-bin copy block' +
-                    ' (skips _.configure)');
-                console.log('    vars: path=' + pathVar +
-                    ' fs=' + fsVar + ' log=' + logVar +
-                    ' stream=' + streamVar +
-                    ' arch=' + archFunc +
-                    ' bundle=' + bundleVar);
+                console.log('  Injected Linux smol-bin copy block (skips _.configure)');
+                console.log(`    vars: path=${pathVar} fs=${fsVar} log=${logVar} stream=${streamVar} arch=${archFunc} bundle=${bundleVar}`);
                 patchCount++;
             } else {
                 const missing = [];
@@ -1374,17 +1368,13 @@ if (serviceErrorIdx !== -1) {
                 if (!streamMatch) missing.push('stream');
                 if (!archMatch) missing.push('arch');
                 if (!bundleMatch) missing.push('bundlePath');
-                console.log('  WARNING: Could not extract' +
-                    ' minified variable(s): ' +
-                    missing.join(', '));
+                console.log(`  WARNING: Could not extract minified variable(s): ${missing.join(', ')}`);
             }
         } else {
-            console.log('  WARNING: Could not find closing' +
-                ' brace after Windows VM service anchor');
+            console.log('  WARNING: Could not find closing brace after Windows VM service anchor');
         }
     } else {
-        console.log('  WARNING: Could not find Windows VM' +
-            ' service anchor for smol-bin patch');
+        console.log('  WARNING: Could not find Windows VM service anchor for smol-bin patch');
     }
 }
 

--- a/build.sh
+++ b/build.sh
@@ -1288,6 +1288,8 @@ if (serviceErrorIdx !== -1) {
 // (Windows HCS setup) which causes "Request timed out" on
 // Linux (#315). Inject a separate Linux block after the win32
 // block that only does the smol-bin copy.
+// Variable names are extracted dynamically from the win32 block
+// since minified names change between releases (#344).
 // ============================================================
 {
     const anchor = '"[VM:start] Windows VM service configured"';
@@ -1296,29 +1298,93 @@ if (serviceErrorIdx !== -1) {
         // Find the "}" closing the win32 if-block after the anchor
         const closingBrace = code.indexOf('}', anchorIdx + anchor.length);
         if (closingBrace !== -1) {
-            // Scope variables: uX()=arch, Qe=path, i=bundlePath,
-            //   ft=fs, vg=stream/pipeline, tt=logger
-            const linuxBlock =
-                'if(process.platform==="linux"){' +
-                'const _la=uX(),' +
-                '_ls=Qe.join(process.resourcesPath,`smol-bin.${_la}.vhdx`),' +
-                '_ld=Qe.join(i,"smol-bin.vhdx");' +
-                'ft.existsSync(_ls)?' +
-                '(tt.info(`[VM:start] Copying smol-bin.${_la}.vhdx to bundle (Linux)`),' +
-                'await vg.pipeline(ft.createReadStream(_ls),ft.createWriteStream(_ld)),' +
-                'tt.info(`[VM:start] smol-bin.${_la}.vhdx copied successfully`))' +
-                ':tt.warn(`[VM:start] smol-bin.${_la}.vhdx not found at ${_ls}`)' +
-                '}';
-            code = code.substring(0, closingBrace + 1) +
-                linuxBlock +
-                code.substring(closingBrace + 1);
-            console.log('  Injected Linux smol-bin copy block (skips _.configure)');
-            patchCount++;
+            // Extract minified variable names from the win32 block
+            // Search backwards from anchor to find the win32 block
+            const regionStart = Math.max(0, anchorIdx - 1000);
+            const region = code.substring(regionStart, anchorIdx);
+
+            // path var: VAR.join(process.resourcesPath,
+            const pathMatch = region.match(
+                /(\w+)\.join\(\s*process\.resourcesPath\s*,/
+            );
+            // fs var: VAR.existsSync(
+            const fsMatch = region.match(/(\w+)\.existsSync\(/);
+            // logger var: VAR.info("[VM:start]
+            const logMatch = region.match(
+                /(\w+)\.info\(\s*[`"]\[VM:start\]/
+            );
+            // stream/pipeline var: VAR.pipeline(
+            const streamMatch = region.match(/(\w+)\.pipeline\(/);
+            // arch function: const VAR=FUNC(), used in smol-bin
+            // Pattern: const LOCALVAR=ARCHFUNC(),LOCALVAR2=PATH.join
+            const archMatch = region.match(
+                /const\s+(\w+)\s*=\s*(\w+)\(\)\s*,\s*\w+\s*=\s*\w+\.join/
+            );
+            // bundlePath var: PATH.join(VAR,"smol-bin.vhdx")
+            const bundleMatch = region.match(
+                /\.join\(\s*(\w+)\s*,\s*"smol-bin\.vhdx"\s*\)/
+            );
+
+            if (pathMatch && fsMatch && logMatch &&
+                streamMatch && archMatch && bundleMatch) {
+                const pathVar = pathMatch[1];
+                const fsVar = fsMatch[1];
+                const logVar = logMatch[1];
+                const streamVar = streamMatch[1];
+                const archFunc = archMatch[2];
+                const bundleVar = bundleMatch[1];
+
+                const linuxBlock =
+                    'if(process.platform==="linux"){' +
+                    'const _la=' + archFunc + '(),' +
+                    '_ls=' + pathVar + '.join(process.resourcesPath,' +
+                        '`smol-bin.${_la}.vhdx`),' +
+                    '_ld=' + pathVar + '.join(' + bundleVar +
+                        ',"smol-bin.vhdx");' +
+                    fsVar + '.existsSync(_ls)?' +
+                    '(' + logVar + '.info(' +
+                        '`[VM:start] Copying smol-bin.${_la}' +
+                        '.vhdx to bundle (Linux)`),' +
+                    'await ' + streamVar + '.pipeline(' +
+                        fsVar + '.createReadStream(_ls),' +
+                        fsVar + '.createWriteStream(_ld)),' +
+                    logVar + '.info(' +
+                        '`[VM:start] smol-bin.${_la}' +
+                        '.vhdx copied successfully`))' +
+                    ':' + logVar + '.warn(' +
+                        '`[VM:start] smol-bin.${_la}' +
+                        '.vhdx not found at ${_ls}`)' +
+                    '}';
+                code = code.substring(0, closingBrace + 1) +
+                    linuxBlock +
+                    code.substring(closingBrace + 1);
+                console.log('  Injected Linux smol-bin copy block' +
+                    ' (skips _.configure)');
+                console.log('    vars: path=' + pathVar +
+                    ' fs=' + fsVar + ' log=' + logVar +
+                    ' stream=' + streamVar +
+                    ' arch=' + archFunc +
+                    ' bundle=' + bundleVar);
+                patchCount++;
+            } else {
+                const missing = [];
+                if (!pathMatch) missing.push('path');
+                if (!fsMatch) missing.push('fs');
+                if (!logMatch) missing.push('logger');
+                if (!streamMatch) missing.push('stream');
+                if (!archMatch) missing.push('arch');
+                if (!bundleMatch) missing.push('bundlePath');
+                console.log('  WARNING: Could not extract' +
+                    ' minified variable(s): ' +
+                    missing.join(', '));
+            }
         } else {
-            console.log('  WARNING: Could not find closing brace after Windows VM service anchor');
+            console.log('  WARNING: Could not find closing' +
+                ' brace after Windows VM service anchor');
         }
     } else {
-        console.log('  WARNING: Could not find Windows VM service anchor for smol-bin patch');
+        console.log('  WARNING: Could not find Windows VM' +
+            ' service anchor for smol-bin patch');
     }
 }
 


### PR DESCRIPTION
## Summary

- Patch 9 (smol-bin VHDX copy for Linux) hardcoded minified variable names (`Qe`, `ft`, `vg`, `tt`, `uX`, `i`) which change between upstream releases, causing `"Qe is not defined"` runtime crashes
- Now extracts all 6 variables dynamically from the win32 block using regex patterns that handle both minified and beautified code
- Adds diagnostic logging of extracted variable names for easier debugging
- Documents repo versioning system (REPO_VERSION/CLAUDE_DESKTOP_VERSION variables and tag format) in CLAUDE.md

Fixes #344

## Test plan

- [x] Built AppImage with `--clean no` — all 8 cowork patches applied successfully
- [x] Verified dynamic extraction matched expected values: `path=Qe fs=ft log=tt stream=vg arch=uX bundle=i`
- [x] Tested regex patterns against both minified (no whitespace) and beautified (newlines + indentation) code with different variable names
- [x] shellcheck clean

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
85% AI / 15% Human
Claude: identified bug, wrote fix with dynamic variable extraction, tested regexes, built AppImage, documented versioning
Human: reported issue context, directed fix approach, requested build validation, reviewed