### PR TITLE
fix(kvm): probe virtiofsd fallback paths in KvmBackend (#447)

### DIFF
--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -578,6 +578,70 @@ function resolveCommand(command, sdkBinaryPath) {
     }
 }
 
+/**
+ * Probe for an executable at the given path.
+ * Guards against broken symlinks, directories, and non-executable
+ * files so stale install artifacts don't masquerade as a binary.
+ */
+function isExecutableFile(p) {
+    try {
+        const st = fs.statSync(p);
+        if (!st.isFile()) return false;
+        fs.accessSync(p, fs.constants.X_OK);
+        return true;
+    } catch (_) {
+        return false;
+    }
+}
+
+/**
+ * Locate the virtiofsd binary.
+ *
+ * On Debian/Ubuntu virtiofsd ships at /usr/libexec/virtiofsd, on
+ * Arch/CachyOS/Manjaro at /usr/lib/virtiofsd — neither directory is
+ * on the default PATH, so `spawn('virtiofsd', ...)` ENOENTs even
+ * when the package is installed. KvmBackend silently falls back to
+ * virtio-9p in that case (lower performance).
+ *
+ * Search order (matches scripts/doctor.sh::_find_virtiofsd):
+ *   1. COWORK_VM_VIRTIOFSD_BIN — explicit user override
+ *   2. PATH (via `which`)
+ *   3. Known install locations
+ *
+ * Override _COWORK_VFSD_PATHS (colon-separated) replaces the built-in
+ * fallback list. Shared with doctor.sh so doctor's diagnosis and the
+ * daemon's actual probe stay in lock-step. Internal test hook —
+ * underscore prefix signals "not a user knob".
+ *
+ * Returns the absolute path to the binary, or null on miss.
+ */
+function findVirtiofsd() {
+    const override = process.env.COWORK_VM_VIRTIOFSD_BIN;
+    if (override) {
+        return isExecutableFile(override) ? override : null;
+    }
+
+    try {
+        const onPath = execFileSync('which', ['virtiofsd'],
+            { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }
+        ).trim();
+        if (onPath && isExecutableFile(onPath)) return onPath;
+    } catch (_) { /* fall through to fallback-path probe */ }
+
+    const fallbackEnv = process.env._COWORK_VFSD_PATHS;
+    const fallbacks = fallbackEnv
+        ? fallbackEnv.split(':').filter(Boolean)
+        : [
+            '/usr/libexec/virtiofsd',   // deb/rpm
+            '/usr/lib/qemu/virtiofsd',  // legacy Debian
+            '/usr/lib/virtiofsd',       // Arch/CachyOS/Manjaro
+        ];
+    for (const p of fallbacks) {
+        if (isExecutableFile(p)) return p;
+    }
+    return null;
+}
+
 // ============================================================
 // Bwrap Mount Configuration
 // ============================================================
