### PR TITLE
Fix cowork patch regexes to match dollar-prefixed minified vars

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1434,23 +1434,23 @@ if (serviceErrorIdx !== -1) {
 
             // path var: VAR.join(process.resourcesPath,
             const pathMatch = region.match(
-                /(\w+)\.join\(\s*process\.resourcesPath\s*,/
+                /(\$?\w+)\.join\(\s*process\.resourcesPath\s*,/
             );
             // fs var: VAR.existsSync(
-            const fsMatch = region.match(/(\w+)\.existsSync\(/);
+            const fsMatch = region.match(/(\$?\w+)\.existsSync\(/);
             // logger var: VAR.info("[VM:start]
             const logMatch = region.match(
-                /(\w+)\.info\(\s*[`"]\[VM:start\]/
+                /(\$?\w+)\.info\(\s*[`"]\[VM:start\]/
             );
             // stream/pipeline var: VAR.pipeline(
-            const streamMatch = region.match(/(\w+)\.pipeline\(/);
+            const streamMatch = region.match(/(\$?\w+)\.pipeline\(/);
             // arch function: const VAR=FUNC(), used in smol-bin
             const archMatch = region.match(
-                /const\s+(\w+)\s*=\s*(\w+)\(\)\s*,\s*\w+\s*=\s*\w+\.join/
+                /const\s+(\$?\w+)\s*=\s*(\$?\w+)\(\)\s*,\s*\$?\w+\s*=\s*\$?\w+\.join/
             );
             // bundlePath var: PATH.join(VAR,"smol-bin.vhdx")
             const bundleMatch = region.match(
-                /\.join\(\s*(\w+)\s*,\s*"smol-bin\.vhdx"\s*\)/
+                /\.join\(\s*(\$?\w+)\s*,\s*"smol-bin\.vhdx"\s*\)/
             );
 
             if (pathMatch && fsMatch && logMatch &&


### PR DESCRIPTION
## What this fixes

In Claude Desktop 1.3109.0 (and presumably later releases with the same minification pattern), `patch_cowork_linux()` fails to correctly extract the minified `fs` variable name from the upstream Vite bundle, producing an `app.asar` where the injected Linux `smol-bin` copy block calls `e.existsSync(...)` on the enclosing function's options parameter instead of on `fs`. The Cowork tab then fails to start with:

```
TypeError: existsSync is not a function
```

in the UI, and

```
Cannot read properties of undefined (reading 'existsSync')
    at xTr (...app.asar/.vite/build/index.js:1897:4165)
```

in the launcher log.

## Root cause

Six regexes on lines 1437-1453 of `build.sh` use `\w+` to capture minified variable names. `\w+` only matches `[A-Za-z0-9_]`. In 1.3109.0, Vite binds `fs` as `$e`; the `$` is skipped by `\w+` and the capture returns only `e`, which is the options parameter of the enclosing `async function xTr(e, A, t, i)`.

## Fix

Change `\w+` to `\$?\w+` in all six variable-extraction regexes so a leading `$` is captured as part of the identifier. This is backwards-compatible: non-dollar-prefixed variables continue to match unchanged.

## Verification

Built and installed on an arm64 Raspberry Pi 5, Debian Trixie, upstream Claude Desktop 1.3109.0. Build log now reports:

```
vars: path=ae fs=$e log=qe stream=SL arch=Bre bundle=r
Injected Linux smol-bin copy block (skips _.configure)
```

Note `fs=$e` rather than the previous `fs=e`. After install, the Cowork tab loads and functions normally; no further `existsSync` errors appear in the launcher log.

## Scope

This patch only touches the six regexes in `patch_cowork_linux()`. It does not address the secondary `C.getAppInfoForFile is not a function` that appears elsewhere in the UI log — that is a separate unrelated issue.

## Credit

Root cause and the one-character fix were diagnosed by the repo's `github-actions` triage bot in a comment on issue #417. This PR implements that diagnosis.

Fixes #417