### PR TITLE
fix: move --dir $HOME before --ro-bind sdkDir in bwrap sandbox

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -857,14 +857,16 @@ class BwrapBackend extends LocalBackend {
             log('BwrapBackend: could not resolve /etc/resolv.conf:', e.message);
         }
 
+        // Create home directory (needed for ~ expansion) but don't
+        // expose real home contents. Must come before any --ro-bind of
+        // subdirectories inside $HOME (e.g. the SDK binary path), otherwise
+        // bwrap processes --dir after the bind and shadows it.
+        const homeDir = os.homedir();
+        bwrapArgs.push('--dir', homeDir);
+
         // Bind the SDK binary read-only
         const sdkDir = path.dirname(actualCommand);
         bwrapArgs.push('--ro-bind', sdkDir, sdkDir);
-
-        // Create home directory (needed for ~ expansion) but don't
-        // expose real home contents.
-        const homeDir = os.homedir();
-        bwrapArgs.push('--dir', homeDir);
 
         // Create /sessions/<name>/mnt/ guest path structure and mount
         // host directories at guest paths, matching the KVM backend


### PR DESCRIPTION
## Summary

**Bug**: When starting a new Cowork conversation, such an error appeared.
```
bwrap: execvp /home/.../.config/Claude/claude-code-vm/.../claude: No such file or directory
```

- bwrap processes mount args in order — when the SDK binary lives under `$HOME` (e.g. `~/.config/Claude/claude-code-vm/`), the `--ro-bind` of its parent directory was being added **before** `--dir $HOME`
- The later `--dir` wiped out the bind mount, causing `bwrap: execvp /home/.../.config/Claude/claude-code-vm/.../claude: No such file or directory`
- Fix: move `--dir $HOME` first so the home skeleton exists before subdirectory bind mounts are layered on top