### PR TITLE
fix: strip mode on node-pty cp at source, retire chmod

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1740,9 +1740,11 @@ install_node_pty() {
 	if [[ -n $pty_src_dir && -d $pty_src_dir ]]; then
 		echo 'Copying node-pty JavaScript files into app.asar.contents...'
 		mkdir -p "$app_staging_dir/app.asar.contents/node_modules/node-pty" || exit 1
-		cp -r "$pty_src_dir/lib" \
+		# --no-preserve=mode so read-only bits from the Nix store
+		# (--node-pty-dir) don't propagate into the staging tree.
+		cp -r --no-preserve=mode "$pty_src_dir/lib" \
 			"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
-		cp "$pty_src_dir/package.json" \
+		cp --no-preserve=mode "$pty_src_dir/package.json" \
 			"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
 		# Also stage build/ so `asar pack --unpack '**/*.node'` can
 		# create a properly-tracked .unpacked entry. Without this,
@@ -1752,7 +1754,7 @@ install_node_pty() {
 		# fails with MODULE_NOT_FOUND even when the binary exists
 		# in app.asar.unpacked/.
 		if [[ -d $pty_src_dir/build ]]; then
-			cp -r "$pty_src_dir/build" \
+			cp -r --no-preserve=mode "$pty_src_dir/build" \
 				"$app_staging_dir/app.asar.contents/node_modules/node-pty/" || exit 1
 			echo 'node-pty build/ staged (will be unpacked during asar pack)'
 		fi
@@ -1797,10 +1799,7 @@ finalize_app_asar() {
 	if [[ -n $pty_release_dir ]]; then
 		echo 'Copying node-pty native binaries to unpacked directory...'
 		mkdir -p "$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release" || exit 1
-		# asar pack --unpack may have already placed read-only copies here
-		# (preserving Nix store permissions). Make them writable before overwriting.
-		chmod -R u+w "$app_staging_dir/app.asar.unpacked/node_modules/node-pty" 2>/dev/null || true
-		cp -r "$pty_release_dir/"* \
+		cp -r --no-preserve=mode "$pty_release_dir/"* \
 			"$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release/" || exit 1
 		chmod +x "$app_staging_dir/app.asar.unpacked/node_modules/node-pty/build/Release/"* 2>/dev/null || true
 		echo 'node-pty native binaries copied'


### PR DESCRIPTION
## Summary

Follow-up to #432. That PR unblocked the Nix build by `chmod -R u+w`-ing the
staging tree immediately before overwriting read-only `.node` files. This PR
fixes the root cause instead: the read-only bits propagated through because
`cp -r` (by default) copies source mode minus umask, and the Nix store
source is `0444`. Passing `--no-preserve=mode` forces `(0666 & ~umask)` for
the destination, so the staging tree is writable from the start and the
post-hoc chmod is no longer needed.

## Changes

- `install_node_pty()` — add `--no-preserve=mode` to the three `cp` calls
  that read from `$pty_src_dir` (which may be the Nix store).
- `finalize_app_asar()` — add `--no-preserve=mode` to the `cp` from
  `$pty_release_dir` for the same reason, and remove the `chmod -R u+w`
  band-aid that #432 added (along with its comment).

## Why this is safer

- npm flows: no-op. npm-installed files are already `0644`/`0755`;
  `--no-preserve=mode` just produces the same result.
- Nix flows: 0444 from the store becomes `(0666 & ~umask)` in staging
  (typically `0644`). Writable, overwrite-able, internally consistent
  across `app.asar.contents` and `app.asar.unpacked`.
- Narrower blast radius than `chmod -R u+w`: mode is set at ingress per
  `cp`, so a future change that unpacks additional node-pty files (e.g.
  widening the `--unpack` glob) can't have its permissions silently
  mutated.
- The `chmod +x` on `build/Release/*` at the end of `finalize_app_asar()`
  still runs, so native binaries stay executable.

## Test plan

- [ ] CI build passes for amd64/arm64 deb/rpm/AppImage (npm flow)
- [ ] Nix build succeeds locally: `nix build .#claude-desktop`
- [ ] Built AppImage launches and terminal features (node-pty) work

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
10% AI / 90% Human
Claude: implemented the mode-stripping change and wrote the description based on contrarian-review findings
Human: reviewed #432, requested contrarian analysis, directed the root-cause follow-up