### PR TITLE
fix: translate guest paths inside --allowedTools / --disallowedTools

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -308,20 +308,90 @@ function buildSpawnEnv(appEnv, mountMap) {
 }
 
 /**
+ * Split a CSV --allowedTools / --disallowedTools value into entries
+ * while respecting parentheses. Tool patterns may legitimately contain
+ * commas inside parens (e.g. "Bash(npm test, npm build)"), so a naive
+ * split on "," would corrupt them. Returns an array of entries with no
+ * trimming applied.
+ */
+function splitToolList(csv) {
+    const result = [];
+    if (!csv) return result;
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < csv.length; i++) {
+        const ch = csv[i];
+        if (ch === '(') depth++;
+        else if (ch === ')') depth = Math.max(0, depth - 1);
+        else if (ch === ',' && depth === 0) {
+            result.push(csv.slice(start, i));
+            start = i + 1;
+        }
+    }
+    result.push(csv.slice(start));
+    return result;
+}
+
+/**
+ * Translate VM guest paths embedded inside a CSV tool-permission
+ * string (e.g. --allowedTools value). Each entry is either "Tool"
+ * (passed through) or "Tool(pattern)" (pattern is translated if it
+ * looks like a /sessions/ guest path). Entries whose guest path can't
+ * be mapped to a host path are dropped — a permission rule that
+ * can never match is worse than absent.
+ *
+ * Defensively normalizes leading double slashes (the Electron app
+ * emits "//sessions/..." due to an upstream path.join('/', ...) on an
+ * already-absolute path).
+ */
+function translateEmbeddedGuestPaths(csv, mountMap) {
+    if (!csv) return csv;
+    const out = [];
+    for (const entry of splitToolList(csv)) {
+        const m = entry.match(/^(\w+)\(([^)]+)\)$/);
+        if (!m) {
+            out.push(entry);
+            continue;
+        }
+        const tool = m[1];
+        const normalized = m[2].replace(/^\/+/, '/');
+        if (!normalized.startsWith('/sessions/')) {
+            out.push(entry);
+            continue;
+        }
+        const translated = translateGuestPath(normalized, mountMap || {});
+        if (!translated) {
+            log(`translateEmbeddedGuestPaths: dropping "${entry}" (no host mapping)`);
+            continue;
+        }
+        log(`translateEmbeddedGuestPaths: ${entry} -> ${tool}(${translated})`);
+        out.push(`${tool}(${translated})`);
+    }
+    return out.join(',');
+}
+
+/**
  * Translate args that reference VM guest paths (/sessions/...) to host
- * paths using mountMap. If translation fails, the flag pair is removed.
+ * paths using mountMap. Two flag styles are handled:
+ *   - Single-path flags (--add-dir, --plugin-dir): the value is one
+ *     guest path. Translation failure drops the whole flag pair.
+ *   - Tool-list flags (--allowedTools, --disallowedTools): the value
+ *     is a CSV of "Tool" or "Tool(pattern)" entries. Each entry is
+ *     translated independently; entries that fail are dropped from
+ *     the CSV but the flag itself is retained.
  */
 function cleanSpawnArgs(rawArgs, mountMap) {
     const cleanArgs = [];
     const guestPathFlags = new Set(['--add-dir', '--plugin-dir']);
+    const toolListFlags = new Set(['--allowedTools', '--disallowedTools']);
     for (let i = 0; i < rawArgs.length; i++) {
-        if (guestPathFlags.has(rawArgs[i]) &&
+        const flag = rawArgs[i];
+        const value = rawArgs[i + 1];
+
+        if (guestPathFlags.has(flag) &&
             i + 1 < rawArgs.length &&
-            rawArgs[i + 1].startsWith('/sessions/')) {
-            const flag = rawArgs[i];
-            let hostPath = translateGuestPath(
-                rawArgs[i + 1], mountMap
-            );
+            value.startsWith('/sessions/')) {
+            let hostPath = translateGuestPath(value, mountMap);
             if (hostPath) {
                 // --plugin-dir needs the plugin root, not a skills/
                 // subdirectory — walk up to find it.
@@ -330,15 +400,25 @@ function cleanSpawnArgs(rawArgs, mountMap) {
                         hostPath, os.homedir()
                     );
                 }
-                log(`cleanSpawnArgs: translated ${flag} ${rawArgs[i + 1]} -> ${hostPath}`);
+                log(`cleanSpawnArgs: translated ${flag} ${value} -> ${hostPath}`);
                 cleanArgs.push(flag, hostPath);
             } else {
-                log(`cleanSpawnArgs: removing ${flag} ${rawArgs[i + 1]} (no host mapping)`);
+                log(`cleanSpawnArgs: removing ${flag} ${value} (no host mapping)`);
             }
             i++;
             continue;
         }
-        cleanArgs.push(rawArgs[i]);
+
+        if (toolListFlags.has(flag) && i + 1 < rawArgs.length) {
+            cleanArgs.push(
+                flag,
+                translateEmbeddedGuestPaths(value, mountMap),
+            );
+            i++;
+            continue;
+        }
+
+        cleanArgs.push(flag);
     }
     return cleanArgs;
 }

