### PR TITLE
fix: capture $-prefixed minified names in Patch 9 (#413)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1432,25 +1432,31 @@ if (serviceErrorIdx !== -1) {
             const regionStart = Math.max(0, anchorIdx - 1000);
             const region = code.substring(regionStart, anchorIdx);
 
+            // JS identifiers can start with $ (e.g. "$e"). Regex \w
+            // does not include $, so use [\w$] to capture minified
+            // names like $e, $$, _$a, etc. Without this, a var like
+            // "$e.existsSync(" gets captured as "e", pointing us at
+            // an unrelated in-scope variable and producing
+            // "e.existsSync is not a function" at runtime (#413).
             // path var: VAR.join(process.resourcesPath,
             const pathMatch = region.match(
-                /(\w+)\.join\(\s*process\.resourcesPath\s*,/
+                /([\w$]+)\.join\(\s*process\.resourcesPath\s*,/
             );
             // fs var: VAR.existsSync(
-            const fsMatch = region.match(/(\w+)\.existsSync\(/);
+            const fsMatch = region.match(/([\w$]+)\.existsSync\(/);
             // logger var: VAR.info("[VM:start]
             const logMatch = region.match(
-                /(\w+)\.info\(\s*[`"]\[VM:start\]/
+                /([\w$]+)\.info\(\s*[`"]\[VM:start\]/
             );
             // stream/pipeline var: VAR.pipeline(
-            const streamMatch = region.match(/(\w+)\.pipeline\(/);
+            const streamMatch = region.match(/([\w$]+)\.pipeline\(/);
             // arch function: const VAR=FUNC(), used in smol-bin
             const archMatch = region.match(
-                /const\s+(\w+)\s*=\s*(\w+)\(\)\s*,\s*\w+\s*=\s*\w+\.join/
+                /const\s+([\w$]+)\s*=\s*([\w$]+)\(\)\s*,\s*[\w$]+\s*=\s*[\w$]+\.join/
             );
             // bundlePath var: PATH.join(VAR,"smol-bin.vhdx")
             const bundleMatch = region.match(
-                /\.join\(\s*(\w+)\s*,\s*"smol-bin\.vhdx"\s*\)/
+                /\.join\(\s*([\w$]+)\s*,\s*"smol-bin\.vhdx"\s*\)/
             );
 
             if (pathMatch && fsMatch && logMatch &&


### PR DESCRIPTION
## Summary

Fixes #413 — workspace startup failing with `e.existsSync is not a function` on 1.3109.0.

Patch 9 (the Linux smol-bin copy block in `patch_app_linux()`) extracts minified variable names from the upstream win32 block and re-uses them in an injected Linux block. The extraction regexes used `\w+`, which in JS regex is `[A-Za-z0-9_]` — **it does not include `$`**. The 1.3109.0 minifier bound the `fs` module to `$e`; our regex `(\w+)\.existsSync\(` matched `$e.existsSync(` but captured only the trailing `e`. The injected Linux block then called `e.existsSync(_ls)`, where `e` resolves to an unrelated in-scope function parameter, raising the TypeError and aborting VM startup.

Other patches in `build.sh` already use `\$?\w+` when grepping for minified identifiers (e.g. the tray/theme/frame patches) for exactly this reason — Patch 9 just never got the memo. Swapping all six name-capture regexes in the block to `[\w$]+` makes them match `$`-prefixed identifiers correctly, with a comment explaining the gotcha and referencing the issue.

## Reproduction

Before the fix, on 1.3109.0:

```js
// Our regex capture
buggy regex fsVar = "e"   // wrong — "e" is an outer-fn param, not fs
fixed regex fsVar = "$e"  // correct — fs module
```

The resulting win32 vs injected Linux blocks in `.vite/build/index.js`:

```js
// Win32 (upstream, correct)
if (\$e.existsSync(U)) { await SL.pipeline(\$e.createReadStream(U), SX(J)) }

// Linux (our injection, broken)
\$e.existsSync(_ls) ? ... // was e.existsSync(_ls) → TypeError
```

## After the fix

Build log shows `fs=\$e` in the extraction report:

```
Injected Linux smol-bin copy block (skips _.configure)
  vars: path=ae fs=\$e log=qe stream=SL arch=Bre bundle=r
```

Runtime on my workstation (1.3109.0, host backend):

```
[VM:start] Copying smol-bin.x64.vhdx to bundle (Linux)
[VM:start] smol-bin.x64.vhdx copied successfully
[VM:start] Startup complete, total time: 1048ms
```

Full Cowork session then spawned, ran to completion, exited code=0.

## Test plan

- [x] Rebuild AppImage on 1.3109.0 and verify Patch 9 log reports `fs=\$e`
- [x] Verify injected Linux block in built `app.asar` uses `\$e.existsSync` / `\$e.createReadStream` / `\$e.createWriteStream`
- [x] Launch built AppImage and start a Cowork workspace — confirmed no `e.existsSync is not a function`, VM:start completes, Cowork session spawns successfully
- [ ] Verify on ARM64 build (haven't tested, should be the same code path)

---

Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
20% AI / 80% Human
Claude: diagnosed the `\w` vs `$` regex gap by comparing buggy capture against the live minified source, patched the six regexes, rebuilt and verified
Human: spotted the new issue #413, recognized it as a build-level bug rather than runtime, directed the investigation, tested the rebuilt AppImage end-to-end