### PR TITLE
fix: detect virtiofsd at off-PATH install locations (#447)

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -630,22 +630,17 @@ print(len(servers))
 		if [[ $_vfsd_path == "$_vfsd_on_path" ]]; then
 			_pass 'virtiofsd: found'
 		elif $_kvm_active; then
-			_warn \
-				"virtiofsd: found at $_vfsd_path but not on PATH"
-			_info \
-				'KvmBackend spawns by PATH name and will fall back'
-			_info \
-				'to virtio-9p (lower performance) without a symlink.'
-			_info \
-				"Fix: sudo ln -s $_vfsd_path /usr/local/bin/virtiofsd"
+			_warn "virtiofsd: found at $_vfsd_path but not on PATH"
+			_info 'KvmBackend spawns by PATH name and will fall back'
+			_info 'to virtio-9p (lower performance) without a symlink.'
+			_info "Fix: sudo ln -s $_vfsd_path /usr/local/bin/virtiofsd"
 		else
 			_pass "virtiofsd: found at $_vfsd_path (not on PATH)"
 		fi
 	else
 		"$_kvm_issue" 'virtiofsd: not found'
 		if $_kvm_active; then
-			_info \
-				"Fix: $(_cowork_pkg_hint "$_distro_id" virtiofsd)"
+			_info "Fix: $(_cowork_pkg_hint "$_distro_id" virtiofsd)"
 		fi
 	fi
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -93,6 +93,46 @@ _fail() {
 _warn() { echo -e "${_yellow}[WARN]${_reset} $*"; }
 _info() { echo -e "       $*"; }
 
+# Locate the virtiofsd binary. Distros install it at different
+# off-PATH locations:
+#   - Debian/Ubuntu: /usr/libexec/virtiofsd (qemu-system-common)
+#   - Fedora/RHEL:   /usr/libexec/virtiofsd
+#   - Older Debian:  /usr/lib/qemu/virtiofsd
+#   - Arch/Manjaro:  /usr/lib/virtiofsd
+#
+# `command -v virtiofsd` alone produces a false negative on any of
+# the above. Search PATH first, then the well-known fallback paths.
+#
+# Prints the discovered path on stdout; returns 0 on hit, 1 on miss.
+# Fallback paths are overridable via _COWORK_DOCTOR_VFSD_PATHS
+# (colon-separated) so tests can point at a stub directory. The
+# namespaced prefix signals "internal test hook — not a user knob".
+_find_virtiofsd() {
+	local bin
+	bin=$(command -v virtiofsd 2>/dev/null)
+	if [[ -n $bin ]]; then
+		printf '%s' "$bin"
+		return 0
+	fi
+
+	local fallback_paths="${_COWORK_DOCTOR_VFSD_PATHS:-}"
+	if [[ -z $fallback_paths ]]; then
+		fallback_paths='/usr/libexec/virtiofsd'
+		fallback_paths+=':/usr/lib/qemu/virtiofsd'
+		fallback_paths+=':/usr/lib/virtiofsd'
+	fi
+
+	local fallback
+	local IFS=:
+	for fallback in $fallback_paths; do
+		if [[ -x $fallback ]]; then
+			printf '%s' "$fallback"
+			return 0
+		fi
+	done
+	return 1
+}
+
 # Check custom bwrap mount configuration and report findings
 _doctor_check_bwrap_mounts() {
 	local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/Claude"
@@ -552,12 +592,12 @@ print(len(servers))
 		fi
 	fi
 
-	# KVM tools: QEMU, socat, virtiofsd
+	# KVM tools: QEMU, socat. virtiofsd is handled separately below
+	# because Debian/Ubuntu install it off-PATH.
 	local _tool_label _tool_bin _tool_pkg
 	for _tool_label in \
 		'QEMU:qemu-system-x86_64:qemu' \
-		'socat:socat:socat' \
-		'virtiofsd:virtiofsd:virtiofsd'
+		'socat:socat:socat'
 	do
 		_tool_bin="${_tool_label#*:}"
 		_tool_pkg="${_tool_bin#*:}"
@@ -574,6 +614,40 @@ print(len(servers))
 			fi
 		fi
 	done
+
+	# virtiofsd: ships off-PATH on several distros (see _find_virtiofsd
+	# above). Probe known locations so we don't report "not found" when
+	# the package is actually installed. KvmBackend spawns by PATH name
+	# and silently falls back to virtio-9p (lower perf) if the spawn
+	# fails — so when KVM is the active backend and virtiofsd is only
+	# reachable off-PATH, surface a [WARN] so the user knows they need
+	# a symlink to actually get virtiofs performance. On the bwrap
+	# default path virtiofsd is unused, so [PASS] is fine.
+	local _vfsd_path _vfsd_on_path
+	_vfsd_on_path=$(command -v virtiofsd 2>/dev/null)
+	_vfsd_path=$(_find_virtiofsd)
+	if [[ -n $_vfsd_path ]]; then
+		if [[ $_vfsd_path == "$_vfsd_on_path" ]]; then
+			_pass 'virtiofsd: found'
+		elif $_kvm_active; then
+			_warn \
+				"virtiofsd: found at $_vfsd_path but not on PATH"
+			_info \
+				'KvmBackend spawns by PATH name and will fall back'
+			_info \
+				'to virtio-9p (lower performance) without a symlink.'
+			_info \
+				"Fix: sudo ln -s $_vfsd_path /usr/local/bin/virtiofsd"
+		else
+			_pass "virtiofsd: found at $_vfsd_path (not on PATH)"
+		fi
+	else
+		"$_kvm_issue" 'virtiofsd: not found'
+		if $_kvm_active; then
+			_info \
+				"Fix: $(_cowork_pkg_hint "$_distro_id" virtiofsd)"
+		fi
+	fi
 
 	# VM image
 	local vm_image

--- a/tests/cowork-bwrap-config.bats
+++ b/tests/cowork-bwrap-config.bats
@@ -665,3 +665,93 @@ assert(warnings[1].includes('/outside/home'), 'warns about rw outside home');
 	# Should just show info that no custom mounts are configured
 	[[ "$output" != *"FAIL"* ]]
 }
+
+# =============================================================================
+# _find_virtiofsd (issue #447)
+# =============================================================================
+
+@test "_find_virtiofsd: finds virtiofsd on PATH" {
+	mkdir -p "${TEST_TMP}/bin"
+	local stub="${TEST_TMP}/bin/virtiofsd"
+	printf '#!/bin/sh\nexit 0\n' > "$stub"
+	chmod +x "$stub"
+
+	# shellcheck source=scripts/launcher-common.sh
+	source "scripts/launcher-common.sh"
+	PATH="${TEST_TMP}/bin" \
+		_COWORK_DOCTOR_VFSD_PATHS='/nonexistent/virtiofsd' \
+		run _find_virtiofsd
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == "$stub" ]]
+}
+
+@test "_find_virtiofsd: falls back to /usr/libexec-like path" {
+	mkdir -p "${TEST_TMP}/libexec"
+	local stub="${TEST_TMP}/libexec/virtiofsd"
+	printf '#!/bin/sh\nexit 0\n' > "$stub"
+	chmod +x "$stub"
+
+	# shellcheck source=scripts/launcher-common.sh
+	source "scripts/launcher-common.sh"
+	# Empty PATH so `command -v` cannot resolve virtiofsd
+	PATH='' \
+		_COWORK_DOCTOR_VFSD_PATHS="$stub" \
+		run _find_virtiofsd
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == "$stub" ]]
+}
+
+@test "_find_virtiofsd: tries fallback paths in order" {
+	mkdir -p "${TEST_TMP}/alt"
+	local stub="${TEST_TMP}/alt/virtiofsd"
+	printf '#!/bin/sh\nexit 0\n' > "$stub"
+	chmod +x "$stub"
+
+	# shellcheck source=scripts/launcher-common.sh
+	source "scripts/launcher-common.sh"
+	# First fallback is missing; second is present. Expect second.
+	PATH='' \
+		_COWORK_DOCTOR_VFSD_PATHS="/nonexistent/virtiofsd:$stub" \
+		run _find_virtiofsd
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == "$stub" ]]
+}
+
+@test "_find_virtiofsd: returns non-zero and empty when missing" {
+	# shellcheck source=scripts/launcher-common.sh
+	source "scripts/launcher-common.sh"
+	PATH='' \
+		_COWORK_DOCTOR_VFSD_PATHS='/nonexistent/a:/nonexistent/b' \
+		run _find_virtiofsd
+	[[ "$status" -eq 1 ]]
+	[[ -z "$output" ]]
+}
+
+@test "_find_virtiofsd: skips non-executable fallback paths" {
+	mkdir -p "${TEST_TMP}/libexec"
+	local stub="${TEST_TMP}/libexec/virtiofsd"
+	# Create a readable but NOT executable file — must be rejected
+	printf 'not executable\n' > "$stub"
+	chmod 644 "$stub"
+
+	# shellcheck source=scripts/launcher-common.sh
+	source "scripts/launcher-common.sh"
+	PATH='' \
+		_COWORK_DOCTOR_VFSD_PATHS="$stub" \
+		run _find_virtiofsd
+	[[ "$status" -eq 1 ]]
+	[[ -z "$output" ]]
+}
+
+@test "_find_virtiofsd: default path list covers deb/rpm/arch" {
+	# Guard against regression: the built-in fallback list (used when
+	# _COWORK_DOCTOR_VFSD_PATHS is unset) must include the off-PATH
+	# install locations for Debian/Ubuntu, legacy Debian, and Arch.
+	# shellcheck source=scripts/launcher-common.sh
+	source "scripts/launcher-common.sh"
+	local body
+	body=$(declare -f _find_virtiofsd)
+	[[ "$body" == *'/usr/libexec/virtiofsd'* ]]
+	[[ "$body" == *'/usr/lib/qemu/virtiofsd'* ]]
+	[[ "$body" == *'/usr/lib/virtiofsd'* ]]
+}


