### PR TITLE
chore(triage): v2 production cutover

### DIFF
--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -1,8 +1,8 @@
 name: Issue Triage v2
 run-name: |
-  Triage v2: #${{ inputs.issue_number }}
+  Triage v2: #${{ github.event.issue.number || inputs.issue_number }}
 
-# Phase 4 — Stages 1, 2, 3, 4, 5, 6, 7, 8a, 8b, 8c, 9.
+# Production — Stages 1, 2, 3, 4, 5, 6, 7, 8a, 8b, 8c, 9.
 # Bug / duplicate / enhancement classifications run through
 # investigate → mechanical-validate → adversarial-review → decision
 # gate. Decision gate selects between 8a (bug findings), 8c
@@ -14,10 +14,17 @@ run-name: |
 # keeps it at reduced weight in the avg-confidence gate; reject
 # drops it. Confirmed-duplicate routing fires only when the reviewer
 # rated the duplicate_of target exact or related.
-# v1 (issue-triage.yml) stays wired to its own triggers during rollout.
+#
+# Triggers: fires automatically on `issues: [opened]`; also accepts
+# `workflow_dispatch` for re-runs, dry-run testing, and manual
+# triage on backfilled issues. v1 (issue-triage.yml) is kept as a
+# workflow_dispatch-only fallback — its `issues` trigger was
+# disabled when v2 took over production routing.
 # See docs/issue-triage/{README.md,implementation-plan.md}.
 
 on:
+  issues:
+    types: [opened]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -35,7 +42,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: issue-triage-v2-${{ inputs.issue_number }}
+  group: issue-triage-v2-${{ github.event.issue.number || inputs.issue_number }}
   cancel-in-progress: true
 
 jobs:
@@ -53,7 +60,7 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
-          ISSUE_NUMBER: ${{ inputs.issue_number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
         run: |
           echo "issue_number=${ISSUE_NUMBER}" >> "$GITHUB_OUTPUT"
 
@@ -539,7 +546,10 @@ jobs:
           # CLI hands back prose for any reason.
           #
           # Step hardening from earlier PRs:
-          # * `timeout 600s` bounds the step at 10 min
+          # * `timeout 1200s` bounds the step at 20 min. Bumped from
+          #   10m after repeated timeouts on complex issues (e.g. #311
+          #   on two consecutive dispatches) where the investigator
+          #   needed more tool-call budget to verify claims.
           # * `if cmd; then; else` form — GHA's `bash -e` treats a
           #   failing command substitution as a fatal error and aborts
           #   before `claude_exit=$?` can run; the if-form is the only
@@ -550,7 +560,7 @@ jobs:
           #   post-mortem debuggable.
           # * Raw response + extracted payload archived before schema
           #   checks so a reject still leaves artifacts to inspect.
-          if raw=$(timeout 600s claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
+          if raw=$(timeout 1200s claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
               --dangerously-skip-permissions \
               --output-format json \
               --json-schema "${schema}" \

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,10 +1,17 @@
-name: Issue Triage
+name: Issue Triage (v1 — manual fallback only)
 run-name: |
-  Triage: #${{ github.event.issue.number || inputs.issue_number }}
+  Triage v1: #${{ inputs.issue_number }}
+
+# v1 pipeline kept as a workflow_dispatch-only fallback. Automatic
+# triggering on `issues` was removed when v2 (issue-triage-v2.yml)
+# took over production routing. If v2 is ever paused or rolled back,
+# re-enable the `issues: [opened, reopened]` trigger here.
+#
+# Kept (not deleted) because v1 uses different code paths for
+# investigation and label application, which still occasionally help
+# for backfilled issues the maintainer wants a second opinion on.
 
 on:
-  issues:
-    types: [opened, reopened]
   workflow_dispatch:
     inputs:
       issue_number:
@@ -18,7 +25,7 @@ permissions:
   actions: read
 
 concurrency:
-  group: issue-triage-${{ github.event.issue.number || inputs.issue_number }}
+  group: issue-triage-${{ inputs.issue_number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Cutover PR. Three changes bundled because they land together.

### 1. v2 production trigger

`issue-triage-v2.yml` gains `issues: [opened]` alongside existing `workflow_dispatch`. `run-name`, `concurrency.group`, and the gate step resolve the issue number via `github.event.issue.number || inputs.issue_number` so both paths work. The existing `inputs.dry_run != true` gate on label/comment application already handles the issues-trigger case correctly (empty `inputs.dry_run` != `true`, so production-trigger runs post + label).

### 2. v1 decommissioned as automatic

`issue-triage.yml` keeps `workflow_dispatch` for manual fallback but drops its `issues: [opened, reopened]` trigger. The file stays (not deleted) — v1 uses different investigation and labeling code paths; keeping it around for manual second-opinion runs on backfilled issues is cheap. Rollback to v1-as-primary is a one-line change in either file.

### 3. Investigate timeout 600s → 1200s

Bumped after two consecutive timeouts on #311 (exit 124, empty `investigate-raw.json`) during Phase 4 + drift-as-banner verification. The investigator needs more tool-call budget on complex issues. Review step stays at 600s — it runs without tool access and has never timed out.

## Rollback plan

`git revert` this commit restores v1's automatic trigger and drops v2's. Single-atomic rollback; no partial state.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
10% AI / 90% Human
Claude: wrote the workflow edits and commit scope per the user's direction
Human: called the cutover, scoped what stays and what flips, chose the 20-min timeout value