### PR TITLE
fix: default Nix flake to FHS package for NixOS compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           claude-desktop-fhs = pkgs.callPackage ./nix/fhs.nix {
             inherit claude-desktop;
           };
-          default = claude-desktop;
+          default = claude-desktop-fhs;
         };
       };
 


### PR DESCRIPTION
## Summary
- Changes the flake's default package from `claude-desktop` to `claude-desktop-fhs` so NixOS users get a working FHS environment out of the box
- Fixes dynamically linked binaries (like the Cowork CLI) failing with "Could not start dynamically linked executable" on NixOS
- Users on non-NixOS distros can still explicitly use the `claude-desktop` package

Fixes #355

## Test plan
- [ ] NixOS user tests `nix run` with the flake and confirms Cowork CLI launches without linker errors
- [ ] Verify `claude-desktop-fhs` and `claude-desktop` packages are both still accessible as named outputs
- [ ] Verify non-NixOS Nix users can still use `claude-desktop` explicitly

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: investigated issue, analyzed architecture, ran contrarian review, implemented fix, drafted issue comment
Human: directed investigation, reviewed approach, approved fix direction