### PR TITLE
fix(triage): normalize claimed_version before drift compare

### DIFF
--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -296,6 +296,14 @@ jobs:
       # claimed_version against the repo variable CLAUDE_DESKTOP_VERSION.
       # Investigation still runs regardless; the drift flag steers the
       # final decision gate.
+      #
+      # Both sides are normalized before compare: strip a leading `v`,
+      # then strip anything from the first `-` or space onward.
+      # Handles the common case where a reporter pastes the deb
+      # package version (`claude-desktop 1.3561.0-2.0.0` — upstream +
+      # REPO_VERSION suffix) or the AppImage filename (which can
+      # carry the same suffix). A bare upstream version still
+      # round-trips unchanged.
       - name: Check version drift
         id: drift
         if: steps.route.outputs.route == 'investigate'
@@ -304,11 +312,22 @@ jobs:
         run: |
           claimed=$(jq -r '.claimed_version // ""' \
             /tmp/triage/classification.json)
-          if [[ -n "${claimed}" && "${claimed}" != "null" \
-              && -n "${CURRENT_VERSION}" \
-              && "${claimed}" != "${CURRENT_VERSION}" ]]; then
+
+          normalize() {
+            local v="${1#v}"
+            v="${v%%-*}"
+            v="${v%% *}"
+            printf '%s' "${v}"
+          }
+
+          claimed_norm=$(normalize "${claimed}")
+          current_norm=$(normalize "${CURRENT_VERSION}")
+
+          if [[ -n "${claimed_norm}" && "${claimed_norm}" != "null" \
+              && -n "${current_norm}" \
+              && "${claimed_norm}" != "${current_norm}" ]]; then
             echo "drift_detected=true" >> "$GITHUB_OUTPUT"
-            echo "::notice::version drift: claimed=${claimed} current=${CURRENT_VERSION}"
+            echo "::notice::version drift: claimed=${claimed} (normalized ${claimed_norm}) current=${CURRENT_VERSION} (normalized ${current_norm})"
           else
             echo "drift_detected=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Triage on #481 posted an `⚠ You reported this on 1.3561.0-2.0.0; the bot investigated against the current release 1.3561.0…` drift banner even though the reporter was on the current release. The classifier extracted the version verbatim from their `Package: claude-desktop 1.3561.0-2.0.0` line — that's `CLAUDE_DESKTOP_VERSION-REPO_VERSION`, the full deb package version string. The naive `claimed != CLAUDE_DESKTOP_VERSION` compare in Stage 3a didn't know about the `-REPO_VERSION` suffix and flagged drift.

## Fix

Normalize both sides of the compare:

1. Strip a leading `v` (handles copy-paste with prefix)
2. Strip everything from the first `-` or space (handles deb-packaged version suffixes + whitespace qualifiers)

Tested locally:

| Input | Normalized |
|---|---|
| `1.3561.0` | `1.3561.0` |
| `1.3561.0-2.0.0` | `1.3561.0` |
| `v1.3561.0` | `1.3561.0` |
| `v1.3561.0-1` | `1.3561.0` |
| `1.3561.0 stable` | `1.3561.0` |
| `1.1.7464` | `1.1.7464` |

Same normalization applied to `CURRENT_VERSION` for symmetry — defensive against a future change where the repo variable might pick up a suffix.

## Scope

One workflow edit, one new bash function (`normalize`), unchanged logic flow. actionlint clean.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
10% AI / 90% Human
Claude: wrote the normalizer + commit message
Human: spotted the miscalled drift on #481, scoped the fix