### PR TITLE
fix: patch hardcoded CLI path in LocalAgentMode sessions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1322,9 +1322,35 @@ if (serviceErrorIdx !== -1) {
     }
 }
 
+// ============================================================
+// Patch 10: LocalAgentMode CLI path — use dynamic resolution
+// LocalAgentModeSessionManager hardcodes /usr/local/bin/claude
+// which doesn't exist on Linux. Replace with dynamic resolution
+// using the same CcdBinaryManager singleton regular sessions use.
+// ============================================================
+{
+    const binaryMgrMatch = code.match(/(\w+)\.getBinaryPathIfReady/);
+    if (binaryMgrMatch) {
+        const mgr = binaryMgrMatch[1];
+        const hardcoded = 'pathToClaudeCodeExecutable:"/usr/local/bin/claude"';
+        const replacement = 'pathToClaudeCodeExecutable:' +
+            '(await ' + mgr + '.getHostBinaryPathIfPresent())||' +
+            '"/usr/local/bin/claude"';
+        if (code.includes(hardcoded)) {
+            code = code.replace(hardcoded, replacement);
+            console.log('  Patched LocalAgentMode hardcoded CLI path');
+            patchCount++;
+        } else {
+            console.log('  WARNING: LocalAgentMode hardcoded CLI path not found');
+        }
+    } else {
+        console.log('  WARNING: Could not find CcdBinaryManager variable');
+    }
+}
+
 fs.writeFileSync(indexJs, code);
 console.log(`  Applied ${patchCount} cowork patches`);
-if (patchCount < 5) {
+if (patchCount < 6) {
     console.log('  WARNING: Some patches failed - Cowork mode may not work');
 }
 COWORK_PATCH


### PR DESCRIPTION
## Summary

- **Patch 10** replaces the hardcoded `/usr/local/bin/claude` path in `LocalAgentModeSessionManager` with a dynamic call to `CcdBinaryManager.getHostBinaryPathIfPresent()`
- Extracts the minified singleton variable name dynamically via the `getBinaryPathIfReady` method anchor
- Falls back to `/usr/local/bin/claude` if resolution fails
- Bumps minimum expected patch count from 5 to 6

Fixes #375

## Root cause

`LocalAgentModeSessionManager` (Cowork bwrap sessions) builds the SDK config with `pathToClaudeCodeExecutable: "/usr/local/bin/claude"` hardcoded. Unlike regular sessions, it never calls `applyFreshBinaryPath()` to resolve the binary dynamically. On Linux the CLI lives at `~/.config/Claude/claude-code/<version>/claude`, so the hardcoded path fails.

## Test plan

- [x] `./build.sh --build deb --clean no` — patch applies: `Patched LocalAgentMode hardcoded CLI path`
- [x] Extracted asar confirms replacement: `pathToClaudeCodeExecutable:(await ac.getHostBinaryPathIfPresent())||"/usr/local/bin/claude"`
- [x] Installed deb, started Cowork session — agent mode works

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
90% AI / 10% Human
Claude: investigation, patch implementation, issue creation, PR
Human: testing, validation, direction