### PR TITLE
fix: handle upstream titleBarStyle change for About window

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -81,15 +81,19 @@ const CLOSE_TO_TRAY = process.platform === 'linux'
   && process.env.CLAUDE_QUIT_ON_CLOSE !== '1';
 console.log(`[Frame Fix] Close-to-tray: ${CLOSE_TO_TRAY ? 'on' : 'off'}`);
 
-// Detect if a window intends to be frameless (popup/Quick Entry/About)
-// Quick Entry: titleBarStyle:"", skipTaskbar:true, transparent:true, resizable:false
-// About:       titleBarStyle:"", skipTaskbar:true, resizable:false
-// Main:        titleBarStyle:"", titleBarOverlay:false(linux), resizable (has minWidth)
-// The main window has minWidth set; popups do not.
+// Detect if a window intends to be frameless (popup/Quick Entry/About).
+// Window kinds — see build-reference/app-extracted/.vite/build/index.js:
+//   Quick Entry:    titleBarStyle:"hidden",      frame:false  (caught early)
+//   About:          titleBarStyle:"hiddenInset", no minWidth, no parent
+//   Main:           titleBarStyle:"hidden",      minWidth:600
+//   Hardware Buddy: titleBarStyle:"hiddenInset", parent set (child modal — keep frame)
+// minWidth excludes Main; the `parent` key excludes Hardware Buddy. About
+// went from "" to "hiddenInset" upstream, so the test matches either.
 function isPopupWindow(options) {
   if (!options) return false;
   if (options.frame === false) return true;
-  if (options.titleBarStyle === '' && !options.minWidth) return true;
+  if ('parent' in options) return false;
+  if ((options.titleBarStyle === '' || options.titleBarStyle === 'hiddenInset') && !options.minWidth) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Upstream changed the About window's `titleBarStyle` from `""` to `"hiddenInset"`, causing `isPopupWindow()` to no longer recognize it as a popup
- The About window was misclassified as the main window, receiving `frame: true` and resize handlers, which broke its rendering on GNOME/X11 (showed minified JS instead of version info)
- Update `isPopupWindow()` to also match `titleBarStyle === 'hiddenInset'` for windows without `minWidth`

## Test plan
- [ ] Launch `claude-desktop` on GNOME/X11 with default menu bar mode (auto)
- [ ] Press Alt to show menu bar, open "About This App"
- [ ] Verify the About dialog displays version info correctly (not minified JS)
- [ ] Verify the main window still works normally with native frame
- [ ] Verify Quick Entry window still works as frameless popup

## Follow-up
Since this fix makes the About window frameless (`frame: false`), there is no native close button. A follow-up PR to add Escape key support for closing popup windows is ready at [`fix/popup-escape-close`](https://github.com/Hayao0819/claude-desktop-debian/tree/fix/popup-escape-close).

Fixes #481