### PR TITLE
fix: translate CLAUDE_COWORK_MEMORY_PATH_OVERRIDE on HostBackend

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -228,8 +228,8 @@ function buildMountMap(additionalMounts, mountBinds) {
 
 /**
  * Build a merged environment for a spawned process. Combines filtered
- * daemon env with app-provided env, and translates CLAUDE_CONFIG_DIR
- * guest paths using mountMap.
+ * daemon env with app-provided env, and translates guest paths in
+ * CLAUDE_CONFIG_DIR and CLAUDE_COWORK_MEMORY_PATH_OVERRIDE using mountMap.
  */
 function buildSpawnEnv(appEnv, mountMap) {
     const mergedEnv = {
@@ -266,6 +266,44 @@ function buildSpawnEnv(appEnv, mountMap) {
         }
     }
 
+
+    // Translate CLAUDE_COWORK_MEMORY_PATH_OVERRIDE from guest path to
+    // host path. The Electron app sets this to /sessions/{id}/mnt/.auto-memory
+    // regardless of backend, but on HostBackend the /sessions/ directory
+    // does not exist. Try translateGuestPath first (works if .auto-memory
+    // is in mountMap via additionalMounts), then fall back to resolving
+    // the mount-name portion the way HostBackend.mountPath() would —
+    // via resolveSubpath() — so the path resolves to a writable host
+    // location (typically ~/.auto-memory).
+    if (mergedEnv.CLAUDE_COWORK_MEMORY_PATH_OVERRIDE) {
+        const memPath = mergedEnv.CLAUDE_COWORK_MEMORY_PATH_OVERRIDE;
+        if (memPath.startsWith('/sessions/')) {
+            const translated = translateGuestPath(memPath, mountMap);
+            if (translated) {
+                log(`buildSpawnEnv: translated CLAUDE_COWORK_MEMORY_PATH_OVERRIDE: ${memPath} -> ${translated}`);
+                mergedEnv.CLAUDE_COWORK_MEMORY_PATH_OVERRIDE = translated;
+            } else {
+                // .auto-memory is an internal Cowork path typically not
+                // present in additionalMounts. Extract the mount-name
+                // (and any trailing subpath) and resolve via
+                // resolveSubpath, mirroring HostBackend.mountPath().
+                const match = memPath.match(
+                    /^\/sessions\/[^/]+\/mnt\/([^/]+)(\/.*)?$/
+                );
+                if (match) {
+                    const hostPath = path.join(
+                        resolveSubpath(match[1]),
+                        match[2] || ''
+                    );
+                    log(`buildSpawnEnv: resolved CLAUDE_COWORK_MEMORY_PATH_OVERRIDE via fallback: ${memPath} -> ${hostPath}`);
+                    mergedEnv.CLAUDE_COWORK_MEMORY_PATH_OVERRIDE = hostPath;
+                } else {
+                    log(`buildSpawnEnv: could not translate CLAUDE_COWORK_MEMORY_PATH_OVERRIDE, removing: ${memPath}`);
+                    delete mergedEnv.CLAUDE_COWORK_MEMORY_PATH_OVERRIDE;
+                }
+            }
+        }
+    }
     return mergedEnv;
 }
 


### PR DESCRIPTION
## Summary

`buildSpawnEnv()` translates `CLAUDE_CONFIG_DIR` from `/sessions/` guest paths to host paths, but `CLAUDE_COWORK_MEMORY_PATH_OVERRIDE` passes through untranslated. On HostBackend, the `/sessions/` directory does not exist, so the auto-memory path points to a non-existent location and memory writes silently fail.

**Observed behavior:** `CLAUDE_COWORK_MEMORY_PATH_OVERRIDE` is set to `/sessions/eager-affectionate-ramanujan/mnt/.auto-memory` on a `COWORK_VM_BACKEND=host` system. The `/sessions/` directory doesn't exist. Auto-memory persistence is broken — writes fail with `EACCES: permission denied, mkdir '/sessions'`.

**Root cause:** Same pattern as #373 — the Electron app constructs guest paths regardless of backend, and the service needs to translate them. `CLAUDE_CONFIG_DIR` was already handled; `CLAUDE_COWORK_MEMORY_PATH_OVERRIDE` was missed.

## Fix

Adds guest-path translation for `CLAUDE_COWORK_MEMORY_PATH_OVERRIDE` in `buildSpawnEnv()`:

1. **Try `translateGuestPath()`** — works if `.auto-memory` is in `mountMap` via `additionalMounts`
2. **Fall back to `resolveSubpath()`** on the mount-name portion, mirroring what `HostBackend.mountPath()` would return (typically `~/.auto-memory`)
3. **Remove the env var** if neither translation succeeds, so Claude Code falls back to default memory behavior

BwrapBackend is unaffected — it overrides `spawn()` with its own env construction and `/sessions/` paths are real inside the sandbox.

## Test plan

- Verify on a `COWORK_VM_BACKEND=host` system that `CLAUDE_COWORK_MEMORY_PATH_OVERRIDE` resolves to `~/.auto-memory` (or the appropriate host path)
- Verify auto-memory writes succeed after the fix
- Verify BwrapBackend behavior is unchanged (no `/sessions/` translation in its spawn path)

## Environment

- CachyOS (Arch-based), native host backend
- Claude Desktop AppImage
- Diagnosed via `env | grep CLAUDE_COWORK_MEMORY_PATH_OVERRIDE` showing the untranslated `/sessions/` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)