### PR TITLE
fix(shortcut): scope Ctrl+Q to focused window, not system-wide

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -132,6 +132,20 @@ Module.prototype.require = function(id) {
               this.webContents.insertCSS(LINUX_CSS).catch(() => {});
             });
 
+            // Quit on Ctrl+Q, but only when Claude has keyboard focus.
+            // Replaces a prior globalShortcut registration that grabbed
+            // the key system-wide and, on non-QWERTY layouts (e.g.
+            // AZERTY), swallowed other shortcuts like Ctrl+A because
+            // Electron matches globals by physical keycode. Fixes: #399
+            this.webContents.on('before-input-event', (event, input) => {
+              if (input.type !== 'keyDown') return;
+              if (!input.control) return;
+              if (input.alt || input.shift || input.meta) return;
+              if (input.key !== 'q' && input.key !== 'Q') return;
+              event.preventDefault();
+              electronModule.app.quit();
+            });
+
             // In 'hidden' mode, suppress Alt toggle by re-hiding
             // on every show event. In 'auto' mode, let
             // autoHideMenuBar handle the toggle natively.
@@ -319,29 +333,6 @@ Module.prototype.require = function(id) {
           console.log('[Frame Fix] Menu bar hidden on all windows');
         }
       };
-
-      // Register Ctrl+Q as a global shortcut to quit the app.
-      // The upstream menu has CmdOrCtrl+Q but Electron doesn't fire
-      // menu accelerators when the menu bar is hidden/auto-hide on
-      // Linux. This ensures Ctrl+Q always works. Fixes: #321
-      const registerQuitShortcut = () => {
-        try {
-          if (!result.globalShortcut.isRegistered('CommandOrControl+Q')) {
-            result.globalShortcut.register('CommandOrControl+Q', () => {
-              console.log('[Frame Fix] Ctrl+Q pressed, quitting');
-              result.app.quit();
-            });
-            console.log('[Frame Fix] Ctrl+Q quit shortcut registered');
-          }
-        } catch (e) {
-          console.log('[Frame Fix] Failed to register Ctrl+Q shortcut:', e.message);
-        }
-      };
-      if (result.app.isReady()) {
-        registerQuitShortcut();
-      } else {
-        result.app.once('ready', registerQuitShortcut);
-      }
 
       console.log('[Frame Fix] Patches built successfully');
     }


### PR DESCRIPTION
## Summary

Replaces the `globalShortcut.register('CommandOrControl+Q', ...)` call in `scripts/frame-fix-wrapper.js` with a per-window `webContents.on('before-input-event', ...)` handler. Ctrl+Q now only quits Claude when Claude has keyboard focus.

## The bug

The original global registration (added alongside #321 so Ctrl+Q kept working with the menu bar hidden) installed a compositor-level passive grab for the physical keycode mapped to US-layout "Q." Two consequences:

1. **Every layout loses Ctrl+Q system-wide.** Hitting Ctrl+Q in Firefox, a terminal, or any other app killed Claude in the background instead. Reported in #399.
2. **Non-QWERTY layouts also lose whatever keysym sits at the US "Q" position.** On AZERTY (`be,us`), that's "A," so Ctrl+A stopped working everywhere while Claude was running. Reported in #474 with the tell-tale `[Frame Fix] Ctrl+Q quit shortcut registered` in the launcher log. Confirmed by MaxiusVoys via `setxkbmap us` reversing the symptom.

On X11 the grab is exclusive — the victim app never sees the key. On Wayland the grab only bites XWayland clients, which is why the impact varied by session type in the reports.

## The fix

`before-input-event` fires on `webContents` before Chromium's keyboard routing and only when the window has keyboard focus. No compositor grab, no layout-keycode coupling. Matches `Ctrl+Q` / `Ctrl+q` with no other modifiers and calls `electronModule.app.quit()`.

The original #321 motivation (menu accelerators don't fire when the menu bar is hidden on Linux) is preserved — `before-input-event` intercepts the key directly and is independent of menu visibility.

## Test plan

- [x] Build AppImage locally with `./build.sh --build appimage --clean no`
- [x] Claude focused → Ctrl+Q quits Claude
- [x] Kate focused (Claude in tray) → Ctrl+Q closes Kate only; Claude stays running
- [ ] Firefox focused → Ctrl+Q triggers Firefox's "quit with N tabs" prompt; Claude unaffected
- [ ] AZERTY layout (`setxkbmap be,us`) → Ctrl+A works in other apps while Claude runs
- [ ] Menu-bar-hidden case still lets Ctrl+Q quit when Claude is focused (covers #321 regression surface)

Fixes #399
Fixes #474

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
20% AI / 80% Human
Claude: drafted the diagnosis, narrowed the fix to before-input-event, wrote the patch and PR body
Human: reviewed the root-cause reasoning, tested the built AppImage end-to-end, confirmed the repro and the fix behavior