### PR TITLE
fix: remove self-referential .mcpb-cache symlinks before bwrap mount

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -848,6 +848,22 @@ class BwrapBackend extends LocalBackend {
 
         for (const [mountName, hostPath] of Object.entries(mountMap)) {
             try {
+                // Fix #342: upstream fs-extra can create .mcpb-cache
+                // as a self-referential symlink after repeated sessions.
+                // Detect and remove before mkdir so the bind mount works.
+                try {
+                    const st = fs.lstatSync(hostPath);
+                    if (st.isSymbolicLink()) {
+                        const target = fs.readlinkSync(hostPath);
+                        const resolved = path.resolve(
+                            path.dirname(hostPath), target
+                        );
+                        if (resolved === hostPath) {
+                            log(`BwrapBackend spawn: removing self-referential symlink: ${hostPath}`);
+                            fs.unlinkSync(hostPath);
+                        }
+                    }
+                } catch { /* ENOENT is fine — path doesn't exist yet */ }
                 if (!fs.existsSync(hostPath)) {
                     fs.mkdirSync(hostPath, { recursive: true });
                 }


### PR DESCRIPTION
## Summary

- Upstream fs-extra can replace `.mcpb-cache` directories with self-referential symlinks after repeated Cowork sessions, causing `ELOOP: too many symbolic links encountered` on subsequent launches
- Added detection in `BwrapBackend.spawn()` mount loop: `lstatSync` + `readlinkSync` identifies self-referential symlinks, `unlinkSync` removes them, and the existing `mkdirSync` recreates as a proper directory
- Only targets self-referential symlinks — legitimate symlinks are left alone

Fixes #342

## Test plan

- [x] Built AppImage — patch included in packaged `cowork-vm-service.js`
- [x] Functional test: created self-referential symlink, ran fix logic, confirmed detection → removal → directory recreation
- [x] Verified `existsSync` returns `false` for self-referential symlinks (kernel ELOOP), confirming the old code path would fail at `mkdirSync`

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
90% AI / 10% Human
Claude: investigated upstream source, identified root cause, wrote fix, validated with functional test
Human: directed investigation, reviewed approach