@@ -1462,40 +1526,67 @@ class KvmBackend extends BackendBase {
         // Start home directory share for guest VM.
         // Try virtiofsd first (best performance), fall back to virtio-9p
         // (built into QEMU, no daemon needed, works unprivileged).
+        //
+        // On stock Debian/Ubuntu/Arch the virtiofsd binary lives outside
+        // the default PATH, so resolve it via findVirtiofsd() before
+        // spawning — otherwise `spawn('virtiofsd', ...)` ENOENTs and we
+        // silently drop to 9p even though the package is installed.
         const virtiofsSock = path.join(this.sessionDir, 'virtiofs.sock');
-        try {
-            this.virtiofsdProcess = spawnProcess('virtiofsd', [
-                `--socket-path=${virtiofsSock}`,
-                '-o', `source=${os.homedir()}`,
-                '-o', 'cache=auto',
-            ], {
-                stdio: ['ignore', 'pipe', 'pipe'],
-            });
-            this.virtiofsdProcess.on('error', (err) => {
-                log('KvmBackend: virtiofsd error:', err.message);
-                this.virtiofsdProcess = null;
-            });
-            log(`KvmBackend: virtiofsd started, socket=${virtiofsSock}`);
+        const virtiofsdBin = findVirtiofsd();
+        if (!virtiofsdBin) {
+            log('KvmBackend: virtiofsd binary not found on PATH or at '
+                + 'known install locations (/usr/libexec, /usr/lib/qemu, '
+                + '/usr/lib); using virtio-9p fallback. Install the '
+                + 'virtiofsd package or set COWORK_VM_VIRTIOFSD_BIN to '
+                + 'use virtiofs.');
+        } else {
+            log(`KvmBackend: virtiofsd resolved: ${virtiofsdBin}`);
+            // Local flag so the socket-wait loop can bail the moment
+            // the async 'error' event fires (e.g. binary removed between
+            // probe and exec) instead of stalling for the full 5s.
+            let spawnFailed = false;
+            try {
+                this.virtiofsdProcess = spawnProcess(virtiofsdBin, [
+                    `--socket-path=${virtiofsSock}`,
+                    '-o', `source=${os.homedir()}`,
+                    '-o', 'cache=auto',
+                ], {
+                    stdio: ['ignore', 'pipe', 'pipe'],
+                });
+                this.virtiofsdProcess.on('error', (err) => {
+                    log('KvmBackend: virtiofsd error:', err.message);
+                    spawnFailed = true;
+                    this.virtiofsdProcess = null;
+                });
+                log(`KvmBackend: virtiofsd started, ` +
+                    `socket=${virtiofsSock}`);
 
-            // Wait for virtiofsd to create its socket before starting QEMU
-            const vfsWaitStart = Date.now();
-            while (!fs.existsSync(virtiofsSock) &&
-                   Date.now() - vfsWaitStart < 5000) {
-                await new Promise(r => setTimeout(r, 100));
-            }
-            if (fs.existsSync(virtiofsSock)) {
-                log('KvmBackend: virtiofsd socket ready ' +
-                    `(${Date.now() - vfsWaitStart}ms)`);
-                this.homeShareType = 'virtiofs';
-            } else {
-                log('KvmBackend: virtiofsd socket not ready ' +
-                    'after 5s, will try virtio-9p fallback');
-                this.virtiofsdProcess.kill();
+                // Wait for virtiofsd to create its socket before
+                // starting QEMU. Bail early on async spawn failure.
+                const vfsWaitStart = Date.now();
+                while (!spawnFailed && !fs.existsSync(virtiofsSock) &&
+                       Date.now() - vfsWaitStart < 5000) {
+                    await new Promise(r => setTimeout(r, 100));
+                }
+                if (!spawnFailed && fs.existsSync(virtiofsSock)) {
+                    log('KvmBackend: virtiofsd socket ready ' +
+                        `(${Date.now() - vfsWaitStart}ms)`);
+                    this.homeShareType = 'virtiofs';
+                } else {
+                    const reason = spawnFailed
+                        ? 'spawn failed'
+                        : 'socket not ready after 5s';
+                    log(`KvmBackend: virtiofsd ${reason}, ` +
+                        'will try virtio-9p fallback');
+                    if (this.virtiofsdProcess) {
+                        this.virtiofsdProcess.kill();
+                        this.virtiofsdProcess = null;
+                    }
+                }
+            } catch (e) {
+                log(`KvmBackend: virtiofsd not available: ${e.message}`);
                 this.virtiofsdProcess = null;
             }
-        } catch (e) {
-            log(`KvmBackend: virtiofsd not available: ${e.message}`);
-            this.virtiofsdProcess = null;
         }
 
         // Fallback: use virtio-9p if virtiofsd failed. virtio-9p is

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -104,9 +104,11 @@ _info() { echo -e "       $*"; }
 # the above. Search PATH first, then the well-known fallback paths.
 #
 # Prints the discovered path on stdout; returns 0 on hit, 1 on miss.
-# Fallback paths are overridable via _COWORK_DOCTOR_VFSD_PATHS
+# Fallback paths are overridable via _COWORK_VFSD_PATHS
 # (colon-separated) so tests can point at a stub directory. The
 # namespaced prefix signals "internal test hook — not a user knob".
+# Shared with the VM daemon (cowork-vm-service.js) so doctor's
+# diagnosis and the daemon's actual probe stay in lock-step.
 _find_virtiofsd() {
 	local bin
 	bin=$(command -v virtiofsd 2>/dev/null)
@@ -115,7 +117,7 @@ _find_virtiofsd() {
 		return 0
 	fi
 
-	local fallback_paths="${_COWORK_DOCTOR_VFSD_PATHS:-}"
+	local fallback_paths="${_COWORK_VFSD_PATHS:-}"
 	if [[ -z $fallback_paths ]]; then
 		fallback_paths='/usr/libexec/virtiofsd'
 		fallback_paths+=':/usr/lib/qemu/virtiofsd'

--- a/tests/cowork-bwrap-config.bats
+++ b/tests/cowork-bwrap-config.bats
@@ -679,7 +679,7 @@ assert(warnings[1].includes('/outside/home'), 'warns about rw outside home');
 	# shellcheck source=scripts/launcher-common.sh
 	source "scripts/launcher-common.sh"
 	PATH="${TEST_TMP}/bin" \
-		_COWORK_DOCTOR_VFSD_PATHS='/nonexistent/virtiofsd' \
+		_COWORK_VFSD_PATHS='/nonexistent/virtiofsd' \
 		run _find_virtiofsd
 	[[ "$status" -eq 0 ]]
 	[[ "$output" == "$stub" ]]
@@ -695,7 +695,7 @@ assert(warnings[1].includes('/outside/home'), 'warns about rw outside home');
 	source "scripts/launcher-common.sh"
 	# Empty PATH so `command -v` cannot resolve virtiofsd
 	PATH='' \
-		_COWORK_DOCTOR_VFSD_PATHS="$stub" \
+		_COWORK_VFSD_PATHS="$stub" \
 		run _find_virtiofsd
 	[[ "$status" -eq 0 ]]
 	[[ "$output" == "$stub" ]]
@@ -711,7 +711,7 @@ assert(warnings[1].includes('/outside/home'), 'warns about rw outside home');
 	source "scripts/launcher-common.sh"
 	# First fallback is missing; second is present. Expect second.
 	PATH='' \
-		_COWORK_DOCTOR_VFSD_PATHS="/nonexistent/virtiofsd:$stub" \
+		_COWORK_VFSD_PATHS="/nonexistent/virtiofsd:$stub" \
 		run _find_virtiofsd
 	[[ "$status" -eq 0 ]]
 	[[ "$output" == "$stub" ]]
@@ -721,7 +721,7 @@ assert(warnings[1].includes('/outside/home'), 'warns about rw outside home');
 	# shellcheck source=scripts/launcher-common.sh
 	source "scripts/launcher-common.sh"
 	PATH='' \
-		_COWORK_DOCTOR_VFSD_PATHS='/nonexistent/a:/nonexistent/b' \
+		_COWORK_VFSD_PATHS='/nonexistent/a:/nonexistent/b' \
 		run _find_virtiofsd
 	[[ "$status" -eq 1 ]]
 	[[ -z "$output" ]]
@@ -737,7 +737,7 @@ assert(warnings[1].includes('/outside/home'), 'warns about rw outside home');
 	# shellcheck source=scripts/launcher-common.sh
 	source "scripts/launcher-common.sh"
 	PATH='' \
-		_COWORK_DOCTOR_VFSD_PATHS="$stub" \
+		_COWORK_VFSD_PATHS="$stub" \
 		run _find_virtiofsd
 	[[ "$status" -eq 1 ]]
 	[[ -z "$output" ]]
@@ -745,7 +745,7 @@ assert(warnings[1].includes('/outside/home'), 'warns about rw outside home');
 
 @test "_find_virtiofsd: default path list covers deb/rpm/arch" {
 	# Guard against regression: the built-in fallback list (used when
-	# _COWORK_DOCTOR_VFSD_PATHS is unset) must include the off-PATH
+	# _COWORK_VFSD_PATHS is unset) must include the off-PATH
 	# install locations for Debian/Ubuntu, legacy Debian, and Arch.
 	# shellcheck source=scripts/launcher-common.sh
 	source "scripts/launcher-common.sh"


### PR DESCRIPTION
## Summary

Follow-up to #453. Doctor now detects virtiofsd at off-PATH install locations, but the daemon itself still calls `spawnProcess('virtiofsd', ...)` at [`scripts/cowork-vm-service.js:1467`](https://github.com/aaddrick/claude-desktop-debian/blob/main/scripts/cowork-vm-service.js#L1467) — pure PATH lookup. On stock Debian/Ubuntu (`/usr/libexec/virtiofsd`) and Arch/CachyOS/Manjaro (`/usr/lib/virtiofsd`), the spawn `ENOENT`s and `KvmBackend` silently falls through to virtio-9p. Users who opt into `COWORK_VM_BACKEND=kvm` and installed virtiofsd get 9p performance without knowing.

This PR mirrors doctor's `_find_virtiofsd` on the JS side so the daemon actually uses virtiofs on those distros.

### Changes

1. **`findVirtiofsd()` + `isExecutableFile()` helpers** in `cowork-vm-service.js`, right next to `resolveCommand`. Search order matches doctor.sh exactly:
   - `COWORK_VM_VIRTIOFSD_BIN` — explicit user override (new, user-facing)
   - `which virtiofsd` — PATH lookup
   - `/usr/libexec/virtiofsd` → `/usr/lib/qemu/virtiofsd` → `/usr/lib/virtiofsd`

2. **Replace virtiofsd spawn block** (`KvmBackend.startVM()`): resolve via helper, pass absolute path as `argv[0]`, skip the spawn entirely when the helper returns null and log a clear reason. The existing try/catch + async `error` handler + 9p fallback block are preserved as belt-and-suspenders.

3. **`spawnFailed` flag** in the error handler. Contrarian pass noted that the async `error` event silently zeroed `virtiofsdProcess`, and the socket-wait loop didn't check — so a failed spawn meant waiting the full 5 s before 9p kicked in. Now the loop bails immediately.

4. **Guard `this.virtiofsdProcess.kill()`** against the race where the error handler zeroed it first.

5. **Rename** doctor.sh's test hook `_COWORK_DOCTOR_VFSD_PATHS` → `_COWORK_VFSD_PATHS` so doctor and daemon share the same internal env var for lock-step test parity. Shipped 24 h ago in #453, zero external users.

### Verification

#### Unit (node test harness, 8 scenarios — all pass)

Ran as an isolated copy of the helper so we can exercise env-var semantics without starting the daemon:

| Scenario | Expected | Got |
|---|---|---|
| PATH hit | stub path | stub path ✓ |
| Fallback hit (empty PATH) | stub path | stub path ✓ |
| Fallback ordering (first miss, second hit) | second stub | second stub ✓ |
| Total miss | `null` | `null` ✓ |
| Non-executable (mode 644) rejected | `null` | `null` ✓ |
| `COWORK_VM_VIRTIOFSD_BIN` overrides PATH | override path | override path ✓ |
| Override non-executable → `null` (no fall-through) | `null` | `null` ✓ |
| Override missing → `null` (no fall-through) | `null` | `null` ✓ |

The "override does not fall through" semantics matter: if a user says "use *this* binary," we honor that or fail — we don't silently pick something else behind their back.

#### BATS (45/45 pass)

Existing doctor.sh tests all pass after the `_COWORK_VFSD_PATHS` rename, including the default-list regression guard for the three fallback paths.

#### Lint

- `git grep -l '^#\( *shellcheck \|!...)' | xargs shellcheck` — rc=123 but every diagnostic is pre-existing in `build.sh`/`launcher-common.sh`, none from this PR.
- `node --check scripts/cowork-vm-service.js` — clean.

#### Not verified locally

Ubuntu `/usr/libexec/virtiofsd` hit — I don't have an Ubuntu VM with `qemu-system-common` wired up. Logic is symmetric to the `/usr/lib/virtiofsd` Arch case (which is on my daily driver), and the helper's behavior is exercised by the node harness + BATS tests, so I'm comfortable shipping without the live Ubuntu run.

### Scope

- **In-scope** (cowork/KVM lane): `scripts/cowork-vm-service.js`, `scripts/doctor.sh` (env-var rename), `tests/cowork-bwrap-config.bats` (test rename).
- **Out-of-scope, punted**: teaching `resolveCommand` about fallback paths generally (no concrete demand); documenting `COWORK_VM_VIRTIOFSD_BIN` in README (mention here; docs PR later if anyone asks).
- **Out-of-scope, separate tracking**: `.auto_reinstall_attempted` stale-flag investigation from #445 — per [prior comment on #446](https://github.com/aaddrick/claude-desktop-debian/issues/446#issuecomment-4283487237), the flag is a loop-breaker and shouldn't be patched at the delete-list layer. If #445 recurs after this PR + #453 land, I'll take a separate pass on doctor.sh advisory visibility.

### Test plan

- [x] BATS suite (45/45)
- [x] Node helper harness (8/8 scenarios)
- [x] `node --check` clean
- [x] `shellcheck` clean on changed files
- [ ] Live Ubuntu VM with `/usr/libexec/virtiofsd` — invited during review

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
85% AI / 15% Human
Claude: Contrarian pass, `findVirtiofsd()`/`isExecutableFile()` implementation, spawn-block rewrite with `spawnFailed` guard, `_COWORK_DOCTOR_VFSD_PATHS` → `_COWORK_VFSD_PATHS` rename, node test harness.
Human: Scoped the follow-up, caught the stale-branch risk, gated on contrarian review, approved merge.
