### PR TITLE
build.sh: improve regexp quick window patch regexp readibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Special thanks to:
 - **[davidamacey](https://github.com/davidamacey)** for identifying and fixing the XRDP GPU compositing blank-window issue on remote desktop sessions
 - **[pb3ck](https://github.com/pb3ck)** for diagnosing the Cowork `CLAUDE_CODE_OAUTH_TOKEN` env-strip bug with a working reference diff
 - **[aJV99](https://github.com/aJV99)** for exporting `GDK_BACKEND=wayland` in native Wayland mode to fix XWayland fallback blur on HiDPI displays
+- **[Andrej730](https://github.com/Andrej730)** for the quick-window regex readability refactor (`String.raw` + `escapeRegExp` helper)
 
 ## Sponsorship
 

--- a/scripts/patches/quick-window.sh
+++ b/scripts/patches/quick-window.sh
@@ -84,6 +84,7 @@ const anchors = [
     'Navigating to existing chat',
     'Creating new chat with submit_quick_entry',
 ];
+const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 for (const anchor of anchors) {
     const anchorIdx = code.indexOf(anchor);
     if (anchorIdx === -1) {
@@ -98,9 +99,9 @@ for (const anchor of anchors) {
             anchor.substring(0, 30) + '..."');
         continue;
     }
+    // matches: <focusFn>()||(someVar).show()
     const showRe = new RegExp(
-        focusFn.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
-        '\\(\\)\\|\\|(\\w+)\\.show\\(\\)'
+        escapeRegExp(focusFn) + String.raw`\(\)\|\|(\w+)\.show\(\)`
     );
     const showMatch = region.match(showRe);
     if (showMatch) {


### PR DESCRIPTION
@aaddrick

A small change to make regexps more readable.
Wanted to also use `RegExp.escape`, but it's only available in node 24+, so just moved existing regexp to a separate function `escapeRegExp`.