### PR TITLE
fix(cowork): forward CLAUDE_CODE_OAUTH_TOKEN to VM spawn env (#482)

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Special thanks to:
 - **[martin152](https://github.com/martin152)** for detailed diagnosis and a complete patch for three launcher cleanup bugs: `cleanup_orphaned_cowork_daemon` self-match, `cleanup_stale_cowork_socket` socat dependency no-op, and the same self-match in `--doctor`
 - **[hfyeh](https://github.com/hfyeh)** for diagnosing the Ubuntu 24.04 AppArmor unprivileged-userns block on Cowork bwrap and contributing the AppArmor profile workaround
 - **[davidamacey](https://github.com/davidamacey)** for identifying and fixing the XRDP GPU compositing blank-window issue on remote desktop sessions
+- **[pb3ck](https://github.com/pb3ck)** for diagnosing the Cowork `CLAUDE_CODE_OAUTH_TOKEN` env-strip bug with a working reference diff
 
 ## Sponsorship
 

--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -167,33 +167,27 @@ function filterEnv(source, stripPrefixes = []) {
 }
 
 /**
- * Re-add explicitly-forwarded keys from process.env that the
- * CLAUDE_CODE_ prefix strip in filterEnv removed. Uses
- * `mergedEnv[key] === undefined` so an explicit empty-string in
- * appEnv (e.g. Foundry mode signalling "no token") wins over the
- * daemon's inherited value.
+ * Shared base env for HostBackend (buildSpawnEnv) and
+ * BwrapBackend.spawn: strips the CLAUDE_CODE_ prefix from
+ * process.env, overlays appEnv, forces TERM, then re-adds
+ * FORWARDED_ENV_KEYS as a fallback.
+ *
+ * The `=== undefined` check (not truthiness) lets an explicit
+ * empty-string in appEnv (e.g. Foundry mode signalling "no
+ * token") win over the daemon's inherited value.
  */
-function forwardAuthEnv(mergedEnv) {
+function buildBaseSpawnEnv(appEnv) {
+    const mergedEnv = {
+        ...filterEnv(process.env, ['CLAUDE_CODE_']),
+        ...filterEnv(appEnv || {}),
+        TERM: 'xterm-256color',
+    };
     for (const key of FORWARDED_ENV_KEYS) {
         if (process.env[key] && mergedEnv[key] === undefined) {
             mergedEnv[key] = process.env[key];
         }
     }
     return mergedEnv;
-}
-
-/**
- * Shared base env construction for both HostBackend (buildSpawnEnv)
- * and BwrapBackend.spawn. Strips the CLAUDE_CODE_ prefix from
- * process.env (stale daemon inheritance), overlays appEnv, forces
- * TERM, then re-adds FORWARDED_ENV_KEYS as a fallback.
- */
-function buildBaseSpawnEnv(appEnv) {
-    return forwardAuthEnv({
-        ...filterEnv(process.env, ['CLAUDE_CODE_']),
-        ...filterEnv(appEnv || {}),
-        TERM: 'xterm-256color',
-    });
 }
 
 // ============================================================

--- a/scripts/cowork-vm-service.js
+++ b/scripts/cowork-vm-service.js
@@ -139,6 +139,21 @@ const BLOCKED_ENV_KEYS = new Set([
 ]);
 
 /**
+ * CLAUDE_CODE_* keys forwarded from process.env despite the prefix
+ * strip in filterEnv. Upstream's seA() intends these to arrive via
+ * the spawn RPC's params.env, but on Linux the daemon's inherited
+ * process.env is the only surviving source, so we re-add it as a
+ * fallback. appEnv values take precedence when present.
+ *
+ * Caveat: process.env is snapshotted at daemon launch, so a token
+ * refresh in ~/.claude/.credentials.json won't be picked up until
+ * the daemon restarts.
+ *
+ * See https://github.com/aaddrick/claude-desktop-debian/issues/482.
+ */
+const FORWARDED_ENV_KEYS = ['CLAUDE_CODE_OAUTH_TOKEN'];
+
+/**
  * Filter environment variables, removing blocked keys and optional prefixes.
  */
 function filterEnv(source, stripPrefixes = []) {
@@ -149,6 +164,36 @@ function filterEnv(source, stripPrefixes = []) {
         result[k] = v;
     }
     return result;
+}
+
+/**
+ * Re-add explicitly-forwarded keys from process.env that the
+ * CLAUDE_CODE_ prefix strip in filterEnv removed. Uses
+ * `mergedEnv[key] === undefined` so an explicit empty-string in
+ * appEnv (e.g. Foundry mode signalling "no token") wins over the
+ * daemon's inherited value.
+ */
+function forwardAuthEnv(mergedEnv) {
+    for (const key of FORWARDED_ENV_KEYS) {
+        if (process.env[key] && mergedEnv[key] === undefined) {
+            mergedEnv[key] = process.env[key];
+        }
+    }
+    return mergedEnv;
+}
+
+/**
+ * Shared base env construction for both HostBackend (buildSpawnEnv)
+ * and BwrapBackend.spawn. Strips the CLAUDE_CODE_ prefix from
+ * process.env (stale daemon inheritance), overlays appEnv, forces
+ * TERM, then re-adds FORWARDED_ENV_KEYS as a fallback.
+ */
+function buildBaseSpawnEnv(appEnv) {
+    return forwardAuthEnv({
+        ...filterEnv(process.env, ['CLAUDE_CODE_']),
+        ...filterEnv(appEnv || {}),
+        TERM: 'xterm-256color',
+    });
 }
 
 // ============================================================
@@ -267,11 +312,7 @@ function findPrimaryMount(mountMap) {
  * CLAUDE_CONFIG_DIR and CLAUDE_COWORK_MEMORY_PATH_OVERRIDE using mountMap.
  */
 function buildSpawnEnv(appEnv, mountMap) {
-    const mergedEnv = {
-        ...filterEnv(process.env, ['CLAUDE_CODE_']),
-        ...filterEnv(appEnv || {}),
-        TERM: 'xterm-256color',
-    };
+    const mergedEnv = buildBaseSpawnEnv(appEnv);
 
     // Translate CLAUDE_CONFIG_DIR from guest path to host path, or
     // remove it so Claude Code falls back to ~/.claude/.
@@ -1227,11 +1268,7 @@ class BwrapBackend extends LocalBackend {
         // Guest paths (/sessions/...) exist inside our bwrap sandbox,
         // so pass args and env through as-is (no guest->host translation).
         const rawArgs = params.args || [];
-        const mergedEnv = {
-            ...filterEnv(process.env, ['CLAUDE_CODE_']),
-            ...filterEnv(params.env || {}),
-            TERM: 'xterm-256color',
-        };
+        const mergedEnv = buildBaseSpawnEnv(params.env);
 
         // Build a minimal sandbox: empty tmpfs root with only the
         // necessary system paths bound in read-only. This avoids

--- a/tests/cowork-path-translation.bats
+++ b/tests/cowork-path-translation.bats
@@ -222,21 +222,18 @@ function filterEnv(source, stripPrefixes = []) {
     return result;
 }
 
-function forwardAuthEnv(mergedEnv) {
+function buildBaseSpawnEnv(appEnv) {
+    const mergedEnv = {
+        ...filterEnv(process.env, ["CLAUDE_CODE_"]),
+        ...filterEnv(appEnv || {}),
+        TERM: "xterm-256color",
+    };
     for (const key of FORWARDED_ENV_KEYS) {
         if (process.env[key] && mergedEnv[key] === undefined) {
             mergedEnv[key] = process.env[key];
         }
     }
     return mergedEnv;
-}
-
-function buildBaseSpawnEnv(appEnv) {
-    return forwardAuthEnv({
-        ...filterEnv(process.env, ["CLAUDE_CODE_"]),
-        ...filterEnv(appEnv || {}),
-        TERM: "xterm-256color",
-    });
 }
 
 function buildSpawnEnv(appEnv, mountMap) {

--- a/tests/cowork-path-translation.bats
+++ b/tests/cowork-path-translation.bats
@@ -210,6 +210,8 @@ const BLOCKED_ENV_KEYS = new Set([
     "CLAUDECODE", "ELECTRON_RUN_AS_NODE", "ELECTRON_NO_ASAR",
 ]);
 
+const FORWARDED_ENV_KEYS = ["CLAUDE_CODE_OAUTH_TOKEN"];
+
 function filterEnv(source, stripPrefixes = []) {
     const result = {};
     for (const [k, v] of Object.entries(source)) {
@@ -220,12 +222,25 @@ function filterEnv(source, stripPrefixes = []) {
     return result;
 }
 
-function buildSpawnEnv(appEnv, mountMap) {
-    const mergedEnv = {
+function forwardAuthEnv(mergedEnv) {
+    for (const key of FORWARDED_ENV_KEYS) {
+        if (process.env[key] && mergedEnv[key] === undefined) {
+            mergedEnv[key] = process.env[key];
+        }
+    }
+    return mergedEnv;
+}
+
+function buildBaseSpawnEnv(appEnv) {
+    return forwardAuthEnv({
         ...filterEnv(process.env, ["CLAUDE_CODE_"]),
         ...filterEnv(appEnv || {}),
         TERM: "xterm-256color",
-    };
+    });
+}
+
+function buildSpawnEnv(appEnv, mountMap) {
+    const mergedEnv = buildBaseSpawnEnv(appEnv);
     if (mergedEnv.CLAUDE_CONFIG_DIR &&
         mergedEnv.CLAUDE_CONFIG_DIR.startsWith("/sessions/")) {
         const translated = translateGuestPath(
@@ -1114,6 +1129,55 @@ assertEqual(env.GOOD_VAR, 'keep', 'non-blocked kept');
 	run node -e "${NODE_PREAMBLE}
 const env = buildSpawnEnv({ TERM: 'dumb' }, {});
 assertEqual(env.TERM, 'xterm-256color', 'TERM forced');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+# Regression coverage for issue #482: the CLAUDE_CODE_ prefix strip used to
+# remove CLAUDE_CODE_OAUTH_TOKEN from process.env, severing the only auth
+# channel available to the in-VM claude binary.
+
+@test "buildSpawnEnv: forwards CLAUDE_CODE_OAUTH_TOKEN from process.env" {
+	CLAUDE_CODE_OAUTH_TOKEN='tok-from-daemon' run node -e "${NODE_PREAMBLE}
+const env = buildSpawnEnv({}, {});
+assertEqual(env.CLAUDE_CODE_OAUTH_TOKEN,
+    'tok-from-daemon',
+    'OAUTH_TOKEN forwarded from process.env');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "buildSpawnEnv: appEnv CLAUDE_CODE_OAUTH_TOKEN wins over process.env" {
+	CLAUDE_CODE_OAUTH_TOKEN='tok-from-daemon' run node -e "${NODE_PREAMBLE}
+const env = buildSpawnEnv(
+    { CLAUDE_CODE_OAUTH_TOKEN: 'tok-from-app' },
+    {}
+);
+assertEqual(env.CLAUDE_CODE_OAUTH_TOKEN,
+    'tok-from-app',
+    'appEnv token takes precedence');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "buildSpawnEnv: explicit empty appEnv token wins over process.env" {
+	CLAUDE_CODE_OAUTH_TOKEN='tok-from-daemon' run node -e "${NODE_PREAMBLE}
+const env = buildSpawnEnv(
+    { CLAUDE_CODE_OAUTH_TOKEN: '' },
+    {}
+);
+assertEqual(env.CLAUDE_CODE_OAUTH_TOKEN,
+    '',
+    'explicit empty-string preserved');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "buildSpawnEnv: still strips unrelated CLAUDE_CODE_* from process.env" {
+	CLAUDE_CODE_SSE_PORT='9999' run node -e "${NODE_PREAMBLE}
+const env = buildSpawnEnv({}, {});
+assert(!('CLAUDE_CODE_SSE_PORT' in env),
+    'non-allowlisted CLAUDE_CODE_ var still stripped');
 "
 	[[ "$status" -eq 0 ]]
 }


### PR DESCRIPTION
## Summary

Fixes #482 — in-VM `claude` shell tool calls returning `Not logged in · Please run /login` on Cowork mode, even with a valid `~/.claude/.credentials.json` and all doctor checks green.

`buildSpawnEnv` and `BwrapBackend.spawn` both call `filterEnv(process.env, ['CLAUDE_CODE_'])`, which strips every `CLAUDE_CODE_*` key from the daemon's env — including `CLAUDE_CODE_OAUTH_TOKEN`. The bwrap sandbox mounts `$HOME` as an empty `--dir` (not a bind), so `~/.claude/.credentials.json` is inaccessible inside. Env is the only viable auth channel, and the strip severed it.

## What changed

- `scripts/cowork-vm-service.js`:
  - New `FORWARDED_ENV_KEYS = ['CLAUDE_CODE_OAUTH_TOKEN']` allowlist.
  - New `forwardAuthEnv(mergedEnv)` helper — re-adds keys from `process.env` when `appEnv` doesn't provide them. Uses `=== undefined` so an explicit empty string in `appEnv` (e.g. Foundry mode) still wins.
  - New `buildBaseSpawnEnv(appEnv)` — factors the filter/merge/forward logic into one path so the two spawn sites can't drift.
  - `buildSpawnEnv` and `BwrapBackend.spawn` now both route through `buildBaseSpawnEnv`. Reporter's diff only covered `buildSpawnEnv`; the bwrap site needed the same fix.
- `tests/cowork-path-translation.bats`:
  - Updated the inline harness to mirror the new helpers.
  - Added 4 regression tests: token forwarded from `process.env`; `appEnv` wins; explicit empty string preserved; unrelated `CLAUDE_CODE_*` keys still stripped.

## Framing (why this is a fallback, not the root fix)

Upstream's `seA(e)` at `.vite/build/index.js:471` does include `CLAUDE_CODE_OAUTH_TOKEN: e.oauthToken` in the env payload it assembles for spawn. On Linux something in the RPC path to the cowork daemon loses that payload before it hits `params.env`, which is why the original strip (documented as "app provides its own set via the env param below" in commit 25e7932) breaks in practice. Investigating the upstream plumbing is out of scope here — this PR restores the `process.env` fallback that was working before the strip, and adds a comment calling out the staleness caveat (snapshot at daemon launch; token refresh mid-session still requires restart).

## Credit

Full diagnosis and the original diff by @pb3ck in the issue body — thank you for the thorough writeup including `/proc/<pid>/environ` inspection. This PR extends the fix to the second call site (`BwrapBackend.spawn`) you didn't cover, factors a shared helper, and adds regression tests.

## Test plan

- [x] `npx bats tests/cowork-path-translation.bats` — 72/72 pass including 4 new tests (63–66)
- [x] `npx bats tests/cowork-*.bats` — all cowork suites pass
- [x] `node --check scripts/cowork-vm-service.js` — syntax clean
- [x] `git diff --check` — no spurious whitespace or line-ending churn beyond the file's existing CRLF convention
- [ ] End-to-end on a daily driver: build AppImage, replace installed one, start Cowork session, confirm `/proc/<spawned-claude>/environ` contains the token and tool calls succeed

## Security notes

The token already lives in the daemon's env (visible to same UID via `/proc/<daemon-pid>/environ`). Forwarding to a child inside bwrap under the same UID is no expansion of exposure. No new attack surface.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
25% AI / 75% Human
Claude: ran investigation agents, wrote the shared-helper refactor, regenerated the BATS harness, authored tests and PR prose.
Human: triaged pb3ck's report, validated the direction, ran the contrarian pass that surfaced the second call site + harness gap + empty-string edge case, owns the cowork CODEOWNERS lane.