### PR TITLE
fix(triage): pull broken-expectation rule up into first-pass classify

### DIFF
--- a/.claude/scripts/prompts/classify.txt
+++ b/.claude/scripts/prompts/classify.txt
@@ -24,6 +24,30 @@ JSON only, matching the attached schema. No prose outside the schema.
   "Please add", "support for", "it would be nice if", "currently there's no
   way to". Matches the repo's GitHub `enhancement` label.
 - `question` — usage or config question, not a defect claim.
+
+### Bug vs. enhancement — broken-expectation rule
+
+A report that says a behavior **contradicts a reasonable expectation**
+is a `bug` even when it's framed as a "please add" or "should support"
+ask. Defects hide inside enhancement-shaped framing:
+
+- "The app quits when the last window closes; breaks minimize-to-tray"
+  → bug (broken expectation), not enhancement, even though it sounds
+  like "please add minimize-to-tray"
+- "git clone pulls 6 GiB again; regressed since #294" → bug
+  (regression), not enhancement
+- "CTRL+C doesn't close the app" → bug (expectation broken), not a
+  request to add CTRL+C support
+- Any phrase in the shape "breaks X" / "stopped working" / "broken
+  since" / "used to work" / "regressed" / "contradicts Y expectation"
+  is a strong bug signal; let it outweigh adjacent "please add"
+  framing.
+
+Prefer `enhancement` only when the report is a **pure** request for a
+capability that was never there — no broken expectation anywhere in
+the body. When both a broken expectation and a request-for-change are
+present, the broken expectation wins.
+
 - `duplicate` — body explicitly references another issue as a duplicate OR
   obviously restates an existing issue you can identify. Set `duplicate_of`
   to the integer issue number.


### PR DESCRIPTION
## Summary

Post-#466 rename verification on #448, #449, and #424 showed the first-pass classifier now leans `enhancement` on all three, while the doublecheck correctly reads them as `bug`. All three defer via the disagreement failsafe — safe, but wastes the doublecheck as a classification-recovery mechanism rather than a verification one.

The "broken expectation wins" rule was added to the doublecheck prompt in #466 but not to the primary classify prompt. This fix pulls it up, with explicit examples drawn from the test-set failure cases so future calibration drift is easier to spot.

## Test plan

- [ ] Re-dispatch #448, #449, #424 with `dry_run=true` on `main` after merge
- [ ] #448 first-pass: expect `bug` (contradicts minimize-to-tray expectation)
- [ ] #424 first-pass: expect `bug` (CTRL+C expectation broken) — pre-rename behavior
- [ ] #449 first-pass: expect `bug` (regression framing) — matches current doublecheck read

## Notes

Post-rename validation on #449 flagged it as bug via doublecheck on the "regressed since #294" language, even though you read it as enhancement. The new classify rule is consistent with that — "regressed" is called out explicitly as a bug signal. If you'd prefer #449 to stay as enhancement, the "regression" framing needs a separate carve-out (not in this PR). Flagging for your read after the verification dispatches.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
10% AI / 90% Human
Claude: wrote the rule addition; test-set examples pulled from PR #466 validation
Human: spotted the first-pass regression in the PR #466 verification, scoped the fix