### PR TITLE
feat(triage): Phase 0 scaffold for issue triage v2

### DIFF
--- a/.claude/scripts/reasons.json
+++ b/.claude/scripts/reasons.json
@@ -1,0 +1,30 @@
+{
+  "comment": "Single source of truth for Stage 8b human-deferral reasons. Consumed by the 8b template renderer and its post-processor. Adding a new reason is a one-file change. See docs/issue-triage/README.md §8b.",
+  "reasons": [
+    {
+      "id": "version-drift",
+      "text": "version drift"
+    },
+    {
+      "id": "no-findings",
+      "text": "no findings survived validation"
+    },
+    {
+      "id": "low-confidence",
+      "text": "findings below confidence threshold"
+    },
+    {
+      "id": "duplicate",
+      "text": "likely-duplicate-of-#{duplicate_of}",
+      "placeholders": ["duplicate_of"]
+    },
+    {
+      "id": "ambiguous",
+      "text": "ambiguous bug/feature classification"
+    },
+    {
+      "id": "suspicious-input",
+      "text": "suspicious-input — manual review"
+    }
+  ]
+}

--- a/.claude/scripts/taxonomies/label-blocklist.json
+++ b/.claude/scripts/taxonomies/label-blocklist.json
@@ -1,0 +1,10 @@
+{
+  "comment": "Labels that the triage bot never applies, even if they exist in the repo's label set. These are closing decisions or maintainer prerogatives. See docs/issue-triage/README.md §Stage 9 for the gating model.",
+  "blocked_labels": [
+    "wontfix",
+    "invalid",
+    "duplicate",
+    "help wanted",
+    "good first issue"
+  ]
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug Report
+description: Report a bug in claude-desktop-debian.
+title: "[bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before you file:** This repository uses an automated triage bot that
+        sends issue contents to Anthropic's API for classification and
+        investigation. Do not include credentials, tokens, personal data, or
+        anything you wouldn't put on a public issue tracker. See the
+        [Privacy section in the README](https://github.com/aaddrick/claude-desktop-debian/blob/main/README.md#privacy)
+        for what the bot does with your issue.
+  - type: textarea
+    id: doctor
+    attributes:
+      label: Version (`claude-desktop --doctor` output)
+      description: |
+        Run `claude-desktop --doctor` in a terminal and paste the full output here.
+        If the app won't start, the AppImage filename (e.g. `claude-desktop-1.3.23-amd64.AppImage`)
+        or the version from **Help → About** is acceptable.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Describe the bug. What did you see?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen? "Expected X, got Y" phrasing is helpful.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / errors
+      description: |
+        Relevant log output or stack traces. Common locations:
+        - App logs: `~/.config/Claude/logs/`
+        - Launcher log: `~/.cache/claude-desktop-debian/launcher.log`
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: other
+    attributes:
+      label: Anything else
+      description: Additional context, screenshots, or links.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions / usage help
+    url: https://github.com/aaddrick/claude-desktop-debian/discussions
+    about: General questions belong in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature Request
+description: Request a feature or improvement.
+title: "[feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before you file:** This repository uses an automated triage bot that
+        sends issue contents to Anthropic's API for classification and
+        investigation. Do not include credentials, tokens, personal data, or
+        anything you wouldn't put on a public issue tracker. See the
+        [Privacy section in the README](https://github.com/aaddrick/claude-desktop-debian/blob/main/README.md#privacy)
+        for what the bot does with your issue.
+  - type: textarea
+    id: request
+    attributes:
+      label: What would you like
+      description: Describe the feature or improvement.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Why do you need this? What problem does it solve?
+    validations:
+      required: true
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Existing workarounds
+      description: Any existing workarounds, or hints at related surfaces / features already in the app.
+    validations:
+      required: false

--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -1,0 +1,41 @@
+name: Issue Triage v2
+run-name: |
+  Triage v2: #${{ inputs.issue_number }}
+
+# Phase 0 scaffold — workflow_dispatch-only, no live behavior.
+# See docs/issue-triage/implementation-plan.md for the build sequence.
+# v1 (issue-triage.yml) stays wired to its own triggers during rollout.
+
+on:
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue number to triage"
+        required: true
+        type: number
+
+permissions: {}
+
+concurrency:
+  group: issue-triage-v2-${{ inputs.issue_number }}
+  cancel-in-progress: true
+
+jobs:
+  skeleton:
+    name: Phase 0 Skeleton
+    runs-on: ubuntu-latest
+    env:
+      ISSUE_NUMBER: ${{ inputs.issue_number }}
+    steps:
+      - name: Echo issue number
+        run: |
+          echo "Phase 0 skeleton: would triage issue #${ISSUE_NUMBER}"
+          echo "No API calls, no comments, no labels."
+          {
+            echo "## Phase 0 skeleton run"
+            echo ""
+            echo "Issue: #${ISSUE_NUMBER}"
+            echo ""
+            echo "No live behavior yet — stages land in Phase 1+."
+            echo "See \`docs/issue-triage/implementation-plan.md\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -245,6 +245,14 @@ The build scripts in this repository are dual-licensed under:
 
 The Claude Desktop application itself is subject to [Anthropic's Consumer Terms](https://www.anthropic.com/legal/consumer-terms).
 
+## Privacy
+
+This repository uses an automated triage bot that sends issue contents to Anthropic's API for classification and investigation when you file a bug report or feature request. The bot reads the issue body, title, and any referenced related issues; it does not follow URLs, execute code blocks, or read content outside the triggering issue.
+
+Do not include credentials, tokens, personal data, or anything you wouldn't put on a public issue tracker. If you post sensitive content and then edit it out, the bot's original read is preserved as a run artifact for audit — GitHub's UI hides the edit, but the bot's view of what you wrote is recoverable by maintainers.
+
+Full design and data inventory: [`docs/issue-triage/README.md`](docs/issue-triage/README.md).
+
 ## Contributing
 
 Contributions are welcome! By submitting a contribution, you agree to license it under the same dual-license terms as this project.


### PR DESCRIPTION
Phase 0 of the [issue triage v2 implementation plan](docs/issue-triage/implementation-plan.md#phase-0-foundation). Directory scaffolding and a skeleton workflow. No live behavior.

## Summary

- **`.github/workflows/issue-triage-v2.yml`** — `workflow_dispatch`-only trigger, `permissions: {}`, single job that echoes the issue number and writes a stub `$GITHUB_STEP_SUMMARY`. v1 (`issue-triage.yml`) untouched.
- **`.github/ISSUE_TEMPLATE/{config,bug_report,feature_request}.yml`** — GitHub issue *forms* (YAML) per [spec §Issue templates](docs/issue-triage/README.md#issue-templates). `config.yml` disables blank issues and routes questions to Discussions. Both forms lead with the non-editable privacy disclosure markdown block.
- **`.claude/scripts/prompts/.gitkeep`** — per-stage prompts land in Phase 1+.
- **`.claude/scripts/taxonomies/label-blocklist.json`** — Stage 9 suggested-label gating. Five initial entries: `wontfix`, `invalid`, `duplicate`, `help wanted`, `good first issue`. Feature-design-questions and suspicious-input-tells taxonomies land in Phase 4.
- **`.claude/scripts/reasons.json`** — Stage 8b deferral-reason single source of truth (six entries per [spec §8b note](docs/issue-triage/README.md#8b-human-deferral-variant-any-gate-failed)); the `suspicious-input` reason becomes reachable in Phase 4.
- **README Privacy section** — disclosure discoverable without filing; text matches the templates' info block and the future Stage 9 first-issue comment.

## What this PR deliberately does not do

- No LLM calls, no comments, no labels, no artifact uploads — all deferred to Phase 1+.
- `.claude/scripts/schemas/` already exists from v1; Phase 1 adds `classify.json`, Phase 2 adds `investigate.json` / `comment-findings.json`, etc.
- No changes to v1 (`issue-triage.yml`); v1 stays on its current triggers during v2 rollout per [spec §Rollout posture](docs/issue-triage/README.md#rollout-posture).

## Test plan

- [ ] `actionlint .github/workflows/issue-triage-v2.yml` — clean locally
- [ ] `Actions → Issue Triage v2 → Run workflow` against three random issues — each run writes the stub summary and exits green with no API side-effects
- [ ] Filing a new issue via the UI presents the bug / feature chooser with the privacy disclosure at the top of each form
- [ ] `config.yml` routes questions to Discussions (blank issues disabled)
- [ ] `jq -e . .claude/scripts/{reasons.json,taxonomies/label-blocklist.json}` — both parse clean

## Next

Phase 1: Stages 1, 2, 8b, 9 — every dispatched issue gets a human-deferral comment and triage label. Risks validated there: schema plumbing via `claude --json-schema`, label gating, bug/feature double-check.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
40% AI / 60% Human
Claude: wrote the skeleton workflow, issue forms, and taxonomy/reason JSON files per the phase 0 spec.
Human: wrote the underlying design doc that dictated file names, shapes, and Phase 0 exit criteria — Claude is transcribing from there.