### PR TITLE
fix(triage): investigate timeout bypasses errexit + bump to 10m

### DIFF
--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -357,27 +357,34 @@ jobs:
           # extract-json.py helper on the `.result` field in case the
           # CLI hands back prose for any reason.
           #
-          # Step hardening from earlier PR:
-          # * `timeout 300s` bounds the step at 5 min
+          # Step hardening from earlier PRs:
+          # * `timeout 600s` bounds the step at 10 min
+          # * `if cmd; then; else` form — GHA's `bash -e` treats a
+          #   failing command substitution as a fatal error and aborts
+          #   before `claude_exit=$?` can run; the if-form is the only
+          #   reliable way to capture the exit code and branch on it.
+          #   Matters because a timeout (exit 124) must fall through to
+          #   8b gracefully, not fail the whole step.
           # * Stderr to an archived log file so a silent hang is
-          #   post-mortem debuggable
+          #   post-mortem debuggable.
           # * Raw response + extracted payload archived before schema
-          #   checks so a reject still leaves artifacts to inspect
-          set +o pipefail
-          raw=$(timeout 300s claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
-            --dangerously-skip-permissions \
-            --output-format json \
-            --json-schema "${schema}" \
-            --model claude-sonnet-4-6 \
-            --max-budget-usd 3.00 \
-            2>/tmp/triage/investigate-stderr.log)
-          claude_exit=$?
-          set -o pipefail
+          #   checks so a reject still leaves artifacts to inspect.
+          if raw=$(timeout 600s claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
+              --dangerously-skip-permissions \
+              --output-format json \
+              --json-schema "${schema}" \
+              --model claude-sonnet-4-6 \
+              --max-budget-usd 3.00 \
+              2>/tmp/triage/investigate-stderr.log); then
+            claude_exit=0
+          else
+            claude_exit=$?
+          fi
 
           printf '%s' "${raw}" > /tmp/triage/investigate-raw.json
 
           if [[ "${claude_exit}" == "124" ]]; then
-            echo "::warning::investigate call timed out at 300s"
+            echo "::warning::investigate call timed out at 600s"
             echo "investigate_ok=false" >> "$GITHUB_OUTPUT"
             exit 0
           elif [[ "${claude_exit}" != "0" ]]; then


### PR DESCRIPTION
Follow-up from the re-dispatch of #394 under PR #462's timeout change.

## Observed

`timeout 300s` bounded the step correctly, but the step failed with exit 124 rather than gracefully falling through to 8b. Downstream steps (Decide / Render / Label / Post) got skipped, and the raw / payload / stderr archives that the earlier hardening created were never written because the shell aborted at the assignment before `printf > investigate-raw.json`.

## Root cause

GHA default shell is `bash -e {0}`. With errexit on, a failing command substitution:

```bash
raw=$(timeout 300s claude -p ...)
```

propagates the non-zero exit and aborts the script BEFORE `claude_exit=$?` runs. My prior assumption that assignments were exempt from errexit under `bash -e` was wrong in this shell configuration.

## Fix

Use the if-form — the only reliable way to catch a failing command substitution under `bash -e`:

```bash
if raw=$(timeout 600s claude -p ... 2>log); then
  claude_exit=0
else
  claude_exit=$?
fi
```

Classify and doublecheck use the `cmd || { exit 1 }` pattern, which works because `||` catches the failure. I didn't use that on investigate because I wanted to preserve the exit code for branching (timeout vs other failures), and `cmd || branch-on-$?` is awkward.

## Also bumped timeout 300s → 600s

`#424` ran 218s, `#442` ran 220s — 300s left almost no headroom. Doubling gives room for complex issues to converge while still being well short of the ~9-minute hang that motivated the timeout.

## Test plan

- [x] actionlint + shellcheck clean (confirmed locally)
- [ ] Re-dispatch #394 — expect: either clean completion (drift → 8b version-drift + drift-bridge candidates) or graceful 8b no-findings with archived stderr telling us what happened

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
30% AI / 70% Human
Claude: diagnosed the errexit propagation from the run logs, proposed and wrote the if-form fix.
Human: spotted that the step failed rather than gracefully falling through, and called for the timeout extension to 10m based on observed runtimes.