### PR TITLE
fix(triage): raise 8b comment word cap 150 → 300

### DIFF
--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -756,9 +756,14 @@ jobs:
             exit 1
           fi
 
+          # 300-word cap accommodates the optional drift-bridge-
+          # candidates block, which alone can add ~130 words for 10
+          # bullets. Spec §8b flagged "account for optional
+          # drift-bridge-candidates block"; the original 150 was the
+          # base-comment budget.
           words=$(wc -w < /tmp/triage/comment.md)
-          if [[ "${words}" -gt 150 ]]; then
-            echo "::error::8b comment exceeds 150 words (got ${words})"
+          if [[ "${words}" -gt 300 ]]; then
+            echo "::error::8b comment exceeds 300 words (got ${words})"
             exit 1
           fi
 


### PR DESCRIPTION
Re-dispatch of #394 (version-drift test) showed the full drift-routing path works end-to-end — investigate → validate → drift detection → drift-bridge sweep → 8b render — but the post-processor's word cap rejected the rendered comment at **189 words > 150 cap**. Downstream steps were skipped and the workflow failed.

## Root cause

The 8b comment has three optional expansion points:

- Base comment (reason line + boilerplate): ~50 words
- Drift-bridge-candidates block: ~130 words for 10 bullets (what fired here)
- First-issue privacy note: ~30 words

Spec §8b already flagged this:

> Verify length is under 150 words (account for optional drift-bridge-candidates block)

The parenthetical acknowledged the block expands the comment, but the 150 cap was never adjusted when the drift-bridge extension landed in Phase 2.

## Fix

`150 → 300`. Covers observed worst case (~190) with headroom. Comment added to explain the budget breakdown inline.

Capping the drift-bridge render at N entries is a separate signal-to-noise concern (10 commits is more than most readers want to scan) and can land separately if dispatched runs show scannability issues.

## Test plan

- [x] actionlint clean
- [ ] Re-dispatch #394 — expect clean 8b completion this time

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
20% AI / 80% Human
Claude: diagnosed the word-count reject from the archived comment.md and wrote the one-line raise.
Human: pointed to option 1 (raise only) over option 2 (raise + cap entries), keeping the fix tight.