### PR TITLE
fix(nix): enable isPackaged=true by co-locating Electron binary with app resources

### DIFF
--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -128,8 +128,8 @@ stdenvNoCC.mkDerivation {
     # Symlink everything else from electron-unwrapped
     for item in ${electronDir}/*; do
       name=$(basename "$item")
-      [ "$name" = "electron" ] && continue
-      [ "$name" = "resources" ] && continue
+      [[ "$name" = "electron" ]] && continue
+      [[ "$name" = "resources" ]] && continue
       ln -s "$item" "$electron_tree/$name"
     done
 
@@ -144,20 +144,19 @@ stdenvNoCC.mkDerivation {
 
     # Install tray icons into resources
     for tray_icon in build/electron-app/nix-resources/Tray*; do
-      if [ -f "$tray_icon" ]; then
-        cp "$tray_icon" $electron_tree/resources/
-      fi
+      [[ -f "$tray_icon" ]] && cp "$tray_icon" $electron_tree/resources/
     done
 
     # Install SSH helpers into resources
-    if [ -d build/electron-app/nix-resources/claude-ssh ]; then
-      cp -r build/electron-app/nix-resources/claude-ssh $electron_tree/resources/
+    if [[ -d build/electron-app/nix-resources/claude-ssh ]]; then
+      cp -r build/electron-app/nix-resources/claude-ssh \
+        $electron_tree/resources/
     fi
 
     # Install cowork resources (smol-bin, plugin shim)
     for cowork_res in build/electron-app/nix-resources/smol-bin.*.vhdx \
                       build/electron-app/nix-resources/cowork-plugin-shim.sh; do
-      if [ -f "$cowork_res" ]; then
+      if [[ -f "$cowork_res" ]]; then
         cp "$cowork_res" $electron_tree/resources/
         echo "Installed cowork resource: $(basename "$cowork_res")"
       fi
@@ -165,9 +164,8 @@ stdenvNoCC.mkDerivation {
 
     # Install locale JSON files into resources
     for locale_json in build/claude-extract/lib/net45/resources/*-*.json; do
-      if [ -f "$locale_json" ]; then
-        cp "$locale_json" $electron_tree/resources/
-      fi
+      [[ -f "$locale_json" ]] \
+        && cp "$locale_json" $electron_tree/resources/
     done
 
     # Create the electron wrapper — replicates the env setup from the
@@ -175,7 +173,7 @@ stdenvNoCC.mkDerivation {
     # execs our custom binary.  We extract everything except the final
     # exec line from the stock wrapper, then append our own exec.
     head -n -1 ${electron}/bin/electron > $electron_tree/electron-wrapper
-    echo "exec \"$electron_tree/electron\"  \"\$@\"" >> $electron_tree/electron-wrapper
+    echo "exec \"$electron_tree/electron\" \"\$@\"" >> $electron_tree/electron-wrapper
     chmod +x $electron_tree/electron-wrapper
 
     # Update CHROME_DEVEL_SANDBOX to point to our tree's chrome-sandbox
@@ -188,7 +186,6 @@ stdenvNoCC.mkDerivation {
     #==========================================================================
 
     # Convenience symlink for resources dir (used by launcher, FHS, etc.)
-    mkdir -p $out/lib/claude-desktop
     ln -s $electron_tree/resources $out/lib/claude-desktop/resources
 
     # Install icons
@@ -196,7 +193,7 @@ stdenvNoCC.mkDerivation {
       icon_dir=$out/share/icons/hicolor/"$size"x"$size"/apps
       mkdir -p "$icon_dir"
       icon=$(find build/ -name "claude_*''${size}x''${size}x32.png" 2>/dev/null | head -1)
-      if [ -n "$icon" ]; then
+      if [[ -n "$icon" ]]; then
         install -Dm644 "$icon" "$icon_dir/claude-desktop.png"
       fi
     done

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -42,6 +42,11 @@ let
       && !(lib.hasPrefix "result" rel);
   };
 
+  # The unwrapped electron derivation — contains the real ELF binary
+  # and Chromium resources (.pak files, locales/, etc.).
+  electronUnwrapped = electron.passthru.unwrapped or electron;
+  electronDir = "${electronUnwrapped}/libexec/electron";
+
   desktopItem = makeDesktopItem {
     name = "claude-desktop";
     exec = "claude-desktop %u";
@@ -96,10 +101,95 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    # Install app.asar and unpacked resources
-    mkdir -p $out/lib/claude-desktop/resources
-    cp build/electron-app/app.asar $out/lib/claude-desktop/resources/
-    cp -r build/electron-app/app.asar.unpacked $out/lib/claude-desktop/resources/
+    #==========================================================================
+    # Create a custom Electron tree with app resources co-located.
+    #
+    # On NixOS, the stock electron-unwrapped lives in a read-only store
+    # path.  Chromium computes process.resourcesPath from /proc/self/exe,
+    # so it always points to electron-unwrapped's resources/ dir — which
+    # doesn't contain the app's locale JSONs, tray icons, etc.  When
+    # ELECTRON_FORCE_IS_PACKAGED=true, the app reads en-US.json from
+    # resourcesPath at module load time (before frame-fix-wrapper.js can
+    # correct the path), causing an ENOENT crash.
+    #
+    # Solution: copy the Electron ELF binary into our own tree so that
+    # /proc/self/exe resolves here, then merge both Electron's and the
+    # app's resources into resources/.  Everything else (shared libs,
+    # .pak files, locales/) is symlinked to avoid duplication.
+    #==========================================================================
+    electron_tree=$out/lib/claude-desktop/electron
+
+    mkdir -p $electron_tree/resources
+
+    # Copy the ELF binary — MUST be a real copy (not symlink) so that
+    # /proc/self/exe resolves to our tree
+    cp ${electronDir}/electron $electron_tree/electron
+
+    # Symlink everything else from electron-unwrapped
+    for item in ${electronDir}/*; do
+      name=$(basename "$item")
+      [ "$name" = "electron" ] && continue
+      [ "$name" = "resources" ] && continue
+      ln -s "$item" "$electron_tree/$name"
+    done
+
+    # Populate resources/ — start with Electron's own (default_app.asar)
+    for item in ${electronDir}/resources/*; do
+      ln -s "$item" "$electron_tree/resources/$(basename "$item")"
+    done
+
+    # Install app.asar and unpacked resources into the merged tree
+    cp build/electron-app/app.asar $electron_tree/resources/
+    cp -r build/electron-app/app.asar.unpacked $electron_tree/resources/
+
+    # Install tray icons into resources
+    for tray_icon in build/electron-app/nix-resources/Tray*; do
+      if [ -f "$tray_icon" ]; then
+        cp "$tray_icon" $electron_tree/resources/
+      fi
+    done
+
+    # Install SSH helpers into resources
+    if [ -d build/electron-app/nix-resources/claude-ssh ]; then
+      cp -r build/electron-app/nix-resources/claude-ssh $electron_tree/resources/
+    fi
+
+    # Install cowork resources (smol-bin, plugin shim)
+    for cowork_res in build/electron-app/nix-resources/smol-bin.*.vhdx \
+                      build/electron-app/nix-resources/cowork-plugin-shim.sh; do
+      if [ -f "$cowork_res" ]; then
+        cp "$cowork_res" $electron_tree/resources/
+        echo "Installed cowork resource: $(basename "$cowork_res")"
+      fi
+    done
+
+    # Install locale JSON files into resources
+    for locale_json in build/claude-extract/lib/net45/resources/*-*.json; do
+      if [ -f "$locale_json" ]; then
+        cp "$locale_json" $electron_tree/resources/
+      fi
+    done
+
+    # Create the electron wrapper — replicates the env setup from the
+    # stock electron wrapper (GIO, GTK, GDK_PIXBUF, XDG_DATA_DIRS) but
+    # execs our custom binary.  We extract everything except the final
+    # exec line from the stock wrapper, then append our own exec.
+    head -n -1 ${electron}/bin/electron > $electron_tree/electron-wrapper
+    echo "exec \"$electron_tree/electron\"  \"\$@\"" >> $electron_tree/electron-wrapper
+    chmod +x $electron_tree/electron-wrapper
+
+    # Update CHROME_DEVEL_SANDBOX to point to our tree's chrome-sandbox
+    substituteInPlace $electron_tree/electron-wrapper \
+      --replace-quiet "${electron}/libexec/electron/chrome-sandbox" \
+        "$electron_tree/chrome-sandbox"
+
+    #==========================================================================
+    # Standard install (icons, desktop file, launcher)
+    #==========================================================================
+
+    # Convenience symlink for resources dir (used by launcher, FHS, etc.)
+    mkdir -p $out/lib/claude-desktop
+    ln -s $electron_tree/resources $out/lib/claude-desktop/resources
 
     # Install icons
     for size in 16 24 32 48 64 256; do
@@ -111,35 +201,6 @@ stdenvNoCC.mkDerivation {
       fi
     done
 
-    # Install tray icons into resources
-    for tray_icon in build/electron-app/nix-resources/Tray*; do
-      if [ -f "$tray_icon" ]; then
-        cp "$tray_icon" $out/lib/claude-desktop/resources/
-      fi
-    done
-
-    # Install SSH helpers into resources
-    if [ -d build/electron-app/nix-resources/claude-ssh ]; then
-      cp -r build/electron-app/nix-resources/claude-ssh $out/lib/claude-desktop/resources/
-    fi
-
-    # Install cowork resources (smol-bin, plugin shim)
-    for cowork_res in build/electron-app/nix-resources/smol-bin.*.vhdx \
-                      build/electron-app/nix-resources/cowork-plugin-shim.sh; do
-      if [ -f "$cowork_res" ]; then
-        cp "$cowork_res" $out/lib/claude-desktop/resources/
-        echo "Installed cowork resource: $(basename "$cowork_res")"
-      fi
-    done
-
-    # Install locale JSON files into resources (belt-and-suspenders;
-    # they're also packed inside app.asar at resources/i18n/)
-    for locale_json in build/claude-extract/lib/net45/resources/*-*.json; do
-      if [ -f "$locale_json" ]; then
-        cp "$locale_json" $out/lib/claude-desktop/resources/
-      fi
-    done
-
     # Install shared launcher library
     install -Dm755 ${sourceRoot}/scripts/launcher-common.sh \
       $out/lib/claude-desktop/launcher-common.sh
@@ -148,9 +209,7 @@ stdenvNoCC.mkDerivation {
     mkdir -p $out/share/applications
     install -Dm644 ${desktopItem}/share/applications/* $out/share/applications/
 
-    # Create launcher script (sources launcher-common.sh for --doctor,
-    # CLAUDE_USE_WAYLAND, display detection, and other shared features
-    # — matching the deb/RPM/AppImage launchers)
+    # Create launcher script
     mkdir -p $out/bin
     cat > $out/bin/claude-desktop <<'LAUNCHER'
 #!/usr/bin/env bash
@@ -169,7 +228,7 @@ fi
 
 # Setup logging and environment
 setup_logging || exit 1
-setup_electron_env 'nix'
+setup_electron_env
 cleanup_orphaned_cowork_daemon
 cleanup_stale_lock
 cleanup_stale_cowork_socket
@@ -203,10 +262,11 @@ exit_code=$?
 log_message "Electron exited with code: $exit_code"
 exit $exit_code
 LAUNCHER
-    # Substitute placeholders with Nix store paths
+    # Substitute placeholders — electron_exec points to our custom
+    # wrapper (which sets GTK/GIO env then execs our merged binary)
     substituteInPlace $out/bin/claude-desktop \
-      --replace-fail "ELECTRON_PLACEHOLDER" "${electron}/bin/electron" \
-      --replace-fail "RESOURCES_PLACEHOLDER" "$out/lib/claude-desktop/resources" \
+      --replace-fail "ELECTRON_PLACEHOLDER" "$electron_tree/electron-wrapper" \
+      --replace-fail "RESOURCES_PLACEHOLDER" "$electron_tree/resources" \
       --replace-fail "LAUNCHER_LIB_PLACEHOLDER" "$out/lib/claude-desktop/launcher-common.sh"
     chmod +x $out/bin/claude-desktop
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -178,21 +178,13 @@ cleanup_stale_cowork_socket() {
 }
 
 # Set common environment variables
-# Arguments: $1 = package type ("deb", "appimage", "rpm", or "nix")
 setup_electron_env() {
-	local package_type="${1:-deb}"
-
 	# ELECTRON_FORCE_IS_PACKAGED makes app.isPackaged return true, which
 	# causes the Claude app to resolve resources via process.resourcesPath.
-	# On NixOS, Electron is a separate store path so resourcesPath points
-	# to Electron's resources dir, not the app's.  The frame-fix-wrapper
-	# corrects this at JS load time, but some app code may run before the
-	# fix or cache the original value.  Skipping this env var for Nix
-	# keeps isPackaged=false, using development-style fallback paths that
-	# work correctly with NixOS's split-package layout.
-	if [[ $package_type != 'nix' ]]; then
-		export ELECTRON_FORCE_IS_PACKAGED=true
-	fi
+	# The Nix derivation creates a custom Electron tree with the binary
+	# copied and app resources co-located in resources/, so resourcesPath
+	# naturally points to the right place on all package types.
+	export ELECTRON_FORCE_IS_PACKAGED=true
 	export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 }
 


### PR DESCRIPTION
## Summary

- Creates a custom Electron tree in the Nix derivation that copies the ELF binary and merges app resources (locale JSONs, tray icons, cowork files) into the adjacent `resources/` directory
- Symlinks everything else from `electron-unwrapped` to avoid duplicating ~150MB of shared libs, `.pak` files, and locales
- Enables `ELECTRON_FORCE_IS_PACKAGED=true` unconditionally for all package types, removing the NixOS special case that kept it running in development mode
- Generates the electron wrapper from the stock wrapper script to preserve GIO/GTK/GDK environment setup

### Why

On NixOS, Electron and the app live in separate Nix store paths. When `ELECTRON_FORCE_IS_PACKAGED=true`, the app reads `en-US.json` from `process.resourcesPath` at module load time — before `frame-fix-wrapper.js` can correct the path. Since `resourcesPath` is computed from `/proc/self/exe` (which resolves to `electron-unwrapped`'s store path), the locale files aren't found and the app crashes with ENOENT.

The previous workaround skipped `ELECTRON_FORCE_IS_PACKAGED=true` for Nix builds, which meant NixOS users ran with `isPackaged=false` — causing debug-level logging, exposed debug IPC endpoints, and different URL validation behavior.

### How it was verified

Tested in a Fedora 42 distrobox with the Nix package manager:

1. **Baseline (current main, `isPackaged=false`):** App starts but runs in development mode
2. **Current main + `isPackaged=true`:** Crashes with `ENOENT: no such file or directory, open '.../electron-unwrapped-.../resources/en-US.json'`
3. **This PR (`isPackaged=true` + co-located binary):** App starts successfully — BrowserWindow created, navigates to `claude.ai`, DatadogRUM initialized

Both `nix build .#claude-desktop` and `nix build .#claude-desktop-fhs` succeed.

### Tradeoff

The Electron ELF binary (~210MB) is copied rather than symlinked, adding one copy to the Nix store. This is necessary because `/proc/self/exe` resolves symlinks — a symlinked binary would still resolve to `electron-unwrapped`'s store path. All other files (shared libraries, `.pak` locales, license files) remain symlinked.

Fixes #316

## Test plan

- [ ] Verify `nix build .#claude-desktop` succeeds
- [ ] Verify `nix build .#claude-desktop-fhs` succeeds  
- [ ] Verify the native package starts with `isPackaged=true` on NixOS (needs NixOS tester)
- [ ] Verify no regression on deb/AppImage/RPM builds (`setup_electron_env` signature change)
- [ ] Verify `--doctor` still works on NixOS

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
85% AI / 15% Human
Claude: Research, contrarian analysis, distrobox testing, implementation, and PR
Human: Direction, approach decisions, and review