### PR TITLE
fix: launcher-common.sh self-match and stale socket cleanup (#407)

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Special thanks to:
 - **[gianluca-peri](https://github.com/gianluca-peri)**
   - Reporting the GNOME quit accessibility issue
   - Confirming tray behavior with AppIndicator
+- **[martin152](https://github.com/martin152)** for detailed diagnosis and a complete patch for three launcher cleanup bugs: `cleanup_orphaned_cowork_daemon` self-match, `cleanup_stale_cowork_socket` socat dependency no-op, and the same self-match in `--doctor`
 
 ## Sponsorship
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -94,8 +94,10 @@ build_electron_args() {
 # Kill orphaned cowork-vm-service daemon processes.
 # After a crash or unclean shutdown the cowork daemon may outlive the
 # main Electron UI process.  The orphaned daemon holds LevelDB locks
-# in ~/.config/Claude/Local Storage/ which cause new launches to
-# detect a "main instance" and silently quit.
+# in ~/.config/Claude/Local Storage/ AND keeps the Unix socket at
+# $XDG_RUNTIME_DIR/cowork-vm-service.sock bound, which causes a new
+# launch to either silently quit (LevelDB) or connect to the stale
+# daemon (socket) and hang with a blank window.
 # Must run BEFORE cleanup_stale_lock / cleanup_stale_cowork_socket
 # so that stale files left behind by the daemon can be cleaned up.
 cleanup_orphaned_cowork_daemon() {
@@ -103,23 +105,58 @@ cleanup_orphaned_cowork_daemon() {
 	cowork_pids=$(pgrep -f 'cowork-vm-service\.js' 2>/dev/null) \
 		|| return 0
 
-	# Check if a Claude Desktop UI process is also running.
-	# Any claude-desktop electron process that is NOT the cowork
-	# daemon indicates the app is alive and the daemon is expected.
-	local pid cmdline
-	for pid in $(pgrep -f 'claude-desktop' 2>/dev/null); do
+	# Check if a live Claude Desktop UI process is also running.
+	#
+	# We can NOT use `pgrep -f 'claude-desktop'` on its own for this:
+	# it matches the launcher's own bash process (this script's
+	# cmdline contains "/usr/bin/claude-desktop"), any stale launcher
+	# bash left stopped/zombie after a previous crash, and the cowork
+	# daemon itself.  Counting any of those as "the UI is alive"
+	# causes a false negative and the orphan survives.
+	#
+	# The reliable definition of "UI is alive" is: an Electron main
+	# process whose cmdline references app.asar and is NOT a Chromium
+	# helper (--type=...) and NOT the cowork daemon, and is actually
+	# runnable (not stopped/zombie).
+	local pid cmdline state
+	for pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
+		# Skip our own launcher bash and its parent.
+		[[ $pid == $$ || $pid == $PPID ]] && continue
 		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
 			|| continue
+		# Skip the cowork daemon (matches app.asar.unpacked path).
 		[[ $cmdline == *cowork-vm-service* ]] && continue
-		# Found a non-daemon claude-desktop process — not orphaned
+		# Skip Chromium helpers: zygote, renderer, gpu, utility, etc.
+		[[ $cmdline == *--type=* ]] && continue
+		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
+		state=$(awk '/^State:/ {print $2; exit}' \
+			"/proc/$pid/status" 2>/dev/null) || continue
+		[[ $state == T || $state == t || $state == Z ]] && continue
+		# Found a genuine live Electron UI — daemon is expected
 		return 0
 	done
 
-	# No UI process found — daemon is orphaned, terminate it
+	# No UI process found — daemon is orphaned, terminate it.
+	# Escalate to SIGKILL if a daemon is stuck and does not exit
+	# after SIGTERM within ~2s, so cleanup_stale_cowork_socket
+	# (which runs next) reliably sees no daemon.
 	for pid in $cowork_pids; do
 		kill "$pid" 2>/dev/null || true
 	done
-	log_message "Killed orphaned cowork-vm-service daemon (PIDs: $cowork_pids)"
+	local _wait=0
+	while ((_wait < 20)); do
+		pgrep -f 'cowork-vm-service\.js' &>/dev/null || break
+		sleep 0.1
+		((_wait++))
+	done
+	if pgrep -f 'cowork-vm-service\.js' &>/dev/null; then
+		for pid in $cowork_pids; do
+			kill -KILL "$pid" 2>/dev/null || true
+		done
+		log_message "Killed orphaned cowork-vm-service daemon (SIGKILL, PIDs: $cowork_pids)"
+	else
+		log_message "Killed orphaned cowork-vm-service daemon (PIDs: $cowork_pids)"
+	fi
 }
 
 # Clean up stale SingletonLock if the owning process is no longer running.
@@ -155,26 +192,31 @@ cleanup_stale_lock() {
 # $XDG_RUNTIME_DIR/cowork-vm-service.sock. After a crash or unclean
 # shutdown, the socket file persists but nothing is listening, causing
 # ECONNREFUSED instead of ENOENT when the app tries to connect.
+#
+# NOTE: this function MUST run after cleanup_orphaned_cowork_daemon,
+# which is responsible for killing any orphaned daemon.  Given that
+# ordering, the presence of a live daemon proves the socket is in
+# use; the absence of a daemon proves the socket is stale.
+# We use that invariant directly instead of depending on socat (not
+# shipped by default on Debian/Ubuntu) or an age heuristic (the old
+# 24h fallback effectively disabled the cleanup for any recent
+# crash).
 cleanup_stale_cowork_socket() {
 	local sock="${XDG_RUNTIME_DIR:-/tmp}/cowork-vm-service.sock"
 
 	[[ -S $sock ]] || return 0
 
-	if command -v socat &>/dev/null; then
-		# Try connecting — if refused, the socket is stale
-		if socat -u OPEN:/dev/null UNIX-CONNECT:"$sock" 2>/dev/null; then
-			return 0
-		fi
-	else
-		# No socat: fall back to age-based check (>24h = stale)
-		if [[ -z $(find "$sock" -mmin +1440 2>/dev/null) ]]; then
-			return 0
-		fi
-		log_message "No socat available; removing old socket (>24h)"
+	# If a cowork daemon is alive, it owns this socket; leave it.
+	# cleanup_orphaned_cowork_daemon has already run and removed any
+	# orphan (with SIGKILL escalation), so anything still alive here
+	# is a non-orphaned, live daemon.
+	if pgrep -f 'cowork-vm-service\.js' &>/dev/null; then
+		return 0
 	fi
 
+	# No daemon — the socket file is left over from a crash.
 	rm -f "$sock"
-	log_message "Removed stale cowork-vm-service socket"
+	log_message "Removed stale cowork-vm-service socket (no daemon running)"
 }
 
 # Set common environment variables
@@ -746,15 +788,29 @@ print(len(servers))
 	_doctor_check_bwrap_mounts
 
 	# -- Orphaned cowork daemon --
+	# Uses the same live-UI detection as cleanup_orphaned_cowork_daemon
+	# above: a live UI is an Electron main process on app.asar that is
+	# not a Chromium helper (--type=...), not the cowork daemon itself,
+	# and not stopped/zombie.  Counting any `claude-desktop`-matching
+	# process (as the old check did) would include the launcher's own
+	# bash and stuck launcher bashes from previous crashes, producing
+	# false negatives where a real orphan is misreported as "parent
+	# alive".
 	local _cowork_pids
 	_cowork_pids=$(pgrep -f 'cowork-vm-service\.js' 2>/dev/null) \
 		|| true
 	if [[ -n $_cowork_pids ]]; then
-		local _daemon_orphaned=true _pid _cmdline
-		for _pid in $(pgrep -f 'claude-desktop' 2>/dev/null); do
+		local _daemon_orphaned=true _pid _cmdline _state
+		for _pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
+			[[ $_pid == $$ || $_pid == $PPID ]] && continue
 			_cmdline=$(tr '\0' ' ' \
 				< "/proc/$_pid/cmdline" 2>/dev/null) || continue
 			[[ $_cmdline == *cowork-vm-service* ]] && continue
+			[[ $_cmdline == *--type=* ]] && continue
+			_state=$(awk '/^State:/ {print $2; exit}' \
+				"/proc/$_pid/status" 2>/dev/null) || continue
+			[[ $_state == T || $_state == t || $_state == Z ]] \
+				&& continue
 			_daemon_orphaned=false
 			break
 		done

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -121,7 +121,7 @@ cleanup_orphaned_cowork_daemon() {
 	local pid cmdline state
 	for pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
 		# Skip our own launcher bash and its parent.
-		[[ $pid == $$ || $pid == $PPID ]] && continue
+		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
 		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
 			|| continue
 		# Skip the cowork daemon (matches app.asar.unpacked path).
@@ -802,7 +802,7 @@ print(len(servers))
 	if [[ -n $_cowork_pids ]]; then
 		local _daemon_orphaned=true _pid _cmdline _state
 		for _pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
-			[[ $_pid == $$ || $_pid == $PPID ]] && continue
+			[[ $_pid == "$$" || $_pid == "$PPID" ]] && continue
 			_cmdline=$(tr '\0' ' ' \
 				< "/proc/$_pid/cmdline" 2>/dev/null) || continue
 			[[ $_cmdline == *cowork-vm-service* ]] && continue


### PR DESCRIPTION
## Summary

Upstreams the patch [martin152](https://github.com/martin152) attached to #407 — three related bugs in `scripts/launcher-common.sh` that combine to break Claude Desktop startup after any crash that reparents the cowork daemon on Debian/Ubuntu/Mint systems.

Following up on [my 2026-04-17 offer](https://github.com/aaddrick/claude-desktop-debian/issues/407#issuecomment-4270092885) to upstream the fix if martin152 didn't PR it themselves. No response in two days; opening this with their patch intact and full credit in `Co-Authored-By` and README Acknowledgments.

## The three bugs

1. **`cleanup_orphaned_cowork_daemon` self-match** — `pgrep -f 'claude-desktop'` matches the launcher's own bash process (its cmdline is `bash /usr/bin/claude-desktop`). The "is the UI alive?" loop returns true on the self-match, and the function exits before the SIGTERM loop runs. Orphans survive every launch.

2. **`cleanup_stale_cowork_socket` no-op on socat-less systems** — `socat` isn't in a default Debian/Ubuntu/Mint install. The fallback requires the socket file to be older than 24 hours (`find -mmin +1440`), which never fires on realistic crash-restart cycles. Net effect: silent no-op on any Debian-derivative without socat manually installed.

3. **`run_doctor` orphan check has the same self-match flaw** — so `claude-desktop --doctor` reports `[PASS] Cowork daemon: running (parent alive)` on systems with a genuine orphan, actively misleading users trying to diagnose this exact failure.

## The fix

1. Switched the UI-detection query from `pgrep -f 'claude-desktop'` to `pgrep -f 'app\.asar'`, plus `$$`/`$PPID` exclusion, `--type=` filter (skips Chromium helpers), and `/proc/*/status` check (skips stopped/zombie launcher bashes). Added SIGKILL escalation after ~2s so the next cleanup function reliably observes "no daemon."

2. Rewrote `cleanup_stale_cowork_socket` to use the ordering invariant that `cleanup_orphaned_cowork_daemon` runs first: at that point an extant `cowork-vm-service.js` process proves the socket is live, an absent one proves it's stale. No socat dependency, no age heuristic.

3. Applied the same detection primitive to the `run_doctor` path.

## Relation to #410

Complementary, not overlapping: [#410](https://github.com/aaddrick/claude-desktop-debian/pull/410) (landing today) makes the daemon's own lifecycle more robust and reduces how often orphans are *created*. This PR ensures the launcher actually *cleans them up* when they do occur.

## Test plan

- [x] `bash -n scripts/launcher-common.sh` — syntactically clean
- [x] Shellcheck — passes (running on CI)
- [x] Running martin152's patch on my daily-driver fork branch since 2026-04-17; no regressions on boot / app-launch / cowork-session flow
- [ ] Full reproduction on Mint 22.3 (martin152's platform) — I don't have that env handy. Their issue report includes end-to-end reproduction that confirmed the fix before submitting; see #407.
- [ ] `run_doctor` output on a system with a genuine orphan — same as above, trusting martin152's testing.

Adds martin152 to README Acknowledgments.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
10% AI / 90% Human
Claude: drafted the PR description and README Acknowledgments entry; walked through the upstreaming workflow and sanity-checks
Human: martin152 produced the diagnosis and the working patch (issue #407); Travis vetted by running the fix on his daily driver for two days, opened this PR on martin152's behalf after no response to his offer-to-PR comment