### PR TITLE
fix: relax installPlugin gate on Linux for remote marketplaces (#396)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1698,6 +1698,67 @@ if (serviceErrorIdx !== -1) {
     }
 }
 
+// ============================================================
+// Patch 11: Relax installPlugin gate for Linux (#396)
+// Anchor: unique string
+//   "[CustomPlugins] installPlugin: attempting remote API install"
+//
+// The Directory "Anthropic & Partners" tab lists plugins from
+// the knowledge-work-plugins marketplace, which isn't configured
+// as a local marketplace. The app only tries the remote-API
+// install path when (pluginSource==="remote" OR mode==="cowork")
+// AND a sparkplug feature flag is enabled — none of which hold
+// on a normal Linux install, so it falls back to the CLI
+// installer that fails with "marketplace not found".
+//
+// The backend (/api/organizations/{orgId}/plugins/...) is not
+// gated by platform or cowork mode — any Pro/Teams account
+// should reach it. Short-circuit the extra client-side gates on
+// Linux for non-local plugins by wrapping the original gate in
+// (process.platform==="linux" || <original>). Users without an
+// org still fall through to the CLI fallback (expected — the
+// knowledge-work-plugins marketplace requires a Pro/Teams
+// account).
+// ============================================================
+{
+    const installAnchor =
+        '[CustomPlugins] installPlugin: attempting remote API install';
+    const installAnchorIdx = code.indexOf(installAnchor);
+    if (installAnchorIdx !== -1) {
+        const searchStart = Math.max(0, installAnchorIdx - 300);
+        const beforeAnchor = code.substring(searchStart, installAnchorIdx);
+        if (beforeAnchor.includes('process.platform==="linux"||')) {
+            console.log('  installPlugin gate relaxation already applied');
+        } else {
+            // Gate pattern:
+            //   if(!LOCALVAR&&(REMOTEVAR||(...).mode==="cowork")
+            //     &&await FLAGFN())
+            const gateRe = /if\((!\w+)&&(\(\w+\|\|\([$\w]+==null\?void 0:[$\w]+\.mode\)==="cowork"\)&&await [$\w]+\(\))\)/;
+            const gateMatch = beforeAnchor.match(gateRe);
+            if (gateMatch) {
+                const [whole, localCheck, innerGate] = gateMatch;
+                const gateAbsIdx = searchStart + gateMatch.index;
+                const replacement =
+                    'if(' + localCheck +
+                    '&&(process.platform==="linux"||' +
+                    innerGate + '))';
+                code = code.substring(0, gateAbsIdx) +
+                    replacement +
+                    code.substring(gateAbsIdx + whole.length);
+                console.log(
+                    '  Relaxed installPlugin gate for Linux (#396)');
+                patchCount++;
+            } else {
+                console.log(
+                    '  WARNING: Could not find installPlugin gate (#396)');
+            }
+        }
+    } else {
+        console.log(
+            '  WARNING: installPlugin anchor not found (#396)');
+    }
+}
+
 fs.writeFileSync(indexJs, code);
 console.log(`  Applied ${patchCount} cowork patches`);
 if (patchCount < 5) {


### PR DESCRIPTION
Closes #396.

## Summary

The Directory → "Anthropic & Partners" tab lists plugins from the `knowledge-work-plugins` marketplace, which isn't set up as a local marketplace. Three client-side gates in `installPlugin` combine to block the remote-API path:

```js
if (!a && (c || (s?.mode)==="cowork") && await A0()) {
  // remote API install
}
```

- `!a` — plugin is not local-sourced
- `c` — `pluginSource === "remote"` (not set for this tab)
- `mode === "cowork"` — not on a normal Linux install
- `A0()` — sparkplug feature flag (`isFeatureEnabled("2340532315")`)

None of `c`, `mode==="cowork"`, or `A0()` hold for a normal Linux user clicking one of those plugins, so it falls through to the CLI installer, which fails with `Plugin "..." not found in marketplace "knowledge-work-plugins"` (the marketplace isn't configured locally).

The backend (`/api/organizations/{orgId}/plugins/...`) isn't platform- or cowork-gated — any Pro/Teams account should reach it — so the extra client-side gates only hurt on Linux.

## Patch

Adds **Patch 11** to `patch_cowork_linux()` in `build.sh`. It wraps the original gate so Linux short-circuits to the remote-API path for any non-local plugin:

```js
if (!a && (process.platform === "linux" || (c || mode === "cowork") && await A0())) {
  // remote API install — tried on Linux for all non-local plugins
}
```

- Anchored on the unique log string `[CustomPlugins] installPlugin: attempting remote API install`.
- Variable names are extracted dynamically via regex (minifier drift handled — `[$\w]+` covers `$e`-style idents like in patch 9).
- Idempotent via `process.platform==="linux"||` substring check.
- Prints a warning instead of failing if the anchor/pattern changes upstream (non-fatal — core cowork patches are gated on their own anchors).

The `else` branch's `reason` expression still references `c`; after this patch the else only fires when `a` (local) is true, so the reason is always `local-sourced`. The other branches become dead code but don't error.

Users without an org still fall through to the CLI fallback — that's expected behavior, since `knowledge-work-plugins` requires a Pro/Teams account.

macOS/Windows behavior is unchanged, though since this build only targets Linux that's theoretical.

## Verification

- [x] shellcheck passes on `build.sh`
- [x] Regex verified against current minified `app.asar` (Claude Desktop 1.3109.0) — gate pattern matches exactly once in `index.js`
- [x] Replacement produces syntactically valid JS (dry-run printed correct output)
- [ ] End-to-end install test — needs a Pro/Teams login and a fresh build. Happy to verify on request before merge.

## Review request

@aaddrick — this touches `build.sh` patch logic against minified JS, which is outside my cowork/bwrap/KVM maintainer scope (per CLAUDE.local.md). **Holding merge for your review** even though the issue is `cowork`-labeled. Let me know if you'd rather take the patch yourself or want me to adjust the approach.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
30% AI / 70% Human
Claude: wrote the node patch, regex, dry-run verification, and PR body. Human: directed scope decision (tag aaddrick, don't self-merge), reviewed patch strategy.