### PR TITLE
fix: gate quick window patch to KDE sessions only (#393)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -938,25 +938,28 @@ patch_quick_window() {
 	local quick_var_re="${quick_var//\$/\\$}"
 
 	# Part 1: Add blur() before hide() on the quick window so that
-	# isFocused() returns false after hiding (Electron Linux bug).
+	# isFocused() returns false after hiding (Electron Linux bug on KDE).
 	# The hide call sits after || (e.g. GUARD()||VAR.hide()), so both
 	# calls must be wrapped in parens to preserve short-circuit semantics.
-	if grep -qP "${quick_var_re}\.blur\(\),${quick_var_re}\.hide\(\)" \
-		"$index_js"; then
+	# Gated to KDE only: on GNOME/Ubuntu the blur() regresses quick entry
+	# (see #393), and the focus-stale bug doesn't manifest there.
+	local de_check='(process.env.XDG_CURRENT_DESKTOP||"").toLowerCase().includes("kde")'
+	if grep -qF "${quick_var}.blur(),${quick_var}.hide()" "$index_js"; then
 		echo '  Quick window blur already patched'
 	elif grep -qP "\|\|${quick_var_re}\.hide\(\)" "$index_js"; then
 		sed -i \
-			"s/||${quick_var_re}\.hide()/||(${quick_var_re}.blur(),${quick_var_re}.hide())/g" \
+			"s/||${quick_var_re}\.hide()/||(${de_check}?(${quick_var}.blur(),${quick_var}.hide()):${quick_var}.hide())/g" \
 			"$index_js"
-		echo '  Added blur() before hide() on quick window'
+		echo '  Added KDE-gated blur() before hide() on quick window'
 	else
 		echo '  WARNING: Could not find quick window hide() call'
 	fi
 
 	# Part 2: Fix main window not appearing after quick entry submit.
-	# On Linux, isFocused() can return stale true after hiding, causing
-	# FOCUS_CHECK()||Lt.show() to skip the show. Replace the focus check
-	# with the visibility check in quick entry code paths.
+	# On KDE, isFocused() can return stale true after hiding, causing
+	# FOCUS_CHECK()||Lt.show() to skip the show. Gate the visibility-check
+	# replacement to KDE only: on GNOME, the original focus check works
+	# and replacing it regresses quick entry (see #393).
 	if INDEX_JS="$index_js" node << 'QUICK_WINDOW_PATCH'
 const fs = require('fs');
 const indexJs = process.env.INDEX_JS;
@@ -1000,6 +1003,12 @@ for (const anchor of anchors) {
     }
     // Search region after anchor (1500 chars covers promise chains)
     const region = code.substring(anchorIdx, anchorIdx + 1500);
+    // Idempotency: if region already contains the DE gate, skip
+    if (region.indexOf('XDG_CURRENT_DESKTOP') !== -1) {
+        console.log('  Quick entry show() already patched near "' +
+            anchor.substring(0, 30) + '..."');
+        continue;
+    }
     const showRe = new RegExp(
         focusFn.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
         '\\(\\)\\|\\|(\\w+)\\.show\\(\\)'
@@ -1008,12 +1017,17 @@ for (const anchor of anchors) {
     if (showMatch) {
         const oldStr = showMatch[0];
         const mainWin = showMatch[1];
-        const newStr = visFn + '()||' + mainWin + '.show()';
+        // Gate the visibility check to KDE only; fall back to original
+        // focus check on GNOME/other so #390 doesn't regress them (#393).
+        const deCheck = '(process.env.XDG_CURRENT_DESKTOP||"")' +
+            '.toLowerCase().includes("kde")';
+        const newStr = '(' + deCheck + '?' + visFn + '():' +
+            focusFn + '())||' + mainWin + '.show()';
         if (oldStr !== newStr) {
             const absIdx = anchorIdx + region.indexOf(oldStr);
             code = code.substring(0, absIdx) + newStr +
                 code.substring(absIdx + oldStr.length);
-            console.log('  Replaced ' + focusFn + '() with ' + visFn +
+            console.log('  KDE-gated ' + focusFn + '()/' + visFn +
                 '() for show() near "' + anchor.substring(0, 30) + '..."');
             patchCount++;
         }

--- a/build.sh
+++ b/build.sh
@@ -943,7 +943,8 @@ patch_quick_window() {
 	# calls must be wrapped in parens to preserve short-circuit semantics.
 	# Gated to KDE only: on GNOME/Ubuntu the blur() regresses quick entry
 	# (see #393), and the focus-stale bug doesn't manifest there.
-	local de_check='(process.env.XDG_CURRENT_DESKTOP||"").toLowerCase().includes("kde")'
+	local de_check='(process.env.XDG_CURRENT_DESKTOP||"")'
+	de_check+='.toLowerCase().includes("kde")'
 	if grep -qF "${quick_var}.blur(),${quick_var}.hide()" "$index_js"; then
 		echo '  Quick window blur already patched'
 	elif grep -qP "\|\|${quick_var_re}\.hide\(\)" "$index_js"; then


### PR DESCRIPTION
## Summary

- PR #390 fixed quick entry on KDE but regressed GNOME/Ubuntu (#393)
- @Andrej730 confirmed removing `patch_quick_window` restores quick entry on Ubuntu 24.04
- Without a GNOME repro yet, gate both halves of the patch behind a runtime `XDG_CURRENT_DESKTOP` check — apply on KDE, fall back to upstream behavior elsewhere

The gate is a minimum-viable fix to unbreak GNOME/Ubuntu users today while the full bisect happens in VMs. Once the VM work isolates which half actually regresses GNOME, we can narrow the gate to just that half.

## What changed in `build.sh:patch_quick_window()`

**Part 1 — blur() before hide()** now wraps in a ternary:
```js
||((process.env.XDG_CURRENT_DESKTOP||"").toLowerCase().includes("kde")
    ? (Q.blur(), Q.hide())
    : Q.hide())
```

**Part 2 — focus/visibility swap** also KDE-gated:
```js
((process.env.XDG_CURRENT_DESKTOP||"").toLowerCase().includes("kde")
    ? visFn()
    : focusFn())
||mainWin.show()
```

**Idempotency:** added `XDG_CURRENT_DESKTOP` substring pre-check in the node block so re-runs skip cleanly. Part 1's existing grep check still works because `Q.blur(),Q.hide()` appears inside the ternary literally.

## Test plan

- [x] `bash -n build.sh` clean
- [x] `shellcheck` clean on the changed region
- [x] Local AppImage build succeeds, patch log confirms `Added KDE-gated blur()` and `KDE-gated _2()/X5e()` lines
- [ ] Manual test on Nobara/KDE: quick entry submit still opens main window (PR #390 behavior preserved)
- [ ] Manual test on Ubuntu 24.04 VM: quick entry works (falls through to upstream behavior)
- [ ] Manual test on Fedora 43 GNOME VM
- [ ] Manual test on Fedora 43 KDE VM

Refs #393, #370, #404

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
60% AI / 40% Human
Claude: Drafted the DE-gating strategy, wrote the build.sh changes, ran syntax/lint/build checks
Human: Directed the MVP approach (gate vs. full bisect), caught scope/wording, will do manual VM testing