### PR TITLE
chore(codeowners): add @sabiut for testing & release quality

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,6 +65,21 @@
 /STYLEGUIDE.md                          @aaddrick
 /docs/                                  @aaddrick
 
+# ---- Testing & release quality ----
+# Integration test suite, artifact validation, flag-parsing tests,
+# and the --doctor diagnostic tool. Cowork-specific tests stay with
+# @RayCharlizard via the override below.
+/tests/                                 @sabiut
+/scripts/doctor.sh                      @sabiut
+/.github/workflows/test-artifacts.yml   @sabiut
+/.github/workflows/test-flags.yml       @sabiut
+
+# Shared review — either owner can approve.
+# TROUBLESHOOTING is mostly the --doctor user-facing guide; lint
+# touches everything, so either maintainer can sign off.
+/docs/TROUBLESHOOTING.md                @aaddrick @sabiut
+/.github/workflows/shellcheck.yml       @aaddrick @sabiut
+
 #===============================================================================
 # Overrides — listed last so their assignments stick against the
 # broad globs above (/docs/, /.github/, etc.)


### PR DESCRIPTION
## Summary

- Adds @sabiut as CODEOWNER for testing & release-quality paths: `/tests/`, `/scripts/doctor.sh`, and the `test-artifacts` + `test-flags` workflows.
- Shared review with @aaddrick on `/docs/TROUBLESHOOTING.md` and `/.github/workflows/shellcheck.yml` (either owner can approve).
- @RayCharlizard's `/tests/cowork-*.bats` override at the bottom still wins for cowork tests (last-match-wins).

Scope and handle were confirmed with @sabiut via email. Announcement discussion: #467.

## Test plan

- [x] Handle verified via `gh api users/sabiut`
- [ ] GitHub parses the file without warnings (Settings → Code review)
- [ ] A test-only PR correctly requests review from @sabiut

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
40% AI / 60% Human
Claude: drafted the CODEOWNERS block, commit message, and PR description
Human: negotiated scope with @sabiut via email, confirmed the GitHub handle, decided on shared-review for TROUBLESHOOTING.md and shellcheck.yml