### PR TITLE
fix: export GDK_BACKEND=wayland in native Wayland mode

### DIFF
--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -88,6 +88,10 @@ build_electron_args() {
 		electron_args+=('--ozone-platform=wayland')
 		electron_args+=('--enable-wayland-ime')
 		electron_args+=('--wayland-text-input-version=3')
+		# Override any system-wide GDK_BACKEND=x11 that would silently
+		# prevent GTK from connecting to the Wayland compositor, causing
+		# blurry rendering or launch failures on HiDPI displays.
+		export GDK_BACKEND=wayland
 	fi
 }
 


### PR DESCRIPTION
## Problem

When the launcher runs in native Wayland mode (`CLAUDE_USE_WAYLAND=1` or forced by compositor), it sets the correct Electron ozone flags (`--ozone-platform=wayland` etc.) but never exports `GDK_BACKEND`. A system-wide or session-level `GDK_BACKEND=x11` then silently overrides the intent, causing GTK to connect via XWayland and producing blurry rendering — notably on HiDPI displays.

## Fix

Export `GDK_BACKEND=wayland` in the native Wayland branch of `build_electron_args()` so the ozone flags and GDK backend stay in sync.

## Scope

Single-line change. No behaviour change for XWayland mode or X11 sessions.