### PR TITLE
fix: suppress Cowork tab auto-select on every launch (#341)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1282,9 +1282,7 @@ if (!code.includes('"linux":{') && !code.includes("'linux':{") &&
     const statusRe = /getDownloadStatus\(\)\{return\s+(\w+\(\)\?(\w+)\.Downloading:\w+\(\)\?\2\.Ready:\2\.NotDownloaded)\}/;
     const statusMatch = code.match(statusRe);
     if (statusMatch) {
-        const whole = statusMatch[0];
-        const origExpr = statusMatch[1];
-        const enumVar = statusMatch[2];
+        const [whole, origExpr, enumVar] = statusMatch;
         const replacement =
             'getDownloadStatus(){return process.platform==="linux"?' +
             enumVar + '.NotDownloaded:' + origExpr + '}';

--- a/build.sh
+++ b/build.sh
@@ -1224,8 +1224,12 @@ if (pipeMatch) {
 // Empty arrays mean no VM files are downloaded — this is correct
 // because the VM backend is non-functional on Linux (bwrap is
 // the only working backend and doesn't use VM files).
-// Note: [].every() returns true (vacuous truth), so bO() reports
-// "Ready" status. This is intentional — it skips the download.
+// Note: [].every() returns true (vacuous truth), so iBA() reports
+// that VM files are present. That makes the download() IPC
+// short-circuit without fetching anything, which is the intent
+// here. Patch 4b handles the downstream side-effect on
+// getDownloadStatus() so the Cowork tab doesn't auto-select on
+// every launch (#341).
 // ============================================================
 if (!code.includes('"linux":{') && !code.includes("'linux':{") &&
     !code.includes('linux:{')) {
@@ -1252,6 +1256,49 @@ if (!code.includes('"linux":{') && !code.includes("'linux':{") &&
     if (!code.includes('linux:{x64:')) {
         console.log('  WARNING: Could not add Linux bundle' +
             ' manifest entries');
+    }
+}
+
+// ============================================================
+// Patch 4b: Suppress Cowork tab auto-selection on launch (#341)
+// Anchor: getDownloadStatus() method with readable enum property
+//         names (.Downloading, .Ready, .NotDownloaded) — stable
+//         across minifier releases.
+//
+// Patch 4's vacuous-truth workaround makes iBA() report that VM
+// files are "ready", which is what short-circuits the download
+// path. The side-effect is that getDownloadStatus() also returns
+// Ready on every startup, and the remote web app treats a
+// startup observation of Ready as the "download just finished"
+// transition that auto-navigates to Cowork on macOS/Windows.
+// Linux users hit that transition on every launch.
+//
+// Fix: return NotDownloaded on Linux from getDownloadStatus().
+// iBA() is left alone so download() still short-circuits, and
+// clicking the Cowork tab still works (the web app's setup flow
+// calls download() which returns success immediately).
+// ============================================================
+{
+    const statusRe = /getDownloadStatus\(\)\{return\s+(\w+\(\)\?(\w+)\.Downloading:\w+\(\)\?\2\.Ready:\2\.NotDownloaded)\}/;
+    const statusMatch = code.match(statusRe);
+    if (statusMatch) {
+        const whole = statusMatch[0];
+        const origExpr = statusMatch[1];
+        const enumVar = statusMatch[2];
+        const replacement =
+            'getDownloadStatus(){return process.platform==="linux"?' +
+            enumVar + '.NotDownloaded:' + origExpr + '}';
+        code = code.replace(whole, replacement);
+        console.log('  Patched getDownloadStatus to return ' +
+            'NotDownloaded on Linux (suppresses auto-nav, #341)');
+        patchCount++;
+    } else if (code.includes(
+        'getDownloadStatus(){return process.platform==="linux"?'
+    )) {
+        console.log('  Cowork auto-nav suppression already applied');
+    } else {
+        console.log('  WARNING: Could not find getDownloadStatus' +
+            ' pattern for auto-nav suppression (#341)');
     }
 }
 


### PR DESCRIPTION
## Summary

- New Patch 4b in `patch_cowork_linux()` short-circuits `getDownloadStatus()` to `NotDownloaded` on Linux
- Stops the remote web app from auto-navigating to the Cowork tab on every launch
- Clicking Cowork still works — `iBA()` is unchanged, so `download()` short-circuits instantly when the web app's setup flow calls it

## Root cause

Patch 4 injects an empty Linux bundle manifest (`linux: { x64: [], arm64: [] }`) to suppress VM file downloads. `Array.prototype.every()` on `[]` is vacuously `true`, so `iBA()` reports "VM files present" and `getDownloadStatus()` returns `Ready` on every startup.

The remote web app treats a startup observation of `Ready` as the same "download just finished" transition that auto-navigates macOS/Windows users to Cowork after completing a VM download. Linux users trip that transition on every launch.

## Fix

Patch 4b wraps the return in a Linux short-circuit to `NotDownloaded`:

```js
// Before
getDownloadStatus(){return k1t()?SN.Downloading:iBA()?SN.Ready:SN.NotDownloaded}

// After
getDownloadStatus(){return process.platform==="linux"?SN.NotDownloaded:k1t()?SN.Downloading:iBA()?SN.Ready:SN.NotDownloaded}
```

`iBA()` is deliberately left alone — that's the gate on the actual download path, and we want it to keep short-circuiting so no VM files are fetched. The trade-off is that if a user clicks Cowork while it reports `NotDownloaded`, the web app's setup UI may flash briefly before the `download()` IPC returns success (instant, via `iBA()` still being true) and the web app navigates into Cowork.

## Why the anchor is stable

`getDownloadStatus` is an exported IPC method name — not minified. The enum property names (`.Downloading`, `.Ready`, `.NotDownloaded`) are preserved readable in the bundle because they're string values of the enum. Only the enum variable (`SN` in 1.3109.0) and the two helper functions (`k1t`, `iBA`) are minified, and they're pulled dynamically from the matched groups.

## Test plan

- [x] Isolated node run against pristine 1.3109.0 `index.js` — patch applied, output verified
- [x] Idempotent on re-runs — "already applied" path taken
- [x] `shellcheck build.sh` clean
- [ ] CI green
- [ ] Smoke test on built AppImage — confirm app opens on the last-used tab instead of Cowork

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
85% AI / 15% Human
Claude: Root-cause analysis, regex design, patch implementation, PR write-up
Human: Direction, review, issue triage context