### PR TITLE
fix(triage): harden Investigate step against hangs and parser drift

### DIFF
--- a/.claude/scripts/triage/extract-json.py
+++ b/.claude/scripts/triage/extract-json.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Extract the first balanced JSON object from stdin.
+
+Used by the Investigate step in .github/workflows/issue-triage-v2.yml
+to parse Claude CLI output that may contain leading or trailing prose
+around the JSON body — a failure mode that fence-strip + jq-presence
+did not handle (PR #459 review item 6). Uses `json.JSONDecoder.raw_decode`,
+which stops at the first complete JSON value and ignores trailing text.
+
+Exit codes:
+  0 — JSON object found and written to stdout
+  1 — no opening brace in input
+  2 — content starting at the first brace was not valid JSON
+"""
+
+import json
+import sys
+
+
+def main() -> int:
+    text = sys.stdin.read()
+    start = text.find("{")
+    if start < 0:
+        return 1
+    try:
+        obj, _ = json.JSONDecoder().raw_decode(text[start:])
+    except json.JSONDecodeError:
+        return 2
+    json.dump(obj, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -348,40 +348,81 @@ jobs:
           } > /tmp/triage/investigate-prompt.txt
 
           # The investigation call runs with tool access (read/grep) so
-          # Claude can verify claims against actual source. Output is the
-          # model's final message; we parse JSON out and validate shape.
-          raw=$(claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
+          # Claude can verify claims against actual source. Output is
+          # the model's final message; we parse JSON out and validate
+          # shape.
+          #
+          # Hardening against the two failure modes seen in the first
+          # dispatch round (PR #460 follow-up):
+          #
+          # * `timeout 300s` bounds the step at 5 min so a wedged CLI
+          #   call can't run to the job-level timeout.
+          # * Stderr goes to an archived log file so post-mortem
+          #   debugging has something to read — previously `2>/dev/null`
+          #   swallowed everything, leaving a silent 8-min gap in the
+          #   step log when the call hung.
+          # * Raw CLI response + extracted payload are archived before
+          #   schema checks, so a schema-reject still leaves artifacts
+          #   to inspect.
+          # * JSON extraction uses Python's `raw_decode` — robust to
+          #   leading OR trailing prose around the JSON body, unlike
+          #   the fence-strip + jq-presence-check it replaces.
+          set +o pipefail
+          raw=$(timeout 300s claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
             --dangerously-skip-permissions \
             --output-format json \
             --model claude-sonnet-4-6 \
             --max-budget-usd 3.00 \
-            2>/dev/null) || {
-              echo "::warning::investigate call failed"
-              echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            }
+            2>/tmp/triage/investigate-stderr.log)
+          claude_exit=$?
+          set -o pipefail
 
-          # Extract the final message; strip any markdown code fences.
+          printf '%s' "${raw}" > /tmp/triage/investigate-raw.json
+
+          if [[ "${claude_exit}" == "124" ]]; then
+            echo "::warning::investigate call timed out at 300s"
+            echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          elif [[ "${claude_exit}" != "0" ]]; then
+            echo "::warning::investigate call failed (exit ${claude_exit})"
+            echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           payload=$(printf '%s' "${raw}" | jq -r '.result // empty')
+          printf '%s' "${payload}" > /tmp/triage/investigate-payload.txt
+
           if [[ -z "${payload}" ]]; then
             echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
             echo "::warning::empty investigation result"
             exit 0
           fi
 
-          # Drop fence lines so a naked JSON body remains for jq.
-          payload=$(printf '%s' "${payload}" | grep -vE '^```')
+          # Extract the first complete JSON object from the payload.
+          # Handles leading prose ("Here is...") and trailing prose
+          # ("Let me know...") that the fence-strip didn't catch.
+          extracted=$(python3 .claude/scripts/triage/extract-json.py \
+            < /tmp/triage/investigate-payload.txt) || {
+            echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::no valid JSON object found in investigation payload"
+            exit 0
+          }
 
-          if ! printf '%s' "${payload}" | jq -e '
-              .findings and .pattern_sweep
-              and .proposed_anchors and .related_issues
+          # Type-check the four required top-level arrays — presence
+          # alone would pass `{"findings": "oops"}` which then explodes
+          # in validate.sh (PR #459 review item 7).
+          if ! printf '%s' "${extracted}" | jq -e '
+              (.findings | type == "array")
+              and (.pattern_sweep | type == "array")
+              and (.proposed_anchors | type == "array")
+              and (.related_issues | type == "array")
               ' >/dev/null 2>&1; then
             echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::investigation output failed minimum schema check"
+            echo "::warning::investigation output failed shape check"
             exit 0
           fi
 
-          printf '%s' "${payload}" > /tmp/triage/investigation.json
+          printf '%s' "${extracted}" > /tmp/triage/investigation.json
           echo "investigate_ok=true" >> "$GITHUB_OUTPUT"
 
       # Stage 5 — mechanical validation. Pure bash via validate.sh.


### PR DESCRIPTION
Fixes three failure modes surfaced during the first round of dispatches against real issues (`dry_run=true` dispatches against #424 #442 #394 #448 #449), all in the Stage 4 Investigate step.

## Observed failures

| Issue | Symptom | Root cause |
|---|---|---|
| #394 | Step hung 9 min until manual cancel; zero log output between step start and cancellation | No per-call timeout on `claude -p`; `2>/dev/null` swallowed stderr so the step log was silent |
| #424, #442 | Classify → bug, doublecheck agreed, Investigate ran to CLI completion, but payload failed the jq presence-check and fell through to 8b no-findings | `grep -vE '^\`\`\`'` handles fence lines but not leading/trailing prose around JSON; raw response wasn't archived so the specific rejection cause was unknowable |

## Fix (one step, five changes)

1. **`timeout 300s`** wraps the `claude -p` invocation. Exit 124 is handled explicitly with a `::warning::investigate call timed out at 300s` and routes to 8b no-findings. 5 min > typical investigate runtime; < the job-level default 6 hours.
2. **`2>/tmp/triage/investigate-stderr.log`** replaces `2>/dev/null`. Stderr is captured to an archived file so next time a call hangs, the CLI's own progress/error traces are available for post-mortem.
3. **`investigate-raw.json`** archived before any parsing — the full CLI response including `.result`, `.usage`, metadata.
4. **`investigate-payload.txt`** archived after `.result` extraction but before schema checks.
5. **`.claude/scripts/triage/extract-json.py`** replaces the fence-strip + jq-presence-check. Uses `json.JSONDecoder.raw_decode` to find the first balanced JSON object, robust to leading AND trailing prose. Shape check now verifies each of the four required fields is an `array` — `{"findings": "oops"}` would have passed presence and exploded in `validate.sh` (addresses PR #459 review item 7 alongside item 6).

## Local testing

`extract-json.py` exercised against five payload shapes:

- Bare JSON → extracts cleanly
- Leading prose (`"Here is my investigation: {...}"`) → extracts JSON, drops prose
- Trailing prose (`"{...}\n\nLet me know..."`) → extracts JSON, drops prose
- Fence-wrapped (`\`\`\`json\n{...}\n\`\`\``) → extracts JSON from inside fences
- Pure prose → exit 1 (caller falls through to 8b no-findings)
- Malformed JSON → exit 2 (same)

`actionlint -shellcheck` clean.

## What this doesn't fix

- The *cause* of #394's hang. That needs a real reproduction with the stderr log captured — this PR just prevents a future hang from blocking the step for 6 hours.
- Why #424 and #442's payloads failed the old presence check. We'll learn that when we re-dispatch them and inspect `investigate-raw.json`.

## Re-dispatch plan after merge

- `gh workflow run issue-triage-v2.yml -f issue_number=424 -f dry_run=true`
- `gh workflow run issue-triage-v2.yml -f issue_number=442 -f dry_run=true`

If both succeed and produce `8a` comments, the parser was the culprit. If they still fail, the archived `investigate-raw.json` + `investigate-stderr.log` will tell us what the CLI emitted.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
60% AI / 40% Human
Claude: implemented the three hardening changes, wrote the Python extractor + smoke-tested it locally.
Human: directed the diagnosis on #394 (identified the `2>/dev/null` blindspot) and confirmed the fix scope.