### PR TITLE
fix: copy ion-dist frontend assets to Electron resources directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -72,6 +72,8 @@ source "$script_dir/scripts/staging/locales.sh"
 source "$script_dir/scripts/staging/ssh-helpers.sh"
 # shellcheck source=scripts/staging/cowork-resources.sh
 source "$script_dir/scripts/staging/cowork-resources.sh"
+# shellcheck source=scripts/staging/ion-dist.sh
+source "$script_dir/scripts/staging/ion-dist.sh"
 
 #===============================================================================
 # Packaging Functions
@@ -297,6 +299,7 @@ main() {
 	process_icons
 	copy_ssh_helpers
 	copy_cowork_resources
+	copy_ion_dist
 
 	cd "$project_root" || exit 1
 

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -142,6 +142,13 @@ stdenvNoCC.mkDerivation {
     cp build/electron-app/app.asar $electron_tree/resources/
     cp -r build/electron-app/app.asar.unpacked $electron_tree/resources/
 
+    # Install ion-dist frontend assets (served by app:// protocol handler)
+    if [[ -d build/electron-app/nix-resources/ion-dist ]]; then
+      cp -r build/electron-app/nix-resources/ion-dist \
+        $electron_tree/resources/
+      echo "Installed ion-dist frontend assets"
+    fi
+
     # Install tray icons into resources
     for tray_icon in build/electron-app/nix-resources/Tray*; do
       [[ -f "$tray_icon" ]] && cp "$tray_icon" $electron_tree/resources/

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -41,6 +41,9 @@ fi
 if [[ -d $app_staging_dir/app.asar.unpacked ]]; then
 	cp -a "$app_staging_dir/app.asar.unpacked" "$resources_dir/" || exit 1
 fi
+if [[ -d $app_staging_dir/ion-dist ]]; then
+	cp -a "$app_staging_dir/ion-dist" "$resources_dir/" || exit 1
+fi
 echo 'Application files copied to Electron resources directory'
 
 # Copy shared launcher library (launcher-common.sh sources doctor.sh

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -64,6 +64,9 @@ resources_dir="$install_dir/lib/$package_name/node_modules/electron/dist/resourc
 mkdir -p "$resources_dir" || exit 1
 cp "$app_staging_dir/app.asar" "$resources_dir/" || exit 1
 cp -r "$app_staging_dir/app.asar.unpacked" "$resources_dir/" || exit 1
+if [[ -d $app_staging_dir/ion-dist ]]; then
+	cp -r "$app_staging_dir/ion-dist" "$resources_dir/" || exit 1
+fi
 echo 'Application files copied to Electron resources directory'
 
 # Copy shared launcher library (launcher-common.sh sources doctor.sh

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -216,6 +216,9 @@ $icon_install_cmds
 cp -r $app_staging_dir/node_modules %{buildroot}/usr/lib/$package_name/
 cp $app_staging_dir/app.asar %{buildroot}/usr/lib/$package_name/node_modules/electron/dist/resources/
 cp -r $app_staging_dir/app.asar.unpacked %{buildroot}/usr/lib/$package_name/node_modules/electron/dist/resources/
+if [ -d $app_staging_dir/ion-dist ]; then
+    cp -r $app_staging_dir/ion-dist %{buildroot}/usr/lib/$package_name/node_modules/electron/dist/resources/
+fi
 
 # Copy shared launcher library (launcher-common.sh sources doctor.sh
 # at runtime, so both must live in the same directory)

--- a/scripts/staging/ion-dist.sh
+++ b/scripts/staging/ion-dist.sh
@@ -1,0 +1,31 @@
+#===============================================================================
+# ion-dist staging: copy the ion-dist frontend assets directory into
+# Electron's resources dir.  The app's custom app:// protocol handler
+# serves files from process.resourcesPath/ion-dist; without it every
+# internal page load returns ERR_UNEXPECTED and the UI shows
+# "Couldn't Connect to Claude".
+#
+# Sourced by: build.sh
+# Sourced globals:
+#   claude_extract_dir, electron_resources_dest
+# Modifies globals: (none)
+#===============================================================================
+
+copy_ion_dist() {
+	section_header 'ion-dist Frontend Assets'
+
+	local ion_dist_src="$claude_extract_dir/lib/net45/resources/ion-dist"
+
+	if [[ -d $ion_dist_src ]]; then
+		echo 'Copying ion-dist to Electron resources directory...'
+		cp -a "$ion_dist_src" "$electron_resources_dest/ion-dist" \
+			|| exit 1
+		echo 'ion-dist frontend assets copied'
+	else
+		echo 'Warning: ion-dist directory not found in Claude' \
+			"installer at $ion_dist_src"
+		echo 'The app:// protocol handler will fail without it'
+	fi
+
+	section_footer 'ion-dist Frontend Assets'
+}


### PR DESCRIPTION
## Summary

- Claude Desktop v1.3883.0 serves its UI via a custom `app://` protocol handler that reads from `process.resourcesPath/ion-dist`
- This directory (85MB, 843 files) exists in the Windows installer at `lib/net45/resources/ion-dist/` but was never copied during the Linux build
- Without it, every internal page load returns `ERR_UNEXPECTED` (-9) and the UI shows "Couldn't Connect to Claude Unknown Error"
- Adds `scripts/staging/ion-dist.sh` and wires it into all four packaging paths: AppImage, deb, RPM, and Nix

## Test plan

- [x] Built AppImage locally with `./build.sh --exe <installer> --build appimage --clean no`
- [x] Verified `ion-dist/` (843 files) present in AppImage at `usr/lib/node_modules/electron/dist/resources/ion-dist/`
- [x] Launched app — "Couldn't Connect to Claude" error is gone, UI loads correctly
- [x] Verified deb package staging includes `ion-dist/` (843 files) in correct resources path
- [x] Verified RPM package staging includes `ion-dist/` (843 files) in correct resources path
- [ ] Verify Nix build (code path reviewed, not runtime tested)