### PR TITLE
fix: copy ion-dist static assets for app:// protocol handler

### DIFF
--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -162,6 +162,14 @@ stdenvNoCC.mkDerivation {
       fi
     done
 
+    # Install ion-dist static assets (app:// protocol handler root for
+    # Third-Party Inference setup — see issue #488)
+    if [[ -d build/electron-app/nix-resources/ion-dist ]]; then
+      cp -r build/electron-app/nix-resources/ion-dist \
+        $electron_tree/resources/
+      echo "Installed cowork resource: ion-dist"
+    fi
+
     # Install locale JSON files into resources
     for locale_json in build/claude-extract/lib/net45/resources/*-*.json; do
       [[ -f "$locale_json" ]] \

--- a/scripts/staging/cowork-resources.sh
+++ b/scripts/staging/cowork-resources.sh
@@ -1,6 +1,7 @@
 #===============================================================================
-# Cowork runtime resources: plugin shim script and architecture-specific
-# smol-bin VHDX for KVM guest SDK access.
+# Cowork runtime resources: plugin shim script, architecture-specific smol-bin
+# VHDX for KVM guest SDK access, and ion-dist static assets for the app://
+# protocol handler used by the Third-Party Inference setup window.
 #
 # Sourced by: build.sh
 # Sourced globals:
@@ -39,6 +40,19 @@ copy_cowork_resources() {
 	else
 		echo "Warning: smol-bin VHDX not found at $smol_vhdx"
 		echo "KVM Cowork will rely on virtiofs for SDK access"
+	fi
+
+	# Copy ion-dist static assets. The app registers an app:// protocol
+	# handler rooted at process.resourcesPath/ion-dist; without these
+	# assets, the Third-Party Inference setup window fails to load with
+	# ERR_UNEXPECTED (see issue #488).
+	local ion_dist_src="$resources_src/ion-dist"
+	if [[ -d $ion_dist_src ]]; then
+		cp -a "$ion_dist_src" "$electron_resources_dest/ion-dist"
+		echo 'Copied ion-dist'
+	else
+		echo "Warning: ion-dist not found at $ion_dist_src" \
+			'— Third-Party Inference setup will fail'
 	fi
 
 	section_footer 'Cowork Resources'


### PR DESCRIPTION
## Summary

Fixes #488 — Third-Party Inference setup window opens blank with `ERR_UNEXPECTED` / `ERR_FILE_NOT_FOUND` on `app://localhost/setup-desktop-3p`.

The Claude Desktop app installs a custom `app://` protocol handler rooted at `process.resourcesPath/ion-dist/` (source: `VGr(uA.join(WWt(),"ion-dist"),...)` in the minified main bundle). That directory ships inside the Windows installer under `lib/net45/resources/ion-dist/` and holds the static SPA assets for internal windows — the Third-Party Inference setup is the visible case, but the same handler routes other `app://localhost/*` internal pages. Our Debian/AppImage build was never copying it out of the nupkg, so every `app://localhost/*` request fell through to the handler's `index.html` fallback, which also missed → handler promise rejection → `ERR_UNEXPECTED` at `loadURL` with `ERR_FILE_NOT_FOUND` in the underlying fetch.

## Changes

1. **`scripts/staging/cowork-resources.sh`** — `copy_cowork_resources()` now copies `ion-dist/` from `$claude_extract_dir/lib/net45/resources/ion-dist` into `$electron_resources_dest/ion-dist` via `cp -a` (matching the idiom in `scripts/staging/electron.sh:74`). Warn-and-continue on absence, mirroring the existing `smol-bin` / `cowork-plugin-shim.sh` blocks in the same file.

2. **`nix/claude-desktop.nix`** — matching stanza in `installPhase`. For Nix builds, `$electron_resources_dest` is a sentinel `nix-resources/` directory that the flake cherry-picks from (see lines 156–163 for the existing `smol-bin` / `cowork-plugin-shim.sh` pattern). Without this hunk, change 1 would drop `ion-dist/` into `nix-resources/` and the Nix build would discard it — leaving NixOS users broken. **@typedrat — `nix/claude-desktop.nix` is your lane per CODEOWNERS; happy to drop this hunk and land the bash side alone if you'd rather take the Nix change separately, just let me know.**

## Impact on package size

`ion-dist` is 84 MB uncompressed (React SPA bundle: `assets/`, `audio/`, `i18n/`, `images/`, `index.html`, `robots.txt`, `favicon.ico`). In the AppImage this compresses to roughly 42 MB of delta: `1.3561.0` AppImage was 138 MB, the `1.3883.0` build with this fix is 180 MB. Some of that is upstream growth between the two versions too. Worth noting because `.deb` and `.AppImage` will grow accordingly — but this is the minimum cost to make an advertised menu feature work, so I don't see a leaner path short of pruning `ion-dist` contents by hand (fragile).

## Test plan

- [x] Fresh `./build.sh --build appimage` against upstream `1.3883.0` — build log shows `Copied ion-dist` in the Cowork Resources section
- [x] `--appimage-extract` of the built AppImage — `usr/lib/node_modules/electron/dist/resources/ion-dist/` present with `index.html` + `assets/` + `i18n/` etc.
- [x] Live install on CachyOS daily-driver (`/opt/claude-desktop/claude-desktop.AppImage` swap), fully relaunched
- [x] `Developer → Configure Third-Party Inference…` now renders the 6-tab config UI (Connection / Sandbox & workspace / Connectors & extensions / Telemetry & updates / Usage limits / Plugins & skills / Egress Requirements) per [support.claude.com/en/articles/14680741](https://support.claude.com/en/articles/14680741)
- [x] `grep -E 'ERR_UNEXPECTED|ERR_FILE_NOT_FOUND' ~/.config/Claude/logs/main.log` — no matches on `setup-desktop-3p`
- [x] `shellcheck` on the modified file — no new findings (existing SC2148/SC2154 warnings are pre-existing, inherent to the sourced-module pattern)
- [ ] Nix build (`nix build .#claude-desktop`) — would appreciate @typedrat spot-check before merge

## Log noise worth explaining

The 3P setup window triggers these `Blocked permission check` warnings:
- `media` (twice — once with empty origin, once with `app://localhost/`)
- `web-app-installation`
- `geolocation`
- `background-sync`

These are `setPermissionCheckHandler` deny events (not `Request` events — no user dialogs, no behavior change). The handler's allowlist (`IXe` / `uXe`) accepts only `https://claude.ai` subdomains, `file://`, and the main-window origin — `app://localhost` is intentionally excluded, which is the right security posture for a local protocol handler. The Ion SPA's framework probes these permissions for feature detection, gets `false`, moves on. Same warnings fire on `claude.ai` pages too (pre-existing since well before this change). Not introduced by this PR.

---

Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
30% AI / 70% Human
Claude: diagnosed the missing-resource root cause by grepping the running asar, drafted the fix + Nix hunk, ran contrarian stress-test, wrote the commit / PR body
Human: approved the plan, performed the live install swap (after Claude nearly SIGKILL'd its own hosting session with the documented `pkill mount_claude` recipe — lesson captured), confirmed the UI rendered, and pushed back on dismissed log warnings until they were actually traced