### PR TITLE
fix: home --dir before SDK --ro-bind in bwrap sandbox

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -1192,14 +1192,16 @@ class BwrapBackend extends LocalBackend {
         // Merge user-configured mounts (disable overrides + additional mounts)
         const bwrapArgs = mergeBwrapArgs(defaultBwrapArgs, this.bwrapMountsConfig);
 
+        // Create home directory (needed for ~ expansion) but don't
+        // expose real home contents. Must come before any --ro-bind of
+        // subdirectories inside $HOME (e.g. the SDK binary path),
+        // otherwise bwrap processes --dir after the bind and shadows it.
+        const homeDir = os.homedir();
+        bwrapArgs.push('--dir', homeDir);
+
         // Bind the SDK binary read-only
         const sdkDir = path.dirname(actualCommand);
         bwrapArgs.push('--ro-bind', sdkDir, sdkDir);
-
-        // Create home directory (needed for ~ expansion) but don't
-        // expose real home contents.
-        const homeDir = os.homedir();
-        bwrapArgs.push('--dir', homeDir);
 
         // Create /sessions/<name>/mnt/ guest path structure and mount
         // host directories at guest paths, matching the KVM backend


### PR DESCRIPTION
## Summary

Picks up #388 (filiptrplan) and rebases onto current main without the whitespace-only churn that was blocking merge. The functional change is identical to what @aaddrick already approved.

## Bug

When starting a new Cowork conversation, bwrap fails with:

```
bwrap: execvp /home/.../.config/Claude/claude-code-vm/.../claude: No such file or directory
```

bwrap processes mount args in order. When the SDK binary lives under `$HOME` (e.g. `~/.config/Claude/claude-code-vm/`), the `--ro-bind` of its parent directory was added **before** `--dir $HOME`. The later `--dir` wiped out the bind mount.

## Fix

Move `--dir $HOME` first so the home skeleton exists before subdirectory bind mounts are layered on top.

## Attribution

Original bug diagnosis and fix: @filiptrplan in #388. @aaddrick's review on that PR approved the content and asked for the whitespace noise to be removed; filiptrplan hadn't circled back in ~8 days and the branch went stale against main, so I'm picking it up per our scoped-maintainer process.

## Test plan

- [ ] CI green on amd64/arm64 deb/rpm/appimage
- [ ] Smoke test: starting a new Cowork session with SDK under `$HOME` no longer hits the execvp error

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Filip Trplan <info@trplan.si>
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
20% AI / 80% Human
Claude: byte-precise edit preserving existing CRLF mix, commit/PR drafting
Human (filiptrplan): original bug diagnosis, fix, review response
Human (Travis): scope decision, takeover, attribution