--- a/tests/cowork-path-translation.bats
+++ b/tests/cowork-path-translation.bats
@@ -96,17 +96,58 @@ function resolvePluginRoot(pluginPath, mountBase) {
     return pluginPath;
 }
 
+function splitToolList(csv) {
+    const result = [];
+    if (!csv) return result;
+    let depth = 0;
+    let start = 0;
+    for (let i = 0; i < csv.length; i++) {
+        const ch = csv[i];
+        if (ch === "(") depth++;
+        else if (ch === ")") depth = Math.max(0, depth - 1);
+        else if (ch === "," && depth === 0) {
+            result.push(csv.slice(start, i));
+            start = i + 1;
+        }
+    }
+    result.push(csv.slice(start));
+    return result;
+}
+
+function translateEmbeddedGuestPaths(csv, mountMap) {
+    if (!csv) return csv;
+    const out = [];
+    for (const entry of splitToolList(csv)) {
+        const m = entry.match(/^(\w+)\(([^)]+)\)$/);
+        if (!m) {
+            out.push(entry);
+            continue;
+        }
+        const tool = m[1];
+        const normalized = m[2].replace(/^\/+/, "/");
+        if (!normalized.startsWith("/sessions/")) {
+            out.push(entry);
+            continue;
+        }
+        const translated = translateGuestPath(normalized, mountMap || {});
+        if (!translated) continue;
+        out.push(`${tool}(${translated})`);
+    }
+    return out.join(",");
+}
+
 function cleanSpawnArgs(rawArgs, mountMap) {
     const cleanArgs = [];
     const guestPathFlags = new Set(["--add-dir", "--plugin-dir"]);
+    const toolListFlags = new Set(["--allowedTools", "--disallowedTools"]);
     for (let i = 0; i < rawArgs.length; i++) {
-        if (guestPathFlags.has(rawArgs[i]) &&
+        const flag = rawArgs[i];
+        const value = rawArgs[i + 1];
+
+        if (guestPathFlags.has(flag) &&
             i + 1 < rawArgs.length &&
-            rawArgs[i + 1].startsWith("/sessions/")) {
-            const flag = rawArgs[i];
-            let hostPath = translateGuestPath(
-                rawArgs[i + 1], mountMap || {}
-            );
+            value.startsWith("/sessions/")) {
+            let hostPath = translateGuestPath(value, mountMap || {});
             if (hostPath) {
                 if (flag === "--plugin-dir") {
                     hostPath = resolvePluginRoot(
@@ -120,7 +161,17 @@ function cleanSpawnArgs(rawArgs, mountMap) {
             i++;
             continue;
         }
-        cleanArgs.push(rawArgs[i]);
+
+        if (toolListFlags.has(flag) && i + 1 < rawArgs.length) {
+            cleanArgs.push(
+                flag,
+                translateEmbeddedGuestPaths(value, mountMap),
+            );
+            i++;
+            continue;
+        }
+
+        cleanArgs.push(flag);
     }
     return cleanArgs;
 }
@@ -536,6 +587,177 @@ const result = cleanSpawnArgs(
 assertDeepEqual(result,
     ['--verbose', '--add-dir', '/host/data/x', '--output', 'json'],
     'surrounding args preserved');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "cleanSpawnArgs: translates --allowedTools embedded guest paths" {
+	run node -e "${NODE_PREAMBLE}
+const result = cleanSpawnArgs(
+    [
+        '--allowedTools',
+        'Read,Edit,Edit(//sessions/abc/mnt/.auto-memory/**),Write(//sessions/abc/mnt/.auto-memory/**)'
+    ],
+    {'.auto-memory': '/host/memory'}
+);
+assertDeepEqual(result,
+    [
+        '--allowedTools',
+        'Read,Edit,Edit(/host/memory/**),Write(/host/memory/**)'
+    ],
+    '--allowedTools translated, plain entries preserved');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "cleanSpawnArgs: translates --disallowedTools embedded guest paths" {
+	run node -e "${NODE_PREAMBLE}
+const result = cleanSpawnArgs(
+    [
+        '--disallowedTools',
+        'Bash(rm),Edit(//sessions/abc/mnt/data/secret/**)'
+    ],
+    {'data': '/host/data'}
+);
+assertDeepEqual(result,
+    [
+        '--disallowedTools',
+        'Bash(rm),Edit(/host/data/secret/**)'
+    ],
+    '--disallowedTools translated');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# splitToolList
+# =============================================================================
+
+@test "splitToolList: empty / null input" {
+	run node -e "${NODE_PREAMBLE}
+assertDeepEqual(splitToolList(''), [], 'empty string -> []');
+assertDeepEqual(splitToolList(null), [], 'null -> []');
+assertDeepEqual(splitToolList(undefined), [], 'undefined -> []');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "splitToolList: simple CSV with no parens" {
+	run node -e "${NODE_PREAMBLE}
+assertDeepEqual(
+    splitToolList('Read,Edit,Write'),
+    ['Read', 'Edit', 'Write'],
+    'plain CSV');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "splitToolList: respects parentheses around commas" {
+	run node -e "${NODE_PREAMBLE}
+assertDeepEqual(
+    splitToolList('Bash(npm test, npm build),Edit,Read'),
+    ['Bash(npm test, npm build)', 'Edit', 'Read'],
+    'commas inside parens are preserved');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "splitToolList: handles trailing entry without comma" {
+	run node -e "${NODE_PREAMBLE}
+assertDeepEqual(
+    splitToolList('A,B(c,d)'),
+    ['A', 'B(c,d)'],
+    'final entry includes nested commas');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# translateEmbeddedGuestPaths
+# =============================================================================
+
+@test "translateEmbeddedGuestPaths: passes through entries without parens" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    translateEmbeddedGuestPaths(
+        'Read,Edit,Write',
+        {'.auto-memory': '/host/memory'}
+    ),
+    'Read,Edit,Write',
+    'plain tool names unchanged');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "translateEmbeddedGuestPaths: translates Edit() with double-slash guest path" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    translateEmbeddedGuestPaths(
+        'Edit(//sessions/abc/mnt/.auto-memory/**)',
+        {'.auto-memory': '/host/memory'}
+    ),
+    'Edit(/host/memory/**)',
+    'leading // normalized and translated');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "translateEmbeddedGuestPaths: translates entry with single-slash guest path" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    translateEmbeddedGuestPaths(
+        'Write(/sessions/abc/mnt/.auto-memory/**)',
+        {'.auto-memory': '/host/memory'}
+    ),
+    'Write(/host/memory/**)',
+    'single-slash variant also translated');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "translateEmbeddedGuestPaths: drops entries whose mount is unknown" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    translateEmbeddedGuestPaths(
+        'Read,Edit(//sessions/abc/mnt/unknown/**),Write',
+        {'.auto-memory': '/host/memory'}
+    ),
+    'Read,Write',
+    'unresolvable entry is dropped, others retained');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "translateEmbeddedGuestPaths: leaves non-/sessions paths alone" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    translateEmbeddedGuestPaths(
+        'Bash(rm),Edit(/home/user/explicit/file)',
+        {'.auto-memory': '/host/memory'}
+    ),
+    'Bash(rm),Edit(/home/user/explicit/file)',
+    'host paths and non-paths unchanged');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "translateEmbeddedGuestPaths: handles MCP-style tool names with underscores" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(
+    translateEmbeddedGuestPaths(
+        'mcp__server__tool(//sessions/abc/mnt/data/**)',
+        {'data': '/host/data'}
+    ),
+    'mcp__server__tool(/host/data/**)',
+    'mcp-style tool name preserved');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "translateEmbeddedGuestPaths: empty / null input" {
+	run node -e "${NODE_PREAMBLE}
+assertEqual(translateEmbeddedGuestPaths('', {}), '', 'empty -> empty');
+assertEqual(translateEmbeddedGuestPaths(null, {}), null, 'null -> null');
 "
 	[[ "$status" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

`cleanSpawnArgs` only translated `--add-dir` and `--plugin-dir` flag pairs. The Electron app emits permission patterns inside the single comma-separated `--allowedTools` value:

```
--allowedTools "Task,Bash,Glob,...,Edit(//sessions/{name}/mnt/.auto-memory/**),Write(//sessions/{name}/mnt/.auto-memory/**)"
```

Those `Edit(...)` and `Write(...)` patterns reach the spawned `claude` CLI verbatim. Permission rules referencing non-existent guest paths cannot match the real on-disk locations, so auto-memory grants silently no-op even after #389 made the underlying path resolvable and #392 fixes the cwd resolution.

Confirmed in live daemon logs (`~/.config/Claude/logs/cowork_vm_daemon.log`) — every Cowork session on HostBackend has the same untranslated `Edit(//sessions/.../**)` / `Write(//sessions/.../**)` entries.

Related: #245 (umbrella), #389 (sibling — `CLAUDE_COWORK_MEMORY_PATH_OVERRIDE`), #392 (sibling — cwd resolution).

## The Fix

Two new helpers in `scripts/cowork-vm-service.js`:

**`splitToolList(csv)`** — paren-aware split so `Bash(npm test, npm build)` is one entry rather than two. Returns the array of raw entries.

**`translateEmbeddedGuestPaths(csv, mountMap)`** — walks each entry:
- `Tool` (no parens) → passed through unchanged.
- `Tool(pattern)` → if `pattern` looks like a `/sessions/` guest path, translate it; otherwise pass through.
- Defensively normalizes leading `//` (the Electron app emits double slashes via `path.join('/', '/sessions/...')` on an already-absolute path).
- Entries whose mount can't be resolved are **dropped** from the CSV (a permission rule that can never match is worse than absent). The flag itself is retained.

`cleanSpawnArgs` now recognizes `--allowedTools` and `--disallowedTools` as "tool-list flags" alongside the existing single-path flags. Single-path behavior is unchanged.

## Verification

Local Node.js harness (mirroring the BATS suite) confirms:

| Input | Output |
|---|---|
| `Read,Edit,Write` | `Read,Edit,Write` |
| `Edit(//sessions/abc/mnt/.auto-memory/**)` (real format) | `Edit(/host/memory/**)` |
| `Write(/sessions/abc/mnt/.auto-memory/**)` (single-slash) | `Write(/host/memory/**)` |
| `Read,Edit(//sessions/abc/mnt/unknown/**),Write` | `Read,Write` |
| `Bash(rm),Edit(/home/user/explicit/file)` | passthrough |
| `mcp__server__tool(//sessions/abc/mnt/data/**)` | `mcp__server__tool(/host/data/**)` |

BATS coverage in `tests/cowork-path-translation.bats`:
- `splitToolList`: 4 cases (empty/null, plain CSV, paren-nested commas, trailing nested entry)
- `translateEmbeddedGuestPaths`: 7 cases (passthrough, double-slash, single-slash, drop-on-miss, host-path passthrough, mcp__ tool names, empty/null)
- `cleanSpawnArgs`: 2 new cases (`--allowedTools` integration, `--disallowedTools` integration)

## Test plan

- [ ] Build and run a Cowork session
- [ ] Watch `~/.config/Claude/logs/cowork_vm_daemon.log` — `--allowedTools` entries should be translated to host paths instead of `//sessions/...`
- [ ] In the session, ask Claude Code to write to `.auto-memory/foo.md` — should succeed without permission prompts
- [ ] Run `bats tests/cowork-path-translation.bats`

## Out of scope

- Translating `--mcp-config`, `--settings`, etc. — no current evidence in logs.
- Recursively scanning arbitrary env vars beyond the two already handled in `buildSpawnEnv`.
- Fixing the upstream `//sessions/` double-slash artifact — defensive normalization in the new helper handles it without us touching the Electron side.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>
40% AI / 60% Human
Claude: identified the gap from live daemon logs while reviewing #392, designed the helpers, implemented and tested the change, drafted the PR description
Human: framed the contribution sequence, validated the diagnosis against the bigger #245 picture