### PR TITLE
fix: only route `claude` commands through SDK binary in cowork-vm-service (#427)

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -551,11 +551,15 @@ function resolveSdkBinary(sdkSubpath, version, label) {
 
 /**
  * Resolve the actual command binary to execute.
- * Priority: 1) SDK binary from installSdk, 2) command path, 3) which
+ * Priority: 1) SDK binary (only when basename is `claude`),
+ * 2) command path, 3) which
  * Returns { command, error } — error is set if command not found.
  */
 function resolveCommand(command, sdkBinaryPath) {
-    if (sdkBinaryPath && fs.existsSync(sdkBinaryPath)) {
+    const basename = path.basename(command);
+
+    if (basename === 'claude' &&
+            sdkBinaryPath && fs.existsSync(sdkBinaryPath)) {
         log(`resolveCommand: using SDK binary: ${sdkBinaryPath}`);
         return { command: sdkBinaryPath, error: null };
     }
@@ -564,7 +568,6 @@ function resolveCommand(command, sdkBinaryPath) {
         return { command, error: null };
     }
 
-    const basename = path.basename(command);
     try {
         const resolved = execFileSync('which', [basename],
             { encoding: 'utf-8' }).trim();


### PR DESCRIPTION
## Summary

Fixes #427 — `mcp__workspace__bash` (and every other shell-dependent skill inside Cowork) was failing with `Not logged in · Please run /login`.

The root cause was in `scripts/cowork-vm-service.js`'s `resolveCommand()`: once `installSdk` had populated `sdkBinaryPath`, the function returned that path for **every** command it resolved. Since `resolveSdkBinary` always joins the SDK subpath with the literal string `claude` (see [line 540](https://github.com/aaddrick/claude-desktop-debian/blob/main/scripts/cowork-vm-service.js#L540)), every `bash -c '...'` spawn in the sandbox actually ran `claude -c '...'`. The embedded `claude` had no credentials mounted through, so it immediately bailed out with the login prompt — before bash ever got a chance to execute the user's command.

## Fix

Limit the SDK substitution to commands whose basename is literally `claude`. Everything else falls through to the existing `fs.existsSync` / `which` path resolution.

```diff
 function resolveCommand(command, sdkBinaryPath) {
-    if (sdkBinaryPath && fs.existsSync(sdkBinaryPath)) {
+    const basename = path.basename(command);
+
+    if (basename === 'claude' &&
+            sdkBinaryPath && fs.existsSync(sdkBinaryPath)) {
         log(`resolveCommand: using SDK binary: ${sdkBinaryPath}`);
         return { command: sdkBinaryPath, error: null };
     }
```

This is slightly tighter than the shell-whitelist proposed in the issue — it restores correct behavior for `true`, `python`, `pip`, etc. as well, even though MCP only spawns shells today.

## Credit

Thanks to @martin152 for the thorough diagnostic trace, the working dpkg-divert patch they've been running since 2026-04-16, and the clean repro steps.

## Test plan

- [x] `node --check scripts/cowork-vm-service.js` — syntax OK
- [ ] Build the `.deb` in CI and confirm green
- [ ] Install the built package on Linux Mint / Ubuntu 24.04 base, enable Cowork, run `mcp__workspace__bash` and confirm `echo hi` now works end-to-end
- [ ] Spot-check that running the Claude CLI itself inside Cowork still picks up the SDK binary (regression guard for the intended behavior)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: diagnosed the root cause, chose the basename-based fix over the shell whitelist, wrote the patch and PR
Human: assigned the issue, confirmed the fix shape, will CI-verify and install-test on daily driver