### PR TITLE
fix: cowork existsSync crash on 1.3109+ and unblock node-pty terminal

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1432,25 +1432,29 @@ if (serviceErrorIdx !== -1) {
             const regionStart = Math.max(0, anchorIdx - 1000);
             const region = code.substring(regionStart, anchorIdx);
 
+            // JS identifier may start with $, _, or letter; \w doesn't
+            // match $ so use [$\w]+ to capture vars like `$e` (Claude
+            // >= 1.3109.0 uses $e for the fs module to avoid collision
+            // with the parameter `e`). See issue #418.
             // path var: VAR.join(process.resourcesPath,
             const pathMatch = region.match(
-                /(\w+)\.join\(\s*process\.resourcesPath\s*,/
+                /([$\w]+)\.join\(\s*process\.resourcesPath\s*,/
             );
             // fs var: VAR.existsSync(
-            const fsMatch = region.match(/(\w+)\.existsSync\(/);
+            const fsMatch = region.match(/([$\w]+)\.existsSync\(/);
             // logger var: VAR.info("[VM:start]
             const logMatch = region.match(
-                /(\w+)\.info\(\s*[`"]\[VM:start\]/
+                /([$\w]+)\.info\(\s*[`"]\[VM:start\]/
             );
             // stream/pipeline var: VAR.pipeline(
-            const streamMatch = region.match(/(\w+)\.pipeline\(/);
+            const streamMatch = region.match(/([$\w]+)\.pipeline\(/);
             // arch function: const VAR=FUNC(), used in smol-bin
             const archMatch = region.match(
-                /const\s+(\w+)\s*=\s*(\w+)\(\)\s*,\s*\w+\s*=\s*\w+\.join/
+                /const\s+([$\w]+)\s*=\s*([$\w]+)\(\)\s*,\s*[$\w]+\s*=\s*[$\w]+\.join/
             );
             // bundlePath var: PATH.join(VAR,"smol-bin.vhdx")
             const bundleMatch = region.match(
-                /\.join\(\s*(\w+)\s*,\s*"smol-bin\.vhdx"\s*\)/
+                /\.join\(\s*([$\w]+)\s*,\s*"smol-bin\.vhdx"\s*\)/
             );
 
             if (pathMatch && fsMatch && logMatch &&
@@ -1483,9 +1487,34 @@ if (serviceErrorIdx !== -1) {
                         '`[VM:start] smol-bin.${_la}' +
                         '.vhdx not found at ${_ls}`)' +
                     '}';
-                code = code.substring(0, closingBrace + 1) +
+                // Defensive: if a future upstream emits its own
+                // if(process.platform==="linux"){...} block right
+                // after the win32 close brace, strip it before
+                // injecting our correctly-wired linuxBlock so we
+                // don't end up with two competing blocks.
+                const insertPos = closingBrace + 1;
+                let stripUntil = insertPos;
+                const afterWin32 = code.substring(insertPos);
+                const upstreamRe = /^\s*if\s*\(\s*process\.platform\s*===\s*"linux"\s*\)\s*\{/;
+                const upstreamMatch = afterWin32.match(upstreamRe);
+                if (upstreamMatch) {
+                    const matchEnd = insertPos + upstreamMatch[0].length;
+                    let depth = 1, pos = matchEnd;
+                    while (depth > 0 && pos < code.length) {
+                        if (code[pos] === '{') depth++;
+                        else if (code[pos] === '}') depth--;
+                        pos++;
+                    }
+                    if (depth === 0) {
+                        stripUntil = pos;
+                        console.log('  Stripped pre-existing upstream Linux block');
+                    } else {
+                        console.log('  WARNING: Upstream Linux block found but braces unbalanced; not stripping');
+                    }
+                }
+                code = code.substring(0, insertPos) +
                     linuxBlock +
-                    code.substring(closingBrace + 1);
+                    code.substring(stripUntil);
                 console.log('  Injected Linux smol-bin copy block (skips _.configure)');
                 console.log(`    vars: path=${pathVar} fs=${fsVar} log=${logVar} stream=${streamVar} arch=${archFunc} bundle=${bundleVar}`);
                 patchCount++;

--- a/build.sh
+++ b/build.sh
@@ -1634,6 +1634,18 @@ install_node_pty() {
 			"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
 		cp "$pty_src_dir/package.json" \
 			"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
+		# Also stage build/ so `asar pack --unpack '**/*.node'` can
+		# create a properly-tracked .unpacked entry. Without this,
+		# the asar manifest has no node-pty/build/ entry and
+		# Electron's asar->.unpacked redirect never fires, so
+		# require('../build/Release/pty.node') from inside the asar
+		# fails with MODULE_NOT_FOUND even when the binary exists
+		# in app.asar.unpacked/.
+		if [[ -d $pty_src_dir/build ]]; then
+			cp -r "$pty_src_dir/build" \
+				"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
+			echo 'node-pty build/ staged (will be unpacked during asar pack)'
+		fi
 		echo 'node-pty JavaScript files copied'
 	elif [[ -z $pty_src_dir ]]; then
 		echo 'node-pty source directory not set'
@@ -1646,7 +1658,13 @@ install_node_pty() {
 }
 
 finalize_app_asar() {
-	"$asar_exec" pack app.asar.contents app.asar || exit 1
+	# Pack with --unpack so native modules (.node) are extracted
+	# into app.asar.unpacked/ AND tracked in the asar manifest as
+	# unpacked. Electron's asar->.unpacked redirect requires the
+	# manifest entry to exist; otherwise loaders that require()
+	# files from inside the asar get MODULE_NOT_FOUND.
+	"$asar_exec" pack app.asar.contents app.asar \
+		--unpack '**/*.node' || exit 1
 
 	mkdir -p "$app_staging_dir/app.asar.unpacked/node_modules/@ant/claude-native" || exit 1
 	cp "$source_dir/scripts/claude-native-stub.js" \


### PR DESCRIPTION
Two independent Linux bugs surfaced while debugging Cowork on Claude Desktop 1.3109.0 (Pop!_OS 24.04, amd64). Both fixed and verified end-to-end on my machine.

## Bug 1: `TypeError: e.existsSync is not a function` on Cowork VM boot

**Issue:** #418

`patch_cowork_linux()` Patch 9 extracts six minified variable names from the win32 block and uses them to template a Linux smol-bin copy block. The extraction regexes used `(\w+)`, which doesn't match `$` — but JS identifiers can start with `$`, `_`, or a letter.

In Claude 1.3109.0, upstream renamed the local fs reference inside `startVM`'s win32 block from `e` to `$e`, presumably to avoid shadowing the function parameter `e` (which is the options object):

```js
// Win32 block in 1.3109.0 (excerpt)
if (process.platform === "win32") {
    const x = Bre(), U = ae.join(process.resourcesPath, `smol-bin.${x}.vhdx`), J = ae.join(r, "smol-bin.vhdx");
    if ($e.existsSync(U)) {                       // <-- fs is $e, not e
        await SL.pipeline($e.createReadStream(U), SX(J))
        ...
    }
}
```

The existing `(\w+)\.existsSync\(` regex scans `$e.existsSync(U)`, skips the `$`, captures just `e`, and Patch 9 then injects:

```js
if (process.platform === "linux") {
    ...
    e.existsSync(_ls) ? ... : ...   // e is the options object → TypeError
}
```

The "patch's injection works in 1.2773 but breaks in 1.3109" pattern is exactly this. There's no upstream Linux block to strip — the buggy block we've all been hitting **is the patcher's own injection**, made buggy by the regex missing `$`.

**Fix:** widen all six extraction patterns from `(\w+)` to `([$\w]+)`. Also widened the adjacent unanchored matchers in `archMatch` for consistency.

**Defensive bonus:** added a brace-counting strip step before injection, so if a future upstream version emits its own `if(process.platform==="linux"){...}` block right after the win32 close brace, we remove it before injecting our correctly-wired version. No-op on current upstream; future-proofing.

**Verified:** clean rebuild now logs `vars: path=ae fs=$e log=qe stream=SL arch=Bre bundle=r` and the asar's injected block contains `$e.existsSync(_ls)`. Cowork starts cleanly: `[VM:start] Startup complete, total time: 1242ms`, the VM agent spawns, and prompts get responses end-to-end.

## Bug 2: `Failed to load node-pty` (terminal in Claude Code mode)

Surfaced after fixing Bug 1, when the app reached Claude Code mode with a working shell session attempt. Error:

```
Failed to load node-pty {
  error: Error: Failed to load native module: pty.node, checked: build/Release, build/Debug, prebuilds/linux-x64:
    Error: Cannot find module './prebuilds/linux-x64//pty.node'
  - /usr/lib/claude-desktop/.../app.asar/node_modules/node-pty/lib/utils.js
}
```

**Root cause:** `install_node_pty()` copied only `lib/` and `package.json` into `app.asar.contents/.../node-pty/`, and `finalize_app_asar()` packed app.asar without `--unpack`. The `.node` binaries were then separately dropped into `app.asar.unpacked/.../node-pty/build/Release/`.

The asar manifest therefore had no entry for `node-pty/build/` at all. When node-pty's loader (inside the asar) does `require('../build/Release/pty.node')`, Electron's asar→.unpacked redirect never fires because the redirect requires a manifest entry annotated as unpacked. Result: MODULE_NOT_FOUND despite the binary existing on disk.

**Fix:**
1. `install_node_pty()`: also stage `$pty_src_dir/build/` into `app.asar.contents/node_modules/node-pty/`.
2. `finalize_app_asar()`: pass `--unpack '**/*.node'` to `asar pack` so the binaries get moved into `app.asar.unpacked/` AND recorded in the manifest as unpacked.

**Verified:** new asar manifest now reports
```
UNPACKED: /node_modules/node-pty/build/Release/pty.node
UNPACKED: /node_modules/node-pty/build/Release/conpty.node
UNPACKED: /node_modules/node-pty/build/Release/conpty_console_list.node
```
and Claude Code's terminal loads successfully. Tested by running interactive shell sessions in Claude Code mode of the rebuilt .deb.

The pre-existing copy-to-.unpacked step at the bottom of `finalize_app_asar()` is now redundant but harmless (writes the same bytes). Left in place for now to minimize diff and preserve the `--node-pty-dir` (Nix) flow, where the explicit copy may still be load-bearing.

## Test plan

- [x] `./build.sh --build deb --clean no` against upstream 1.3109.0 produces a working .deb
- [x] Installed .deb on Pop!_OS 24.04 (amd64)
- [x] Cowork mode: VM boots, agent spawns, prompts answered (verified `[VM:start] Startup complete` in `cowork_vm_node.log` + actual chat in the UI)
- [x] Claude Code mode: terminal sessions start without the node-pty error
- [ ] Smoke test on an arm64 machine (don't have one handy; the fix is arch-agnostic)
- [ ] Smoke test against an older Claude Desktop version where fs is just `e` not `$e` — `[$\w]+` is a strict superset of `\w`, so existing extraction still works

## Notes

- Both fixes are minimal and surgical; they don't change any control flow that was working.
- The two commits are atomic — each can be reverted independently if needed.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
85% AI / 15% Human
Claude: bug analysis (asar/JS spelunking, regex root cause, node-pty manifest investigation), patch authoring, build/test loop, commit + PR drafting
Human: ran the rebuilds, ran sudo installs, smoke-tested Cowork & terminal in the UI, decided strategy