### PR DESCRIPTION
## Summary

Closes #447. `doctor.sh` now probes the known off-PATH install locations for `virtiofsd` instead of relying solely on `command -v`, so users on Ubuntu (`/usr/libexec/virtiofsd`), Arch/CachyOS/Manjaro (`/usr/lib/virtiofsd`), and legacy Debian (`/usr/lib/qemu/virtiofsd`) stop seeing a false "not found" report when the package is installed. Reported most recently by @zabka in #445 and originally flagged by @jarrodcolburn.

## Changes

- **`scripts/doctor.sh`** — new `_find_virtiofsd` helper (PATH → three fallback paths; overridable via `_COWORK_DOCTOR_VFSD_PATHS` for tests). Split virtiofsd out of the KVM tools loop into a dedicated three-branch check with honest severity:
  - `[PASS] virtiofsd: found` — on PATH
  - `[PASS] virtiofsd: found at <path> (not on PATH)` — off-PATH, bwrap default (virtiofsd unused, so PASS is fine)
  - `[WARN] virtiofsd: found at <path> but not on PATH` — off-PATH, `COWORK_VM_BACKEND=kvm`. Surfaces that `KvmBackend` will silently fall back to virtio-9p (lower perf) + suggests the symlink fix.
  - `[INFO]`/`[WARN] virtiofsd: not found` — missing (severity ladder unchanged)
