### PR TITLE
fix: resolve working directory from primary mount on HostBackend

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -227,6 +227,23 @@ function buildMountMap(additionalMounts, mountBinds) {
 }
 
 /**
+ * Find the primary user mount name in mountMap — the first key that
+ * is not a dotfile mount (e.g. .claude, .auto-memory) and not the
+ * uploads mount. Used by both resolveWorkDir (HostBackend) and
+ * BwrapBackend.spawn to derive a sensible cwd from the user-selected
+ * project folder when the Electron app sends a session-root path with
+ * no /mnt/{name} component to translate.
+ *
+ * Returns the mount name (string) or null if no user mount exists.
+ */
+function findPrimaryMount(mountMap) {
+    if (!mountMap) return null;
+    return Object.keys(mountMap).find(
+        n => !n.startsWith('.') && n !== 'uploads',
+    ) || null;
+}
+
+/**
  * Build a merged environment for a spawned process. Combines filtered
  * daemon env with app-provided env, and translates guest paths in
  * CLAUDE_CONFIG_DIR and CLAUDE_COWORK_MEMORY_PATH_OVERRIDE using mountMap.
@@ -395,11 +412,8 @@ function resolveWorkDir(cwd, sharedCwdPath, mountMap) {
             // Session-root path (e.g. /sessions/bold-sharp-clarke) has no
             // /mnt/ component, so translateGuestPath can't resolve it.
             // Derive cwd from the primary user mount, mirroring what
-            // BwrapBackend does at spawn time (first non-dotfile,
-            // non-uploads mount).
-            const primaryMount = Object.keys(mountMap || {}).find(
-                n => !n.startsWith('.') && n !== 'uploads',
-            );
+            // BwrapBackend does at spawn time.
+            const primaryMount = findPrimaryMount(mountMap);
             if (primaryMount && mountMap[primaryMount]) {
                 log(`resolveWorkDir: session root "${cwd}", using primary mount "${primaryMount}" -> "${mountMap[primaryMount]}"`);
                 workDir = mountMap[primaryMount];
@@ -1158,9 +1172,7 @@ class BwrapBackend extends LocalBackend {
         );
 
         // Use the primary user mount as cwd (first non-dotfile, non-uploads mount)
-        const primaryMount = Object.keys(mountMap).find(
-            n => !n.startsWith('.') && n !== 'uploads',
-        );
+        const primaryMount = findPrimaryMount(mountMap);
         const guestWorkDir = primaryMount
             ? `${sessionMnt}/${primaryMount}`
             : sessionMnt;

--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -392,8 +392,21 @@ function resolveWorkDir(cwd, sharedCwdPath, mountMap) {
             log(`resolveWorkDir: translated "${cwd}" -> "${translated}"`);
             workDir = translated;
         } else {
-            log(`resolveWorkDir: cwd is VM guest path "${cwd}", using home dir`);
-            workDir = os.homedir();
+            // Session-root path (e.g. /sessions/bold-sharp-clarke) has no
+            // /mnt/ component, so translateGuestPath can't resolve it.
+            // Derive cwd from the primary user mount, mirroring what
+            // BwrapBackend does at spawn time (first non-dotfile,
+            // non-uploads mount).
+            const primaryMount = Object.keys(mountMap || {}).find(
+                n => !n.startsWith('.') && n !== 'uploads',
+            );
+            if (primaryMount && mountMap[primaryMount]) {
+                log(`resolveWorkDir: session root "${cwd}", using primary mount "${primaryMount}" -> "${mountMap[primaryMount]}"`);
+                workDir = mountMap[primaryMount];
+            } else {
+                log(`resolveWorkDir: cwd is VM guest path "${cwd}", no primary mount found, using home dir`);
+                workDir = os.homedir();
+            }
         }
     }
 

--- a/tests/cowork-path-translation.bats
+++ b/tests/cowork-path-translation.bats
@@ -125,6 +125,13 @@ function cleanSpawnArgs(rawArgs, mountMap) {
     return cleanArgs;
 }
 
+function findPrimaryMount(mountMap) {
+    if (!mountMap) return null;
+    return Object.keys(mountMap).find(
+        n => !n.startsWith(".") && n !== "uploads",
+    ) || null;
+}
+
 function resolveWorkDir(cwd, sharedCwdPath, mountMap) {
     let workDir = cwd || os.homedir();
     if (sharedCwdPath) {
@@ -134,7 +141,12 @@ function resolveWorkDir(cwd, sharedCwdPath, mountMap) {
         if (translated) {
             workDir = translated;
         } else {
-            workDir = os.homedir();
+            const primaryMount = findPrimaryMount(mountMap);
+            if (primaryMount && mountMap[primaryMount]) {
+                workDir = mountMap[primaryMount];
+            } else {
+                workDir = os.homedir();
+            }
         }
     }
     if (!fs.existsSync(workDir)) {
@@ -707,6 +719,110 @@ assertEqual(
     resolveWorkDir('/tmp', null, {}),
     '/tmp',
     'local path passthrough');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "resolveWorkDir: session-root cwd uses primary user mount" {
+	mkdir -p "${TEST_TMP}/project"
+
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    resolveWorkDir(
+        '/sessions/bold-sharp-clarke',
+        null,
+        {'project': '${TEST_TMP}/project'}
+    ),
+    '${TEST_TMP}/project',
+    'session-root falls through to primary mount');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "resolveWorkDir: session-root cwd skips dotfile and uploads mounts" {
+	mkdir -p "${TEST_TMP}/project"
+
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    resolveWorkDir(
+        '/sessions/abc',
+        null,
+        {
+            '.claude': '${TEST_TMP}/dotclaude',
+            '.auto-memory': '${TEST_TMP}/automem',
+            'uploads': '${TEST_TMP}/uploads',
+            'project': '${TEST_TMP}/project'
+        }
+    ),
+    '${TEST_TMP}/project',
+    'dotfile and uploads mounts are skipped');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "resolveWorkDir: session-root cwd with no user mount falls back to home" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    resolveWorkDir(
+        '/sessions/abc',
+        null,
+        {
+            '.claude': '/host/dotclaude',
+            'uploads': '/host/uploads'
+        }
+    ),
+    os.homedir(),
+    'no user mount -> homedir fallback');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# findPrimaryMount
+# =============================================================================
+
+@test "findPrimaryMount: returns null for null mountMap" {
+	run node -e "${NODE_PREAMBLE}
+assert(findPrimaryMount(null) === null, 'null mountMap');
+assert(findPrimaryMount(undefined) === null, 'undefined mountMap');
+assert(findPrimaryMount({}) === null, 'empty mountMap');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "findPrimaryMount: returns first non-dotfile non-uploads key" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    findPrimaryMount({'project': '/h/p'}),
+    'project',
+    'single user mount');
+assertEqual(
+    findPrimaryMount({
+        '.claude': '/h/c',
+        'uploads': '/h/u',
+        'project': '/h/p'
+    }),
+    'project',
+    'skips dotfiles and uploads');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "findPrimaryMount: returns null when all mounts are dotfiles or uploads" {
+	run node -e "${NODE_PREAMBLE}
+assert(
+    findPrimaryMount({'.claude': '/h/c', 'uploads': '/h/u'}) === null,
+    'no user mount -> null');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "findPrimaryMount: insertion order determines primary when multiple exist" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    findPrimaryMount({'first': '/h/1', 'second': '/h/2'}),
+    'first',
+    'first inserted user mount wins');
 "
 	[[ "$status" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

- On HostBackend, `resolveWorkDir()` falls back to `os.homedir()` for every Cowork session because the Electron app sends `cwd=/sessions/{name}` (a session-root guest path) and `translateGuestPath()` requires `/sessions/{name}/mnt/{mount}/...` — the session root never matches.
- This means Claude Code always starts in `~` instead of the user's project directory, breaking file access and CLAUDE.md auto-load (issue #245).
- The fix adds primary-mount derivation (mirroring BwrapBackend's existing logic) as a fallback before resorting to homedir.

Related: #245 (umbrella), #389 (sibling fix for `CLAUDE_COWORK_MEMORY_PATH_OVERRIDE`).

## Root Cause

`translateGuestPath()` uses a regex that requires a `/mnt/{mount}` component in the path. Session-root paths like `/sessions/bold-sharp-clarke` don't have one, so translation always fails. BwrapBackend avoids this by overriding `spawn()` with its own CWD derivation from the primary user mount. HostBackend goes through `resolveWorkDir()` which lacked equivalent logic.

## The Fix

When `translateGuestPath()` can't resolve the cwd, derive the working directory from the primary user mount (first non-dotfile, non-uploads key in `mountMap`) — the same heuristic BwrapBackend uses. Falls back to homedir only when no user mount exists.

The logic is now in a shared `findPrimaryMount(mountMap)` helper used by both `resolveWorkDir()` and `BwrapBackend.spawn()`, so the two call sites can't drift.

### Behavior shift beyond the stated case

The new fallback also fires when the cwd takes the form `/sessions/{id}/mnt/unknown` — where the path *is* shaped correctly but the mount name isn't in `mountMap` (translation fails on the mount-name lookup, not the regex). Previously these landed in `~`; they now land in the primary mount. This is intentional and consistent with what BwrapBackend would do.

## Verification

Tested with a Node.js harness simulating exact spawn parameters from live session logs:

| Scenario | Before | After |
|---|---|---|
| Session root + user mount | `~/` (bug) | `/home/user/project/` (correct) |
| Session root + no user mount | `~/` | `~/` (correct fallback) |
| Session root + only dotfile/uploads mounts | `~/` | `~/` (correct fallback) |
| `/mnt/unknown` mount-name miss | `~/` | primary mount (intentional shift) |
| Full guest mount path | Translated correctly | Unchanged |
| Host path passthrough | Passed through | Unchanged |
| `sharedCwdPath` precedence | Takes precedence | Unchanged |

BATS coverage in `tests/cowork-path-translation.bats`:
- 3 new `resolveWorkDir` cases for the primary-mount fallback paths
- 4 new `findPrimaryMount` cases covering null/empty input, mount-class filtering, and ordering

## Test plan

- [ ] Start a Cowork session via Projects sidebar → verify Claude Code CWD is the project directory, not `~/`
- [ ] Start a Cowork session via "New task" → verify same behavior
- [ ] Start a session with no folder selected → verify graceful fallback to homedir
- [ ] Run `bats tests/cowork-path-translation.bats` → all `resolveWorkDir` and `findPrimaryMount` cases pass

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6, Claude Opus 4 <noreply@anthropic.com>
40% AI / 60% Human
Claude: diagnosed the bug, implemented the fix, refactored the shared helper, wrote BATS tests, drafted PR description
Human: identified the symptom, validated the diagnosis against live daemon logs, designed the contribution sequence