### PR TITLE
fix: move claude-desktop-fhs to let block so default can reference it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,9 @@
         claude-desktop = pkgs.callPackage ./nix/claude-desktop.nix {
           inherit node-pty;
         };
+        claude-desktop-fhs = pkgs.callPackage ./nix/fhs.nix {
+          inherit claude-desktop;
+        };
       in {
         _module.args.pkgs = import inputs.nixpkgs {
           inherit system;
@@ -24,10 +27,7 @@
         };
 
         packages = {
-          inherit claude-desktop;
-          claude-desktop-fhs = pkgs.callPackage ./nix/fhs.nix {
-            inherit claude-desktop;
-          };
+          inherit claude-desktop claude-desktop-fhs;
           default = claude-desktop-fhs;
         };
       };


### PR DESCRIPTION
## Summary

- The `packages` attrset defined `claude-desktop-fhs` inline and then referenced it as `default = claude-desktop-fhs;`, but without `rec` the name wasn't in scope
- Moved `claude-desktop-fhs` to the `let` block and used `inherit` in `packages`, which is cleaner than adding `rec`

## Test plan

- [ ] `nix build .#claude-desktop` succeeds
- [ ] `nix build .#claude-desktop-fhs` succeeds
- [ ] `nix build` (default) succeeds and produces the FHS package

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: Identified the scoping issue and restructured the let/packages blocks
Human: Identified the bug and requested the fix