- **`tests/cowork-bwrap-config.bats`** — 6 new BATS tests for `_find_virtiofsd`. All 45 tests pass.

## Scope

In-scope per my cowork/launcher lane (`CODEOWNERS` routes `scripts/doctor.sh` cowork sections to me). Does not touch `cowork-vm-service.js` — teaching `KvmBackend` to probe the same fallback paths would give Ubuntu KVM users real virtiofs performance without needing a symlink, but that's a separate change I'm leaving for a follow-up if demand appears.

## Test plan

- [x] `bats tests/cowork-bwrap-config.bats` — 45/45 pass (39 pre-existing + 6 new)
- [x] CI-style shellcheck (`git grep -l ... | xargs shellcheck -x`) — clean
- [x] Live `run_doctor` on CachyOS (daily driver) — `[PASS] virtiofsd: found` as expected
- [x] Simulated `COWORK_VM_BACKEND=kvm PATH=/usr/bin:/bin` — `[WARN]` branch fires with symlink Fix hint
- [ ] Ubuntu 24.04 VM with `qemu-system-common` installed — should report `[PASS] virtiofsd: found at /usr/libexec/virtiofsd (not on PATH)`. Not yet verified on a live Ubuntu host; invited at review time.

## Verification commands (for reviewers on Ubuntu)

```bash
# Should report [PASS] virtiofsd: found at /usr/libexec/virtiofsd (not on PATH)
claude-desktop --doctor 2>&1 | grep -i virtiofsd

# Simulate KVM-active to see the WARN branch
COWORK_VM_BACKEND=kvm claude-desktop --doctor 2>&1 | grep -A3 -i virtiofsd
```

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Sonnet 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: Investigated #447 + #445, designed the enhance-detection approach, implemented `_find_virtiofsd` + the three-branch doctor check, wrote BATS tests, spawned a contrarian-pass that caught a missing Arch path and an overclaiming `[PASS]`, applied those fixes, verified live output on CachyOS.
Human: Caught a stale-branch mistake before any code was written, chose the minimum-viable scope over dropping the check entirely, directed a contrarian review to double-check the work after the branch-confusion reset, and approved the final diff.