### PR TITLE
fix: diagnose AppArmor userns block on bwrap probe (#351)

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Special thanks to:
   - Reporting the GNOME quit accessibility issue
   - Confirming tray behavior with AppIndicator
 - **[martin152](https://github.com/martin152)** for detailed diagnosis and a complete patch for three launcher cleanup bugs: `cleanup_orphaned_cowork_daemon` self-match, `cleanup_stale_cowork_socket` socat dependency no-op, and the same self-match in `--doctor`
+- **[hfyeh](https://github.com/hfyeh)** for diagnosing the Ubuntu 24.04 AppArmor unprivileged-userns block on Cowork bwrap and contributing the AppArmor profile workaround
 
 ## Sponsorship
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -89,6 +89,51 @@ For enhanced security, consider:
 - Running the AppImage within a separate sandbox (e.g., bubblewrap)
 - Using Gear Lever's integrated AppImage management for better isolation
 
+### Cowork on Ubuntu 24.04+ (AppArmor Blocks User Namespaces)
+
+Ubuntu 24.04 ships with `apparmor_restrict_unprivileged_userns=1`
+by default, which blocks the unprivileged user namespaces that
+Cowork's bubblewrap sandbox relies on. Symptoms:
+
+- `claude-desktop --doctor` reports `bubblewrap: sandbox probe failed`
+  with `Operation not permitted` in stderr.
+- `~/.config/Claude/logs/cowork_vm_daemon.log` contains
+  `bwrap is installed but cannot create a user namespace`.
+- Cowork sessions hang at "Starting VM..." or loop on reconnect.
+
+Permit user namespaces for `bwrap` via an AppArmor profile (one-time
+setup, requires sudo):
+
+```bash
+sudo tee /etc/apparmor.d/bwrap <<'EOF'
+abi <abi/4.0>,
+include <tunables/global>
+
+profile bwrap /usr/bin/bwrap flags=(unconfined) {
+    userns,
+
+    include if exists <local/bwrap>
+}
+EOF
+
+sudo apparmor_parser -r /etc/apparmor.d/bwrap
+```
+
+After applying the profile, run `claude-desktop --doctor` — the
+bubblewrap probe should pass, and Cowork should start without
+falling back to host-direct.
+
+**Security note:** this grants `/usr/bin/bwrap` the unconfined
+profile plus the `userns` capability. It matches the behavior
+bwrap had on Ubuntu 22.04 and earlier, and on most other distros,
+but is a system-wide change that affects every program invoking
+`/usr/bin/bwrap` (not just Claude Desktop). Review the profile
+against your threat model before applying.
+
+Credit: this workaround was contributed by
+[@hfyeh](https://github.com/hfyeh) in
+[#351](https://github.com/aaddrick/claude-desktop-debian/issues/351).
+
 ### Authentication Errors (401)
 
 If you encounter recurring "API Error: 401" messages after periods of inactivity, the cached OAuth token may need to be cleared. This is an upstream application issue reported in [#156](https://github.com/aaddrick/claude-desktop-debian/issues/156).

--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -2190,6 +2190,35 @@ class KvmBackend extends BackendBase {
 // Backend Detection
 // ============================================================
 
+// Classify a failed `bwrap --ro-bind / / true` probe. Returns
+// { kind: 'userns' | 'unknown', stderr: string }.
+//
+// Ubuntu 24.04+ ships `apparmor_restrict_unprivileged_userns=1` by
+// default, which blocks bwrap from creating the user namespace it
+// needs. The probe then fails with EPERM or an AppArmor denial in
+// dmesg; bwrap's own stderr is usually "Creating new user namespace:
+// Operation not permitted" or similar. Matching these patterns lets
+// the daemon and the `--doctor` check emit a specific, actionable
+// diagnosis instead of a generic "bwrap not available" that masks
+// the real problem (issue #351).
+function classifyBwrapProbeError(e) {
+    const stderr = (e && e.stderr ? e.stderr.toString() : '')
+        + (e && e.stdout ? e.stdout.toString() : '');
+    const haystack = (e && e.message ? e.message : '') + '\n' + stderr;
+    const usernsPatterns = [
+        /user[ _-]?namespace/i,
+        /apparmor/i,
+        /operation not permitted/i,
+        /setting up (uid|gid) map/i,
+        /CLONE_NEW(USER|NS)/i,
+        /CAP_SYS_ADMIN/i,
+    ];
+    const kind = usernsPatterns.some((re) => re.test(haystack))
+        ? 'userns'
+        : 'unknown';
+    return { kind, stderr: stderr.trim() };
+}
+
 function detectBackend(emitEvent) {
     const override = BACKEND_OVERRIDE;
     if (override) {
@@ -2206,22 +2235,55 @@ function detectBackend(emitEvent) {
         }
     }
 
-    // Auto-detect: try bwrap first, then KVM, then host.
+    // Auto-detect: try bwrap first. If bwrap is installed but the
+    // sandbox probe fails, stop at host rather than silently falling
+    // through to KVM — KVM auto-selection in that state leads users
+    // into a broken retry loop when the rootfs isn't ready (#351).
+    let bwrapInstalled = false;
     try {
         execFileSync('which', ['bwrap'], { stdio: 'pipe' });
-        execFileSync('bwrap', ['--ro-bind', '/', '/', 'true'], {
-            stdio: 'pipe', timeout: 5000
-        });
-        log('Backend: bwrap');
-        // Hint for users upgrading from KVM-first auto-detection
+        bwrapInstalled = true;
+    } catch (_) {
+        log('bwrap not installed');
+    }
+
+    if (bwrapInstalled) {
         try {
-            fs.accessSync('/dev/kvm', fs.constants.R_OK | fs.constants.W_OK);
-            log('Note: KVM is available but bwrap is now the default. '
-                + 'Set COWORK_VM_BACKEND=kvm for full VM isolation.');
-        } catch (_) { /* KVM not available, no hint needed */ }
-        return new BwrapBackend(emitEvent);
-    } catch (e) {
-        log(`bwrap not available: ${e.message}`);
+            execFileSync('bwrap', ['--ro-bind', '/', '/', 'true'], {
+                stdio: 'pipe', timeout: 5000
+            });
+            log('Backend: bwrap');
+            // Hint for users upgrading from KVM-first auto-detection
+            try {
+                fs.accessSync('/dev/kvm',
+                    fs.constants.R_OK | fs.constants.W_OK);
+                log('Note: KVM is available but bwrap is now the default. '
+                    + 'Set COWORK_VM_BACKEND=kvm for full VM isolation.');
+            } catch (_) { /* KVM not available, no hint needed */ }
+            return new BwrapBackend(emitEvent);
+        } catch (e) {
+            const { kind, stderr } = classifyBwrapProbeError(e);
+            if (kind === 'userns') {
+                logError(
+                    'bwrap is installed but cannot create a user '
+                    + 'namespace. This is common on Ubuntu 24.04+ where '
+                    + 'AppArmor blocks unprivileged user namespaces by '
+                    + 'default (apparmor_restrict_unprivileged_userns=1). '
+                    + 'See the "Cowork on Ubuntu 24.04" section in '
+                    + 'docs/TROUBLESHOOTING.md for the AppArmor profile '
+                    + 'fix.');
+            } else {
+                logError(`bwrap probe failed: ${e.message || '(no message)'}`);
+            }
+            if (stderr) {
+                logError(`bwrap stderr: ${stderr.slice(0, 500)}`);
+            }
+            logError(
+                'Falling back to host-direct (no isolation). Set '
+                + 'COWORK_VM_BACKEND=kvm to opt into KVM, or fix the '
+                + 'bwrap issue above to restore sandbox isolation.');
+            return new HostBackend(emitEvent);
+        }
     }
 
     // Note: rootfs is NOT checked here — the app downloads it to
@@ -2549,4 +2611,5 @@ module.exports = {
     validateMountPath,
     loadBwrapMountsConfig,
     mergeBwrapArgs,
+    classifyBwrapProbeError,
 };

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -685,9 +685,53 @@ print(len(servers))
 	local _distro_id
 	_distro_id=$(_cowork_distro_id)
 
+	# Determine whether bwrap is the active backend (for severity
+	# of bwrap-related diagnostics). Auto-detect prefers bwrap, so
+	# bwrap is active unless the user has overridden to KVM or host.
+	local _bwrap_active=true
+	if [[ -n ${COWORK_VM_BACKEND-} ]]; then
+		case "${COWORK_VM_BACKEND,,}" in
+			kvm|host) _bwrap_active=false ;;
+		esac
+	fi
+
 	# Bubblewrap (default backend)
 	if command -v bwrap &>/dev/null; then
 		_pass 'bubblewrap: found'
+
+		# Probe the sandbox. User namespaces must be available for
+		# bwrap to create its sandbox; Ubuntu 24.04+ blocks them via
+		# AppArmor by default (issue #351).
+		local _bwrap_probe_err='' _bwrap_probe_rc=0
+		_bwrap_probe_err=$(bwrap --ro-bind / / true 2>&1 >/dev/null) \
+			|| _bwrap_probe_rc=$?
+		if ((_bwrap_probe_rc == 0)); then
+			_pass 'bubblewrap: sandbox probe succeeded'
+		else
+			local _bwrap_issue=_warn
+			$_bwrap_active && _bwrap_issue=_fail
+			"$_bwrap_issue" \
+				"bubblewrap: sandbox probe failed" \
+				"(rc=$_bwrap_probe_rc)"
+			if [[ -n $_bwrap_probe_err ]]; then
+				_info "  stderr: $_bwrap_probe_err"
+			fi
+			# Detect the Ubuntu 24.04 AppArmor userns block
+			# specifically, and hint the remediation.
+			local _userns_re='(user[[:space:]_-]?namespace|apparmor|[Oo]peration not permitted|CLONE_NEW|CAP_SYS_ADMIN)'
+			if [[ $_bwrap_probe_err =~ $_userns_re ]]; then
+				_info \
+					'  Likely cause: unprivileged user namespaces' \
+					'are blocked.'
+				_info \
+					'  Common on Ubuntu 24.04+ where AppArmor sets' \
+					'apparmor_restrict_unprivileged_userns=1'
+				_info \
+					'  by default. See docs/TROUBLESHOOTING.md' \
+					'"Cowork on Ubuntu 24.04"'
+				_info '  for the AppArmor profile fix.'
+			fi
+		fi
 	else
 		_warn 'bubblewrap: not found'
 		_info \
@@ -773,9 +817,16 @@ print(len(servers))
 			bwrap) cowork_backend='bubblewrap (namespace sandbox, via override)' ;;
 			host) cowork_backend='host-direct (no isolation, via override)' ;;
 		esac
-	elif command -v bwrap &>/dev/null \
-		&& bwrap --ro-bind / / true &>/dev/null; then
-		cowork_backend='bubblewrap (namespace sandbox)'
+	elif command -v bwrap &>/dev/null; then
+		# bwrap is installed: if the probe succeeds, use it;
+		# otherwise fall to host (matching daemon behavior, so we
+		# don't silently imply KVM will be chosen when bwrap is
+		# blocked — see #351).
+		if bwrap --ro-bind / / true &>/dev/null; then
+			cowork_backend='bubblewrap (namespace sandbox)'
+		else
+			cowork_backend='host-direct (bwrap probe failed — see above)'
+		fi
 	elif [[ -e /dev/kvm ]] \
 		&& [[ -r /dev/kvm && -w /dev/kvm ]] \
 		&& command -v qemu-system-x86_64 &>/dev/null \

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -689,11 +689,9 @@ print(len(servers))
 	# of bwrap-related diagnostics). Auto-detect prefers bwrap, so
 	# bwrap is active unless the user has overridden to KVM or host.
 	local _bwrap_active=true
-	if [[ -n ${COWORK_VM_BACKEND-} ]]; then
-		case "${COWORK_VM_BACKEND,,}" in
-			kvm|host) _bwrap_active=false ;;
-		esac
-	fi
+	case "${COWORK_VM_BACKEND,,}" in
+		kvm|host) _bwrap_active=false ;;
+	esac
 
 	# Bubblewrap (default backend)
 	if command -v bwrap &>/dev/null; then

--- a/tests/cowork-backend-detection.bats
+++ b/tests/cowork-backend-detection.bats
@@ -1,0 +1,126 @@
+#!/usr/bin/env bats
+#
+# cowork-backend-detection.bats
+# Tests for classifyBwrapProbeError — diagnoses why the bwrap sandbox
+# probe failed so the daemon can emit actionable errors instead of
+# silently falling through to a broken KVM backend (issue #351).
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+
+NODE_PREAMBLE='
+const {
+    classifyBwrapProbeError,
+} = require("'"${SCRIPT_DIR}"'/../scripts/cowork-vm-service.js");
+
+function assert(condition, msg) {
+    if (!condition) {
+        process.stderr.write("ASSERTION FAILED: " + msg + "\n");
+        process.exit(1);
+    }
+}
+
+function assertEqual(actual, expected, msg) {
+    assert(actual === expected,
+        msg + " expected=" + JSON.stringify(expected) +
+        " actual=" + JSON.stringify(actual));
+}
+
+function mkErr(stderr, message) {
+    return {
+        message: message || "Command failed",
+        stderr: Buffer.from(stderr || ""),
+        stdout: Buffer.from(""),
+    };
+}
+'
+
+# =============================================================================
+# classifyBwrapProbeError — AppArmor / userns denials (the #351 case)
+# =============================================================================
+
+@test "classifyBwrapProbeError: bwrap EPERM on user namespace" {
+	run node -e "${NODE_PREAMBLE}
+const e = mkErr('bwrap: Creating new user namespace: Operation not permitted');
+const r = classifyBwrapProbeError(e);
+assertEqual(r.kind, 'userns', 'EPERM on userns should classify as userns');
+assert(r.stderr.includes('user namespace'), 'stderr is preserved');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "classifyBwrapProbeError: AppArmor denial message" {
+	run node -e "${NODE_PREAMBLE}
+const e = mkErr('bwrap: setting up uid map: Permission denied');
+const r = classifyBwrapProbeError(e);
+assertEqual(r.kind, 'userns', 'uid map denial should classify as userns');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "classifyBwrapProbeError: explicit apparmor keyword" {
+	run node -e "${NODE_PREAMBLE}
+const e = mkErr('denied by AppArmor policy');
+const r = classifyBwrapProbeError(e);
+assertEqual(r.kind, 'userns', 'apparmor keyword should classify as userns');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "classifyBwrapProbeError: CLONE_NEWUSER keyword in kernel log" {
+	run node -e "${NODE_PREAMBLE}
+const e = mkErr('bwrap: unshare: CLONE_NEWUSER failed: EPERM');
+const r = classifyBwrapProbeError(e);
+assertEqual(r.kind, 'userns', 'CLONE_NEW* should classify as userns');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "classifyBwrapProbeError: CAP_SYS_ADMIN hint" {
+	run node -e "${NODE_PREAMBLE}
+const e = mkErr('need CAP_SYS_ADMIN to create user namespace');
+const r = classifyBwrapProbeError(e);
+assertEqual(r.kind, 'userns', 'CAP_SYS_ADMIN hint should classify as userns');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+# =============================================================================
+# classifyBwrapProbeError — non-userns failures
+# =============================================================================
+
+@test "classifyBwrapProbeError: unrelated bwrap failure" {
+	run node -e "${NODE_PREAMBLE}
+const e = mkErr('bwrap: No such file or directory: /does-not-exist');
+const r = classifyBwrapProbeError(e);
+assertEqual(r.kind, 'unknown', 'unrelated errors should classify as unknown');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "classifyBwrapProbeError: spawn ENOENT has no stderr" {
+	run node -e "${NODE_PREAMBLE}
+const e = { message: 'spawn bwrap ENOENT', code: 'ENOENT' };
+const r = classifyBwrapProbeError(e);
+assertEqual(r.kind, 'unknown', 'ENOENT without userns text is unknown');
+assertEqual(r.stderr, '', 'missing stderr normalized to empty string');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "classifyBwrapProbeError: empty error object" {
+	run node -e "${NODE_PREAMBLE}
+const r = classifyBwrapProbeError({});
+assertEqual(r.kind, 'unknown', 'empty error is unknown, not a crash');
+assertEqual(r.stderr, '', 'missing stderr normalized to empty string');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "classifyBwrapProbeError: null-safe" {
+	run node -e "${NODE_PREAMBLE}
+const r = classifyBwrapProbeError(null);
+assertEqual(r.kind, 'unknown', 'null error does not crash');
+"
+	[[ "$status" -eq 0 ]]
+}


### PR DESCRIPTION
## Summary

Fixes [#351](https://github.com/aaddrick/claude-desktop-debian/issues/351). On Ubuntu 24.04+, AppArmor ships with `apparmor_restrict_unprivileged_userns=1` by default, which blocks the unprivileged user namespace `bwrap` needs. The daemon's probe (`bwrap --ro-bind / / true`) fails, auto-detect silently falls through to KVM, and KVM then hangs waiting for a rootfs the user hasn't set up — leaving Cowork stuck in a retry loop with no actionable error in the logs.

## Changes

- **Classify the probe failure** — new `classifyBwrapProbeError()` helper in [scripts/cowork-vm-service.js](scripts/cowork-vm-service.js) sniffs stderr/message for userns-denial signals (`Operation not permitted`, AppArmor keywords, `CLONE_NEWUSER`, `CAP_SYS_ADMIN`, uid/gid-map denials). The daemon uses this to log a specific pointer to the TROUBLESHOOTING doc instead of a generic "bwrap not available".
- **Stop falling through to KVM when bwrap is installed but blocked.** When the probe fails on an installed bwrap, `detectBackend()` now drops to `HostBackend` rather than auto-selecting KVM. Users who legitimately want KVM can still set `COWORK_VM_BACKEND=kvm`. Fallthrough to KVM still happens when bwrap is not installed at all (unchanged behavior for that path).
- **`--doctor` check** — [scripts/launcher-common.sh](scripts/launcher-common.sh) now runs the same probe, surfaces the stderr, and emits the Ubuntu-24.04 remediation hint. The backend-summary line also reflects the new "stop at host" behavior instead of misleadingly implying KVM.
- **Documentation** — new `Cowork on Ubuntu 24.04+ (AppArmor Blocks User Namespaces)` section in [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) with the full AppArmor profile snippet and a security note.
- **Acknowledgment** — credited [@hfyeh](https://github.com/hfyeh) in [README.md](README.md) for the diagnosis and the working profile.
- **Tests** — new [tests/cowork-backend-detection.bats](tests/cowork-backend-detection.bats) covers nine classifier cases (five userns-style signals, three non-userns failures, null-safety).

## Test plan

- [x] `shellcheck scripts/launcher-common.sh` clean
- [x] `node -c scripts/cowork-vm-service.js` passes
- [x] Direct-run node harness: all 9 classifier cases pass
- [x] `--doctor` smoke test on working bwrap: new `[PASS] bubblewrap: sandbox probe succeeded` line, all checks green
- [x] `--doctor` smoke test with mocked blocked bwrap (auto-detect): `[FAIL] bubblewrap: sandbox probe failed` + userns diagnosis + TROUBLESHOOTING pointer; isolation line reads `host-direct (bwrap probe failed — see above)`
- [x] `--doctor` smoke test with `COWORK_VM_BACKEND=bwrap` override and mocked blocked bwrap: same diagnosis, isolation line still reflects the override (user-visible misconfiguration)
- [ ] CI green

## Scope note

Issue is in my cowork/bwrap maintenance lane per CLAUDE.local.md. Deliberately not shipping the AppArmor profile in the `.deb` `postinst` (the triage bot's suggestion) — that's a system-wide change to `/usr/bin/bwrap` that affects every bwrap user on the system, not just Claude Desktop. Doc-level remediation is the right altitude; the daemon+doctor changes here make sure the user actually gets pointed to it.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
25% AI / 75% Human
Claude: drafted the classifier patterns, doctor wiring, docs, and bats cases; verified via direct node harness and mock-bwrap `--doctor` runs
Human: scoped the approach, decided against postinst profile shipping, reviewed boundary between diagnosis and silent fall-through