### PR TITLE
fix: chmod node-pty unpacked files before overwriting in Nix builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1752,6 +1752,9 @@ finalize_app_asar() {
 	if [[ -n $pty_release_dir ]]; then
 		echo 'Copying node-pty native binaries to unpacked directory...'
 		mkdir -p "$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release" || exit 1
+		# asar pack --unpack may have already placed read-only copies here
+		# (preserving Nix store permissions). Make them writable before overwriting.
+		chmod -R u+w "$app_staging_dir/app.asar.unpacked/node_modules/node-pty" 2>/dev/null || true
 		cp -r "$pty_release_dir/"* \
 			"$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release/" || exit 1
 		chmod +x "$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release/"* 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Fix Nix build failure: `cp: cannot create regular file '...app.asar.unpacked/node_modules/node-pty/build/Release/obj.target/pty.node': Permission denied`
- Add `chmod -R u+w` before copying node-pty native binaries into the unpacked directory

## Root Cause

During `finalize_app_asar()`, `asar pack --unpack '**/*.node'` extracts `.node` files into `app.asar.unpacked/`, preserving the source file permissions. When node-pty comes from the Nix store (via `--node-pty-dir`), those files are read-only (`r--r--r--`) because the Nix store is immutable.

The subsequent `cp -r` at line 1755 tries to overwrite the already-extracted read-only `pty.node` and fails with Permission denied.

## Fix

Added `chmod -R u+w` on the target directory before the copy, making any files previously placed there by `asar --unpack` writable. The `2>/dev/null || true` guard handles the case where the directory doesn't exist yet (non-Nix builds where `asar --unpack` didn't create it).