### PR TITLE
fix(nix): fix package rename asar

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774701658,
-        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
+        "lastModified": 1774855581,
+        "narHash": "sha256-YkreHeMgTCYvJ5fESV0YyqQK49bHGe2B51tH6claUh4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
+        "rev": "15c6719d8c604779cf59e03c245ea61d3d7ab69b",
         "type": "github"
       },
       "original": {

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -7,7 +7,7 @@
   icoutils,
   imagemagick,
   nodejs,
-  nodePackages,
+  asar,
   makeDesktopItem,
   python3,
   bash,
@@ -61,7 +61,7 @@ stdenvNoCC.mkDerivation {
   nativeBuildInputs = [
     p7zip
     nodejs
-    nodePackages.asar
+    asar
     icoutils
     imagemagick
     bash


### PR DESCRIPTION
# What does this PR do?

Updates nixpkgs and fixe a asar package renaming

# How did I test it?

```bash
nix flake build .#claude-desktop
```
which built successfully. Then I did a little intergration test

```
./results/bin/claude-desktop
```

and I hade claude do a little interactive application using javascript.

<img width="2070" height="1328" alt="image" src="https://github.com/user-attachments/assets/357fcbc0-25ba-4ade-8722-8711eea3964d" />


The package builds successfully.