### PR TITLE
fix(triage): pass investigate schema to claude CLI

### DIFF
--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -306,6 +306,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
+          schema=$(cat .claude/scripts/schemas/investigate.json)
           title=$(jq -r '.title' /tmp/triage/issue.json)
           body=$(jq -r '.body // ""' /tmp/triage/issue.json)
           classification=$(cat /tmp/triage/classification.json)
@@ -348,29 +349,25 @@ jobs:
           } > /tmp/triage/investigate-prompt.txt
 
           # The investigation call runs with tool access (read/grep) so
-          # Claude can verify claims against actual source. Output is
-          # the model's final message; we parse JSON out and validate
-          # shape.
+          # Claude can verify claims against actual source. `--json-schema`
+          # constrains the FINAL message; tool-call intermediates flow
+          # freely. Per CLI docs, validation is post-hoc — conforming
+          # output lands in `.structured_output`, prose in `.result`.
+          # We prefer `.structured_output` and fall back to the
+          # extract-json.py helper on the `.result` field in case the
+          # CLI hands back prose for any reason.
           #
-          # Hardening against the two failure modes seen in the first
-          # dispatch round (PR #460 follow-up):
-          #
-          # * `timeout 300s` bounds the step at 5 min so a wedged CLI
-          #   call can't run to the job-level timeout.
-          # * Stderr goes to an archived log file so post-mortem
-          #   debugging has something to read — previously `2>/dev/null`
-          #   swallowed everything, leaving a silent 8-min gap in the
-          #   step log when the call hung.
-          # * Raw CLI response + extracted payload are archived before
-          #   schema checks, so a schema-reject still leaves artifacts
-          #   to inspect.
-          # * JSON extraction uses Python's `raw_decode` — robust to
-          #   leading OR trailing prose around the JSON body, unlike
-          #   the fence-strip + jq-presence-check it replaces.
+          # Step hardening from earlier PR:
+          # * `timeout 300s` bounds the step at 5 min
+          # * Stderr to an archived log file so a silent hang is
+          #   post-mortem debuggable
+          # * Raw response + extracted payload archived before schema
+          #   checks so a reject still leaves artifacts to inspect
           set +o pipefail
           raw=$(timeout 300s claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
             --dangerously-skip-permissions \
             --output-format json \
+            --json-schema "${schema}" \
             --model claude-sonnet-4-6 \
             --max-budget-usd 3.00 \
             2>/tmp/triage/investigate-stderr.log)
@@ -389,28 +386,35 @@ jobs:
             exit 0
           fi
 
-          payload=$(printf '%s' "${raw}" | jq -r '.result // empty')
-          printf '%s' "${payload}" > /tmp/triage/investigate-payload.txt
+          # Prefer the CLI-validated structured_output when the schema
+          # fit cleanly.
+          extracted=$(printf '%s' "${raw}" | jq -c '.structured_output // empty')
 
-          if [[ -z "${payload}" ]]; then
-            echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::empty investigation result"
-            exit 0
+          if [[ -z "${extracted}" ]]; then
+            # Fallback: pull .result and try to rescue JSON from prose.
+            # Handles the case where the CLI's schema enforcement
+            # didn't land a structured_output (e.g. tool-use loop
+            # drifted and the CLI returned prose in .result).
+            payload=$(printf '%s' "${raw}" | jq -r '.result // empty')
+            printf '%s' "${payload}" > /tmp/triage/investigate-payload.txt
+
+            if [[ -z "${payload}" ]]; then
+              echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::empty investigation result"
+              exit 0
+            fi
+
+            extracted=$(python3 .claude/scripts/triage/extract-json.py \
+              < /tmp/triage/investigate-payload.txt) || {
+              echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
+              echo "::warning::no valid JSON object in investigation payload"
+              exit 0
+            }
           fi
-
-          # Extract the first complete JSON object from the payload.
-          # Handles leading prose ("Here is...") and trailing prose
-          # ("Let me know...") that the fence-strip didn't catch.
-          extracted=$(python3 .claude/scripts/triage/extract-json.py \
-            < /tmp/triage/investigate-payload.txt) || {
-            echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::no valid JSON object found in investigation payload"
-            exit 0
-          }
 
           # Type-check the four required top-level arrays — presence
           # alone would pass `{"findings": "oops"}` which then explodes
-          # in validate.sh (PR #459 review item 7).
+          # in validate.sh. When `--json-schema` bit, this is a no-op.
           if ! printf '%s' "${extracted}" | jq -e '
               (.findings | type == "array")
               and (.pattern_sweep | type == "array")


### PR DESCRIPTION
One-line CLI fix for the schema-drift observed in the re-dispatch of #424 and #442.

## Context

After the parser hardening in #461, the investigate step archives raw + payload + stderr diagnostics. The re-dispatch showed:

- Model emitted **valid JSON** (extractor read it cleanly)
- But with **creative shape** — extra top-level wrappers (`summary`, `classification`, `investigation_id`), missing required arrays (`pattern_sweep`, `proposed_anchors` omitted entirely), required per-finding fields nulled (`confidence`, `line_end`)

Root cause: the investigate call was the only Sonnet invocation in v2 without `--json-schema`. Classify and doublecheck use the flag and never drift.

## Fix

Add `--json-schema "${schema}"` to the investigate call. Per claude-code-guide research (and [Claude Code CLI docs](https://code.claude.com/docs/en/cli-reference.md)), the flag performs **post-hoc** validation after the agent loop — weaker than the Agent SDK's constrained decoding, but it catches the specific drift patterns seen above.

Parsing prefers the CLI-validated `.structured_output` field (populated when schema fit cleanly), falling back to `.result` + `extract-json.py` + shape-check for the case where the CLI returns prose on schema miss. The hardened fallback from #461 stays in place as the safety net.

## Escalation path if this isn't enough

If re-dispatch still shows drift, next step is the Agent SDK — constrained decoding via grammar compilation, documented as the right fit for "tool-enabled + structured output." That's a bigger change (~50 lines of Node/Python script replacing `claude -p`), so worth trying the one-line fix first.

## Test plan

- [ ] actionlint + shellcheck clean (confirmed locally)
- [ ] Merge + re-dispatch #424 and #442 with `dry_run=true`
- [ ] Archived `investigate-raw.json` should now populate `.structured_output` with all four required arrays, or we learn post-hoc validation isn't enough and escalate to SDK

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
30% AI / 70% Human
Claude: implemented the one-line flag addition and the structured_output / result fallback wiring.
Human: directed the diagnosis across three PRs (#460 dry-run, #461 parser hardening, this one) and scoped the escalation ladder — every time a failure mode surfaces, we pick the smallest fix that addresses it before escalating.