### PR TITLE
feat: add "Icon color" submenu for Linux tray (Auto/Black/White)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# IDE
+.idea
+
 # Build output
 build/
 build_*/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ The [`docs/learnings/`](docs/learnings/) directory contains hard-won technical k
 - [`nix.md`](docs/learnings/nix.md) — NixOS packaging, Electron resource path resolution, testing without NixOS
 - [`cowork-vm-daemon.md`](docs/learnings/cowork-vm-daemon.md) — Cowork VM daemon lifecycle, respawn logic, crash diagnosis
 - [`plugin-install.md`](docs/learnings/plugin-install.md) — Anthropic & Partners plugin install flow, gate logic, backend endpoints, and DevTools recipes
+- [`tray-icon-theme.md`](docs/learnings/tray-icon-theme.md) — Tray "Icon color" submenu (Auto/Dark/Light), why panel colour auto-detection isn't enough on KDE, and how the nativeTheme Proxy + persistence module wire up
 
 ## Code Style
 

--- a/docs/learnings/tray-icon-theme.md
+++ b/docs/learnings/tray-icon-theme.md
@@ -1,0 +1,232 @@
+# Tray Icon Colour — User Choice via Context-Menu Submenu
+
+Why auto-detection isn't enough, and how the "Icon color" submenu
+works.
+
+## The problem
+
+The minified Claude Desktop app picks its Linux tray icon from the
+pair bundled with the Windows build: `TrayIconTemplate.png` (black,
+for light panels) and `TrayIconTemplate-Dark.png` (white, for dark
+panels). `scripts/patches/tray.sh`'s `patch_tray_icon_selection`
+inserts `nativeTheme.shouldUseDarkColors ? …Dark.png : …png` into the
+ternary so the icon follows the desktop colour scheme.
+
+That works on desktops where the panel colour matches the global
+theme (GNOME, most of XFCE). On KDE Plasma it's routinely wrong:
+Plasma lets users pick the panel's Plasma Style independently from
+the global colour scheme, so a light desktop can have a dark panel
+(and vice versa). `nativeTheme.shouldUseDarkColors` only sees the
+global setting and misses that divergence.
+
+We tried detecting the panel colour ourselves (reading `plasmarc` →
+Plasma theme's `colors` file → kdeglobals fallback). It worked for
+about 90% of real setups but:
+
+- per-panel colour overrides in Plasma 6 aren't covered;
+- third-party themes without a `dark`/`light` keyword in their name
+  and no `colors` file regress to the global scheme;
+- users with niche setups still saw the wrong icon.
+
+So we added an explicit user choice to the tray context menu. Auto
+detection remains the default and behaves exactly as before; the
+`Dark` and `Light` overrides cover the edge cases directly. Pattern
+borrowed from [`figma-linux`](/mnt/DiskE_Crucial/codding/My_Projects/figma-linux)
+which adds tray toggles the same way.
+
+## UX
+
+Right-click the tray icon:
+
+```
+Show App
+Icon color ▶
+  ● Auto      (default — Electron's detection, current behaviour)
+    Black     (forces the black icon)
+    White     (forces the white icon)
+Quit
+```
+
+The submenu sits between `Show App` and `Quit`. Radio labels
+describe the ICON'S colour (what the user sees), not the desktop
+theme the icon is meant for — naming was reworked after users found
+"Dark / Light" confusing (a "Dark" icon means white in the SNI
+world because it's meant for dark panels).
+
+Selecting a different radio triggers an app relaunch
+(`app.relaunch(); app.exit(0)`). An earlier attempt to hot-swap the
+icon via `nativeTheme.emit('updated')` worked on the first click but
+then left a second StatusNotifierItem registered on KDE — the user
+ended up with two tray icons and two independent radio groups. The
+relaunch approach sidesteps that entirely for one line of code.
+
+### Label spacing
+
+The submenu item label is `"Icon color\u00A0"` (trailing non-breaking
+space). Without it, Plasma's SNI renderer glues its own submenu
+indicator glyph directly onto the final letter. A regular trailing
+space can be trimmed by some dbusmenu renderers; NBSP is always
+preserved.
+
+## Implementation
+
+### Persistence (`scripts/tray-icon-settings.js`)
+
+A tiny `EventEmitter` subclass loads/saves
+`~/.config/Claude/linux-tray.json` (`{ "iconMode": "auto" | "black"
+| "white" }`) synchronously. Corrupt / unreadable / missing files
+fall back to `"auto"`. `set(mode)` is a no-op when `mode` matches the
+current value.
+
+The helper `modeToDark(mode)` maps the user choice to the boolean
+`shouldUseDarkColors` value our wrapper returns:
+
+| mode    | `modeToDark` | meaning                                              |
+|---------|--------------|------------------------------------------------------|
+| `auto`  | `null`       | caller falls back to `nativeTheme.shouldUseDarkColors` |
+| `black` | `false`      | force `TrayIconTemplate.png` (black icon)             |
+| `white` | `true`       | force `TrayIconTemplate-Dark.png` (white icon)        |
+
+#### Migration of legacy names
+
+The first iteration used `dark` and `light` as mode names describing
+the *panel theme* the icon was for. That inverted the mental model
+users had (picking "Dark" produced a white icon), so the names were
+renamed in-place:
+
+| legacy | replacement |
+|--------|-------------|
+| `dark` | `white`     |
+| `light`| `black`     |
+
+`MODE_MIGRATIONS` maps old → new on load and rewrites the settings
+file in the new format on first access, so users who ran the earlier
+build don't lose their choice.
+
+### Wiring (`scripts/frame-fix-wrapper.js`)
+
+On first `require('electron')` the wrapper builds a Proxy over
+`result.nativeTheme` that intercepts `shouldUseDarkColors` and
+returns the user-chosen value when the settings module resolves to
+a non-null boolean. On mode change the wrapper calls
+`result.app.relaunch(); result.app.exit(0)` instead of trying to
+re-templatise the tray in place (see UX section above for why).
+
+`nativeTheme` is C++-backed so the Proxy has to be careful:
+
+- read properties via `target[prop]` (no `receiver`) so native
+  getters see the native object as `this`;
+- bind any returned function to `target`, or `.on(...)` and friends
+  throw `TypeError: Illegal invocation`;
+- explicit `set` trap writes to `target` for setters (e.g.
+  `nativeTheme.themeSource = 'dark'`).
+
+The wrapper publishes `globalThis.__claudeTrayIcon = { get, set }`
+so the injected submenu's click handlers can read/write the mode
+without a require cycle inside the minified bundle.
+
+### Submenu injection (`scripts/patches/tray.sh`)
+
+`patch_tray_icon_submenu` uses Node to regex-replace the Quit menu
+item (anchored on its i18n ID `dKX0bpR+a2`, which is much more
+stable across releases than the minified function/variable names)
+with:
+
+```
+<icon-color-submenu>,<original-quit-item>
+```
+
+Each radio's `checked` and `click` reference
+`globalThis.__claudeTrayIcon` with optional-chaining (`?.`) so the
+menu still builds safely if the wrapper somehow didn't load.
+
+Two guards around the injection:
+
+1. **New-format idempotency:** `grep -q '"Black".*"White"'` — if the
+   current submenu is already present, re-running the patch is a
+   no-op.
+2. **Legacy strip:** `grep -q '"Icon color".*"Dark".*"Light"'`
+   detects the first-iteration submenu (`Dark`/`Light` labels) and
+   removes it via a Node regex before the new injection, so users
+   running `--clean no` over an already-patched asar don't end up
+   with two submenus side-by-side.
+
+### Flow on a click
+
+1. User right-clicks the tray, picks "White".
+2. Click handler calls `globalThis.__claudeTrayIcon.set("white")`.
+3. Settings module writes `~/.config/Claude/linux-tray.json` and
+   emits `change`.
+4. Wrapper's change listener calls `app.relaunch(); app.exit(0)`.
+5. The relaunched process reads `"white"` from disk at startup.
+6. Our Proxy returns `true` from `shouldUseDarkColors` → the
+   sed-patched ternary picks `TrayIconTemplate-Dark.png` (white
+   icon) → the new tray comes up with the correct icon and the
+   "White" radio checked.
+
+## Testing manually
+
+```bash
+# Inspect / force a mode without the UI
+cat ~/.config/Claude/linux-tray.json
+echo '{"iconMode":"dark"}' > ~/.config/Claude/linux-tray.json
+
+# Watch the wrapper's state log
+tail -f ~/.cache/claude-desktop-debian/launcher.log \
+  | grep '[Frame Fix].*tray\|Tray icon'
+```
+
+The wrapper logs `[Frame Fix] Tray icon mode = <mode>` at startup
+and `[Frame Fix] Tray icon mode changed to <mode>` on each transition.
+
+## Related: duplicate tray icon on OS theme change
+
+The same StatusNotifierItem re-registration race that motivated the
+relaunch on icon-mode change also bites on OS theme changes — an
+independent pre-existing bug even on main. The minified
+`tray_func()` destroys the current tray, waits 250 ms, then creates
+a new one so the icon PNG switches. On KDE the new SNI appears
+before Plasma processes the old one's unregister signal → two
+icons in the tray side by side until the stale one ages out (often
+requires logout / relogin).
+
+`patch_tray_inplace_update` (in `scripts/patches/tray.sh`) injects a
+fast-path at the top of the tray rebuild:
+
+```js
+if (Nh && e !== false) {
+  Nh.setImage(pA.nativeImage.createFromPath(t));
+  process.platform !== 'darwin' && Nh.setContextMenu(wAt());
+  return;
+}
+```
+
+When the tray already exists and isn't being disabled, we just
+update its image and context menu on the existing SNI object — no
+destroy, no re-registration, no DBus race. The original destroy-
+and-recreate path is retained for initial creation and the tray-
+disable case, where it's unavoidable.
+
+Name extraction: the menu-builder function name (`wAt` in the
+current release) is pulled at build time via
+`grep -oP "${tray_var}\.setContextMenu\(\K\w+(?=\(\))"`, so the patch
+tracks minifier rename churn.
+
+## Pitfalls to watch for
+
+- **Relaunch window.** Clicking a different icon colour closes the
+  app immediately (`app.exit(0)`) and asks it to reopen
+  (`app.relaunch()`). Any unsaved in-process state in other windows
+  is lost. In practice Claude Desktop persists its per-window state
+  so this is invisible to users, but if we add more in-memory-only
+  state in the future, revisit this.
+- **Localisation.** The submenu labels are hardcoded English (`Icon
+  color`, `Auto`, `Black`, `White`) — the same convention as every
+  other patch in this tree. `he.formatMessage` would require wiring
+  into Claude's i18n catalogue, which is out of scope here.
+- **i18n-ID rename.** We anchor the injection on Claude Desktop's
+  internal stringtable ID `dKX0bpR+a2` (Quit). If upstream rotates
+  that ID the patch becomes a no-op and the build surfaces
+  `[FAIL] Quit anchor not found`. Pull the latest IDs from
+  `resources/i18n/en-US.json` in the same release and swap in the
+  new one.

--- a/docs/learnings/tray-icon-theme.md
+++ b/docs/learnings/tray-icon-theme.md
@@ -1,0 +1,232 @@
+# Tray Icon Colour — User Choice via Context-Menu Submenu
+
+Why auto-detection isn't enough, and how the "Icon color" submenu
+works.
+
+## The problem
+
+The minified Claude Desktop app picks its Linux tray icon from the
+pair bundled with the Windows build: `TrayIconTemplate.png` (black,
+for light panels) and `TrayIconTemplate-Dark.png` (white, for dark
+panels). `scripts/patches/tray.sh`'s `patch_tray_icon_selection`
+inserts `nativeTheme.shouldUseDarkColors ? …Dark.png : …png` into the
+ternary so the icon follows the desktop colour scheme.
+
+That works on desktops where the panel colour matches the global
+theme (GNOME, most of XFCE). On KDE Plasma it's routinely wrong:
+Plasma lets users pick the panel's Plasma Style independently from
+the global colour scheme, so a light desktop can have a dark panel
+(and vice versa). `nativeTheme.shouldUseDarkColors` only sees the
+global setting and misses that divergence.
+
+We tried detecting the panel colour ourselves (reading `plasmarc` →
+Plasma theme's `colors` file → kdeglobals fallback). It worked for
+about 90% of real setups but:
+
+- per-panel colour overrides in Plasma 6 aren't covered;
+- third-party themes without a `dark`/`light` keyword in their name
+  and no `colors` file regress to the global scheme;
+- users with niche setups still saw the wrong icon.
+
+So we added an explicit user choice to the tray context menu. Auto
+detection remains the default and behaves exactly as before; the
+`Black` and `White` overrides cover the edge cases directly. Pattern
+borrowed from a sister Electron-repackaging project that adds tray
+toggles the same way.
+
+## UX
+
+Right-click the tray icon:
+
+```
+Show App
+Icon color ▶
+  ● Auto      (default — Electron's detection, current behaviour)
+    Black     (forces the black icon)
+    White     (forces the white icon)
+Quit
+```
+
+The submenu sits between `Show App` and `Quit`. Radio labels
+describe the ICON'S colour (what the user sees), not the desktop
+theme the icon is meant for — naming was reworked after users found
+"Dark / Light" confusing (a "Dark" icon means white in the SNI
+world because it's meant for dark panels).
+
+Selecting a different radio triggers an app relaunch
+(`app.relaunch(); app.exit(0)`). An earlier attempt to hot-swap the
+icon via `nativeTheme.emit('updated')` worked on the first click but
+then left a second StatusNotifierItem registered on KDE — the user
+ended up with two tray icons and two independent radio groups. The
+relaunch approach sidesteps that entirely for one line of code.
+
+### Label spacing
+
+The submenu item label is `"Icon color\u00A0"` (trailing non-breaking
+space). Without it, Plasma's SNI renderer glues its own submenu
+indicator glyph directly onto the final letter. A regular trailing
+space can be trimmed by some dbusmenu renderers; NBSP is always
+preserved.
+
+## Implementation
+
+### Persistence (`scripts/tray-icon-settings.js`)
+
+A tiny `EventEmitter` subclass loads/saves
+`~/.config/Claude/linux-tray.json` (`{ "iconMode": "auto" | "black"
+| "white" }`) synchronously. Corrupt / unreadable / missing files
+fall back to `"auto"`. `set(mode)` is a no-op when `mode` matches the
+current value.
+
+The helper `modeToDark(mode)` maps the user choice to the boolean
+`shouldUseDarkColors` value our wrapper returns:
+
+| mode    | `modeToDark` | meaning                                              |
+|---------|--------------|------------------------------------------------------|
+| `auto`  | `null`       | caller falls back to `nativeTheme.shouldUseDarkColors` |
+| `black` | `false`      | force `TrayIconTemplate.png` (black icon)             |
+| `white` | `true`       | force `TrayIconTemplate-Dark.png` (white icon)        |
+
+#### Migration of legacy names
+
+The first iteration used `dark` and `light` as mode names describing
+the *panel theme* the icon was for. That inverted the mental model
+users had (picking "Dark" produced a white icon), so the names were
+renamed in-place:
+
+| legacy | replacement |
+|--------|-------------|
+| `dark` | `white`     |
+| `light`| `black`     |
+
+`MODE_MIGRATIONS` maps old → new on load and rewrites the settings
+file in the new format on first access, so users who ran the earlier
+build don't lose their choice.
+
+### Wiring (`scripts/frame-fix-wrapper.js`)
+
+On first `require('electron')` the wrapper builds a Proxy over
+`result.nativeTheme` that intercepts `shouldUseDarkColors` and
+returns the user-chosen value when the settings module resolves to
+a non-null boolean. On mode change the wrapper calls
+`result.app.relaunch(); result.app.exit(0)` instead of trying to
+re-templatise the tray in place (see UX section above for why).
+
+`nativeTheme` is C++-backed so the Proxy has to be careful:
+
+- read properties via `target[prop]` (no `receiver`) so native
+  getters see the native object as `this`;
+- bind any returned function to `target`, or `.on(...)` and friends
+  throw `TypeError: Illegal invocation`;
+- explicit `set` trap writes to `target` for setters (e.g.
+  `nativeTheme.themeSource = 'dark'`).
+
+The wrapper publishes `globalThis.__claudeTrayIcon = { get, set }`
+so the injected submenu's click handlers can read/write the mode
+without a require cycle inside the minified bundle.
+
+### Submenu injection (`scripts/patches/tray.sh`)
+
+`patch_tray_icon_submenu` uses Node to regex-replace the Quit menu
+item (anchored on its i18n ID `dKX0bpR+a2`, which is much more
+stable across releases than the minified function/variable names)
+with:
+
+```
+<icon-color-submenu>,<original-quit-item>
+```
+
+Each radio's `checked` and `click` reference
+`globalThis.__claudeTrayIcon` with optional-chaining (`?.`) so the
+menu still builds safely if the wrapper somehow didn't load.
+
+Two guards around the injection:
+
+1. **New-format idempotency:** `grep -q '"Black".*"White"'` — if the
+   current submenu is already present, re-running the patch is a
+   no-op.
+2. **Legacy strip:** `grep -q '"Icon color".*"Dark".*"Light"'`
+   detects the first-iteration submenu (`Dark`/`Light` labels) and
+   removes it via a Node regex before the new injection, so users
+   running `--clean no` over an already-patched asar don't end up
+   with two submenus side-by-side.
+
+### Flow on a click
+
+1. User right-clicks the tray, picks "White".
+2. Click handler calls `globalThis.__claudeTrayIcon.set("white")`.
+3. Settings module writes `~/.config/Claude/linux-tray.json` and
+   emits `change`.
+4. Wrapper's change listener calls `app.relaunch(); app.exit(0)`.
+5. The relaunched process reads `"white"` from disk at startup.
+6. Our Proxy returns `true` from `shouldUseDarkColors` → the
+   sed-patched ternary picks `TrayIconTemplate-Dark.png` (white
+   icon) → the new tray comes up with the correct icon and the
+   "White" radio checked.
+
+## Testing manually
+
+```bash
+# Inspect / force a mode without the UI
+cat ~/.config/Claude/linux-tray.json
+echo '{"iconMode":"dark"}' > ~/.config/Claude/linux-tray.json
+
+# Watch the wrapper's state log
+tail -f ~/.cache/claude-desktop-debian/launcher.log \
+  | grep '[Frame Fix].*tray\|Tray icon'
+```
+
+The wrapper logs `[Frame Fix] Tray icon mode = <mode>` at startup
+and `[Frame Fix] Tray icon mode changed to <mode>` on each transition.
+
+## Related: duplicate tray icon on OS theme change
+
+The same StatusNotifierItem re-registration race that motivated the
+relaunch on icon-mode change also bites on OS theme changes — an
+independent pre-existing bug even on main. The minified
+`tray_func()` destroys the current tray, waits 250 ms, then creates
+a new one so the icon PNG switches. On KDE the new SNI appears
+before Plasma processes the old one's unregister signal → two
+icons in the tray side by side until the stale one ages out (often
+requires logout / relogin).
+
+`patch_tray_inplace_update` (in `scripts/patches/tray.sh`) injects a
+fast-path at the top of the tray rebuild:
+
+```js
+if (Nh && e !== false) {
+  Nh.setImage(pA.nativeImage.createFromPath(t));
+  process.platform !== 'darwin' && Nh.setContextMenu(wAt());
+  return;
+}
+```
+
+When the tray already exists and isn't being disabled, we just
+update its image and context menu on the existing SNI object — no
+destroy, no re-registration, no DBus race. The original destroy-
+and-recreate path is retained for initial creation and the tray-
+disable case, where it's unavoidable.
+
+Name extraction: the menu-builder function name (`wAt` in the
+current release) is pulled at build time via
+`grep -oP "${tray_var}\.setContextMenu\(\K\w+(?=\(\))"`, so the patch
+tracks minifier rename churn.
+
+## Pitfalls to watch for
+
+- **Relaunch window.** Clicking a different icon colour closes the
+  app immediately (`app.exit(0)`) and asks it to reopen
+  (`app.relaunch()`). Any unsaved in-process state in other windows
+  is lost. In practice Claude Desktop persists its per-window state
+  so this is invisible to users, but if we add more in-memory-only
+  state in the future, revisit this.
+- **Localisation.** The submenu labels are hardcoded English (`Icon
+  color`, `Auto`, `Black`, `White`) — the same convention as every
+  other patch in this tree. `he.formatMessage` would require wiring
+  into Claude's i18n catalogue, which is out of scope here.
+- **i18n-ID rename.** We anchor the injection on Claude Desktop's
+  internal stringtable ID `dKX0bpR+a2` (Quit). If upstream rotates
+  that ID the patch becomes a no-op and the build surfaces
+  `[FAIL] Quit anchor not found`. Pull the latest IDs from
+  `resources/i18n/en-US.json` in the same release and swap in the
+  new one.

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -74,10 +74,30 @@ const LINUX_CSS = `
   }
 `;
 
+// Linux tray-icon user choice. The tray context menu patch (in
+// scripts/patches/tray.sh) reads/writes this via globalThis.__claudeTrayIcon.
+let trayIconSettings = null;
+if (process.platform === 'linux') {
+  try {
+    const TrayIconSettings = require('./tray-icon-settings.js');
+    trayIconSettings = new TrayIconSettings();
+    globalThis.__claudeTrayIcon = {
+      get: () => trayIconSettings.get(),
+      set: (m) => trayIconSettings.set(m),
+    };
+    console.log('[Frame Fix] Tray icon mode =', trayIconSettings.get());
+  } catch (e) {
+    console.warn('[Frame Fix] Tray icon settings failed to load:',
+      e && e.message);
+    trayIconSettings = null;
+  }
+}
+
 // Build the patched BrowserWindow class and Menu interceptor once,
 // on first require('electron'), then reuse via Proxy on every access.
 let PatchedBrowserWindow = null;
 let patchedSetApplicationMenu = null;
+let patchedNativeTheme = null;
 let electronModule = null;
 
 Module.prototype.require = function(id) {
@@ -89,6 +109,52 @@ Module.prototype.require = function(id) {
       electronModule = result;
       const OriginalBrowserWindow = result.BrowserWindow;
       const OriginalMenu = result.Menu;
+      const OriginalNativeTheme = result.nativeTheme;
+
+      // Wrap nativeTheme so shouldUseDarkColors reflects the user's
+      // "Icon color" choice. `target[prop]` (not Reflect.get) and
+      // .bind(target) are needed because nativeTheme is C++-backed —
+      // native getters/methods reject the Proxy as `this`.
+      if (process.platform === 'linux' && trayIconSettings
+          && OriginalNativeTheme) {
+        const { modeToDark } = require('./tray-icon-settings.js');
+        patchedNativeTheme = new Proxy(OriginalNativeTheme, {
+          get(target, prop) {
+            if (prop === 'shouldUseDarkColors') {
+              const v = modeToDark(trayIconSettings.get());
+              if (v !== null) return v;
+            }
+            const value = target[prop];
+            if (typeof value === 'function') return value.bind(target);
+            return value;
+          },
+          set(target, prop, value) {
+            target[prop] = value;
+            return true;
+          },
+        });
+
+        // Relaunch on mode change. AppImage: process.execPath points
+        // inside /tmp/.mount_claudeXXX which is unmounted on exit, so
+        // app.relaunch() → SIGTRAP. Re-exec $APPIMAGE instead; other
+        // packaging formats use Electron's built-in relaunch.
+        trayIconSettings.on('change', (next) => {
+          console.log('[Frame Fix] Tray icon mode =', next, '— relaunching');
+          try {
+            const appimage = process.env.APPIMAGE;
+            if (appimage) {
+              const { spawn } = require('child_process');
+              spawn(appimage, [], { detached: true, stdio: 'ignore' })
+                .unref();
+            } else {
+              result.app.relaunch();
+            }
+            result.app.exit(0);
+          } catch (e) {
+            console.warn('[Frame Fix] Relaunch failed:', e && e.message);
+          }
+        });
+      }
 
       PatchedBrowserWindow = class BrowserWindowWithFrame extends OriginalBrowserWindow {
         constructor(options) {
@@ -343,6 +409,7 @@ Module.prototype.require = function(id) {
     return new Proxy(result, {
       get(target, prop, receiver) {
         if (prop === 'BrowserWindow') return PatchedBrowserWindow;
+        if (prop === 'nativeTheme' && patchedNativeTheme) return patchedNativeTheme;
         if (prop === 'Menu') {
           // Return a proxy for Menu that intercepts setApplicationMenu
           const originalMenu = target.Menu;

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -22,6 +22,7 @@ patch_app_asar() {
 	echo "Original main entry: $original_main"
 
 	cp "$source_dir/scripts/frame-fix-wrapper.js" app.asar.contents/frame-fix-wrapper.js || exit 1
+	cp "$source_dir/scripts/tray-icon-settings.js" app.asar.contents/tray-icon-settings.js || exit 1
 
 	cat > app.asar.contents/frame-fix-entry.js << EOFENTRY
 // Load frame fix first
@@ -74,8 +75,15 @@ console.log('Updated package.json: main entry and node-pty dependency');
 	# Patch tray menu handler
 	patch_tray_menu_handler
 
+	# In-place tray update on OS theme change (pre-existing KDE
+	# duplicate-icon bug — see docs/learnings/tray-icon-theme.md)
+	patch_tray_inplace_update
+
 	# Patch tray icon selection
 	patch_tray_icon_selection
+
+	# Inject "Icon color" submenu into tray context menu
+	patch_tray_icon_submenu
 
 	# Patch menuBarEnabled to default to true when unset
 	patch_menu_bar_default

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -76,6 +76,94 @@ patch_tray_menu_handler() {
 	echo '##############################################################'
 }
 
+patch_tray_inplace_update() {
+	echo 'Patching tray rebuild to update in-place on theme change...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Detect prior application of this patch.
+	if grep -qF ".nativeImage.createFromPath(t));process.platform!==" "$index_js"; then
+		echo '  In-place fast-path already present (idempotent)'
+		echo '##############################################################'
+		return
+	fi
+
+	# Re-extract the tray variable name — `patch_tray_menu_handler`
+	# declares it `local` so it's not visible here. Same grep pattern.
+	local tray_func local_tray_var tray_var_re menu_func
+	tray_func=$(grep -oP \
+		'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' "$index_js")
+	if [[ -z $tray_func ]]; then
+		echo '  Could not find tray function — skipping'
+		echo '##############################################################'
+		return
+	fi
+	local_tray_var=$(grep -oP \
+		"\}\);let \K\w+(?==null;(?:async )?function ${tray_func})" \
+		"$index_js")
+	if [[ -z $local_tray_var ]]; then
+		echo '  Could not extract tray variable name — skipping'
+		echo '##############################################################'
+		return
+	fi
+	echo "  Found tray variable: $local_tray_var"
+
+	tray_var_re="${local_tray_var//\$/\\$}"
+	menu_func=$(grep -oP "${tray_var_re}\.setContextMenu\(\K\w+(?=\(\))" \
+		"$index_js" | head -1)
+	if [[ -z $menu_func ]]; then
+		echo '  Could not extract menu function name — skipping'
+		echo '##############################################################'
+		return
+	fi
+	echo "  Found menu function: $menu_func"
+
+	# Inject a fast-path before the existing destroy+recreate block:
+	# when the tray already exists and isn't being disabled, update it
+	# in place with setImage + setContextMenu. Skips the DBus race
+	# where Plasma briefly shows both the old (not yet unregistered)
+	# and the new StatusNotifierItem. Slow path is kept for initial
+	# creation and tray-disable.
+	if ! TRAY_VAR="$local_tray_var" EL_VAR="$electron_var" MENU_FUNC="$menu_func" \
+		node -e "
+const fs = require('fs');
+const p = 'app.asar.contents/.vite/build/index.js';
+const T = process.env.TRAY_VAR;
+const E = process.env.EL_VAR;
+const M = process.env.MENU_FUNC;
+let code = fs.readFileSync(p, 'utf8');
+
+// Build regex that matches the start of the destroy+recreate block,
+// tolerating optional inner whitespace.
+const reEsc = (s) => s.replace(/[.*+?^\${}()|[\\]\\\\]/g, '\\\\\$&');
+const anchor = new RegExp(
+  ';if\\\\(' + reEsc(T) + '&&\\\\(' + reEsc(T) + '\\\\.destroy\\\\(\\\\)'
+);
+if (!anchor.test(code)) {
+  console.error('  [FAIL] destroy-recreate anchor not found');
+  process.exit(1);
+}
+
+const fastPath =
+  'if(' + T + '&&e!==false){' +
+    T + '.setImage(' + E + '.nativeImage.createFromPath(t));' +
+    'process.platform!==\"darwin\"&&' + T + '.setContextMenu(' + M + '());' +
+    'return' +
+  '}';
+
+// Prefix the destroy block with the fast-path, keeping the matched
+// portion ';if(TRAY&&(TRAY.destroy()' intact.
+code = code.replace(anchor, (m) => ';' + fastPath + m.slice(1));
+fs.writeFileSync(p, code);
+console.log('  [OK] Fast-path injected before destroy-recreate');
+"; then
+		echo 'Failed to inject tray in-place fast-path' >&2
+		cd "$project_root" || exit 1
+		exit 1
+	fi
+
+	echo '##############################################################'
+}
+
 patch_tray_icon_selection() {
 	echo 'Patching tray icon selection for Linux visibility...'
 	local index_js='app.asar.contents/.vite/build/index.js'
@@ -89,6 +177,71 @@ patch_tray_icon_selection() {
 	else
 		echo 'Tray icon selection pattern not found or already patched'
 	fi
+	echo '##############################################################'
+}
+
+patch_tray_icon_submenu() {
+	echo 'Patching tray context menu with Icon color submenu...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Strip any previously-injected submenu so re-runs rebuild fresh,
+	# regardless of old label spacing (Dark/Light legacy or Black/White).
+	if grep -q 'Icon color' "$index_js" 2>/dev/null; then
+		echo '  Stripping previous Icon color submenu for clean re-inject...'
+		if ! node -e "
+const fs = require('fs');
+const p = 'app.asar.contents/.vite/build/index.js';
+let code = fs.readFileSync(p, 'utf8');
+const prevRe = /\\{label:\"Icon color[^\"]*\",submenu:\\[[^\\]]*?\\]\\},/;
+if (prevRe.test(code)) {
+  code = code.replace(prevRe, '');
+  fs.writeFileSync(p, code);
+  console.log('  [OK] Previous submenu removed');
+} else {
+  console.error('  [WARN] \\'Icon color\\' found but regex did not match');
+}
+"; then
+			echo 'Failed to strip previous submenu' >&2
+			cd "$project_root" || exit 1
+			exit 1
+		fi
+	fi
+
+	# Anchor on the Quit i18n ID — stable across minifier churn.
+	# Radio labels describe the icon's colour: Black/White/Auto.
+	# Label ends with ASCII space + U+2003 EM SPACE so Plasma's
+	# submenu-arrow glyph doesn't render glued to the letter 'r'
+	# (single U+00A0 rendered as zero-width on Plasma 6).
+	if ! node -e "
+const fs = require('fs');
+const p = 'app.asar.contents/.vite/build/index.js';
+let code = fs.readFileSync(p, 'utf8');
+
+// Quit menu item anchor: {label:X.formatMessage({...id:\"dKX0bpR+a2\"...}),click:FN}
+const quitRe = /\\{label:\\w+\\.formatMessage\\(\\{[^{}]*?id:\"dKX0bpR\\+a2\"[^{}]*?\\}\\),click:\\w+\\}/;
+if (!quitRe.test(code)) {
+  console.error('  [FAIL] Quit anchor not found in index.js');
+  process.exit(1);
+}
+
+const rkey = 'globalThis.__claudeTrayIcon';
+const GAP = ' \u2003';  // ASCII space + U+2003 EM SPACE
+const submenu =
+  '{label:\"Icon color' + GAP + '\",submenu:[' +
+    '{label:\"Auto\",type:\"radio\",checked:(' + rkey + '?.get()||\"auto\")===\"auto\",click(){' + rkey + '?.set(\"auto\")}},' +
+    '{label:\"Black\",type:\"radio\",checked:' + rkey + '?.get()===\"black\",click(){' + rkey + '?.set(\"black\")}},' +
+    '{label:\"White\",type:\"radio\",checked:' + rkey + '?.get()===\"white\",click(){' + rkey + '?.set(\"white\")}}' +
+  ']},';
+
+code = code.replace(quitRe, submenu + '\$&');
+fs.writeFileSync(p, code);
+console.log('  [OK] Icon color submenu inserted before Quit');
+"; then
+		echo 'Failed to inject tray Icon color submenu' >&2
+		cd "$project_root" || exit 1
+		exit 1
+	fi
+
 	echo '##############################################################'
 }
 

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -80,16 +80,10 @@ patch_tray_inplace_update() {
 	echo 'Patching tray rebuild to update in-place on theme change...'
 	local index_js='app.asar.contents/.vite/build/index.js'
 
-	# Detect prior application of this patch.
-	if grep -qF ".nativeImage.createFromPath(t));process.platform!==" "$index_js"; then
-		echo '  In-place fast-path already present (idempotent)'
-		echo '##############################################################'
-		return
-	fi
-
 	# Re-extract the tray variable name — `patch_tray_menu_handler`
 	# declares it `local` so it's not visible here. Same grep pattern.
-	local tray_func local_tray_var tray_var_re menu_func
+	local tray_func local_tray_var tray_var_re electron_var_re_local
+	local menu_func path_var enabled_var
 	tray_func=$(grep -oP \
 		'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' "$index_js")
 	if [[ -z $tray_func ]]; then
@@ -108,6 +102,8 @@ patch_tray_inplace_update() {
 	echo "  Found tray variable: $local_tray_var"
 
 	tray_var_re="${local_tray_var//\$/\\$}"
+	electron_var_re_local="${electron_var//\$/\\$}"
+
 	menu_func=$(grep -oP "${tray_var_re}\.setContextMenu\(\K\w+(?=\(\))" \
 		"$index_js" | head -1)
 	if [[ -z $menu_func ]]; then
@@ -117,22 +113,68 @@ patch_tray_inplace_update() {
 	fi
 	echo "  Found menu function: $menu_func"
 
+	# Extract the icon-path local used in the original
+	#   Nh = new pA.Tray(pA.nativeImage.createFromPath(X))
+	# call. That `X` is the `const` assigned `path.join(resourcesDir(),
+	# suffix)` earlier in the function; minifier renames it between
+	# releases, so it needs to be extracted (not hardcoded).
+	path_var=$(grep -oP \
+		"${tray_var_re}=new ${electron_var_re_local}\.Tray\(${electron_var_re_local}\.nativeImage\.createFromPath\(\K\w+(?=\))" \
+		"$index_js" | head -1)
+	if [[ -z $path_var ]]; then
+		echo '  Could not extract icon-path var — skipping'
+		echo '##############################################################'
+		return
+	fi
+	echo "  Found icon-path var: $path_var"
+
+	# Extract the menuBarEnabled local — identical pattern to
+	# patch_menu_bar_default, but here we want the local inside the
+	# tray function body (the first `const X = fn("menuBarEnabled")`).
+	enabled_var=$(grep -oP \
+		'const \K\w+(?=\s*=\s*\w+\("menuBarEnabled"\))' "$index_js" \
+		| head -1)
+	if [[ -z $enabled_var ]]; then
+		echo '  Could not extract menuBarEnabled var — skipping'
+		echo '##############################################################'
+		return
+	fi
+	echo "  Found menuBarEnabled var: $enabled_var"
+
+	# Idempotency guard: re-running the patch is a no-op once our
+	# fast-path is in place. Key on the distinctive
+	# "setImage(EL.nativeImage.createFromPath(PATH_VAR))" sequence
+	# using the (post-rename) extracted names — the destroy+recreate
+	# slow-path still exists below, so we can't just count occurrences
+	# of setImage.
+	local fast_path_marker
+	fast_path_marker="${local_tray_var}.setImage(${electron_var}.nativeImage.createFromPath(${path_var}))"
+	if grep -qF "$fast_path_marker" "$index_js"; then
+		echo '  In-place fast-path already present (idempotent)'
+		echo '##############################################################'
+		return
+	fi
+
 	# Inject a fast-path before the existing destroy+recreate block:
 	# when the tray already exists and isn't being disabled, update it
 	# in place with setImage + setContextMenu. Skips the DBus race
 	# where Plasma briefly shows both the old (not yet unregistered)
 	# and the new StatusNotifierItem. Slow path is kept for initial
 	# creation and tray-disable.
-	if ! TRAY_VAR="$local_tray_var" EL_VAR="$electron_var" MENU_FUNC="$menu_func" \
+	if ! TRAY_VAR="$local_tray_var" EL_VAR="$electron_var" \
+		MENU_FUNC="$menu_func" PATH_VAR="$path_var" \
+		ENABLED_VAR="$enabled_var" \
 		node -e "
 const fs = require('fs');
 const p = 'app.asar.contents/.vite/build/index.js';
 const T = process.env.TRAY_VAR;
 const E = process.env.EL_VAR;
 const M = process.env.MENU_FUNC;
+const P = process.env.PATH_VAR;
+const V = process.env.ENABLED_VAR;
 let code = fs.readFileSync(p, 'utf8');
 
-// Build regex that matches the start of the destroy+recreate block,
+// Anchor at the start of the existing destroy+recreate block,
 // tolerating optional inner whitespace.
 const reEsc = (s) => s.replace(/[.*+?^\${}()|[\\]\\\\]/g, '\\\\\$&');
 const anchor = new RegExp(
@@ -144,8 +186,8 @@ if (!anchor.test(code)) {
 }
 
 const fastPath =
-  'if(' + T + '&&e!==false){' +
-    T + '.setImage(' + E + '.nativeImage.createFromPath(t));' +
+  'if(' + T + '&&' + V + '!==false){' +
+    T + '.setImage(' + E + '.nativeImage.createFromPath(' + P + '));' +
     'process.platform!==\"darwin\"&&' + T + '.setContextMenu(' + M + '());' +
     'return' +
   '}';

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -234,6 +234,9 @@ patch_tray_icon_submenu() {
 const fs = require('fs');
 const p = 'app.asar.contents/.vite/build/index.js';
 let code = fs.readFileSync(p, 'utf8');
+// NB: [^\\]]*? assumes no radio label inside the submenu contains
+// a literal ']' — true for Auto/Black/White today; revisit the
+// regex (e.g. balanced-brace match) if a future label gains one.
 const prevRe = /\\{label:\"Icon color[^\"]*\",submenu:\\[[^\\]]*?\\]\\},/;
 if (prevRe.test(code)) {
   code = code.replace(prevRe, '');

--- a/scripts/tray-icon-settings.js
+++ b/scripts/tray-icon-settings.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// Persists the Linux tray-icon colour choice to
+// ~/.config/Claude/linux-tray.json as {iconMode: "auto"|"black"|"white"}.
+// Default "auto" preserves pre-existing behaviour (Electron picks).
+// See docs/learnings/tray-icon-theme.md for the why.
+
+const EventEmitter = require('events');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const VALID_MODES = Object.freeze(['auto', 'black', 'white']);
+const DEFAULT_MODE = 'auto';
+
+// Legacy names from the first iteration: map old → new on load.
+const MODE_MIGRATIONS = Object.freeze({
+  dark: 'white',   // old "dark"  meant white icon (for dark panels)
+  light: 'black',  // old "light" meant black icon (for light panels)
+});
+
+const SETTINGS_FILE = path.join(
+  os.homedir(), '.config', 'Claude', 'linux-tray.json',
+);
+
+class TrayIconSettings extends EventEmitter {
+  constructor(options) {
+    super();
+    const opts = options || {};
+    this._path = opts.path || SETTINGS_FILE;
+    this._mode = this._load();
+  }
+
+  get() {
+    return this._mode;
+  }
+
+  // No-op and returns false when mode is invalid or already set.
+  set(mode) {
+    if (!VALID_MODES.includes(mode)) {
+      console.warn('[Tray Icon] Rejecting invalid mode:', mode);
+      return false;
+    }
+    if (mode === this._mode) return false;
+    this._mode = mode;
+    this._save();
+    this.emit('change', mode);
+    return true;
+  }
+
+  _load() {
+    let raw;
+    try {
+      raw = fs.readFileSync(this._path, 'utf8');
+    } catch (e) {
+      // ENOENT on first launch is the common path — silent.
+      if (e && e.code !== 'ENOENT') {
+        console.warn('[Tray Icon] Read failed:', e.message);
+      }
+      return DEFAULT_MODE;
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      console.warn('[Tray Icon] Parse failed:', e.message);
+      return DEFAULT_MODE;
+    }
+
+    const stored = parsed && parsed.iconMode;
+    const migrated = MODE_MIGRATIONS[stored] || stored;
+    if (!VALID_MODES.includes(migrated)) return DEFAULT_MODE;
+
+    // Write back in the new format so subsequent reads are clean.
+    if (migrated !== stored) {
+      this._mode = migrated;
+      this._save();
+    }
+    return migrated;
+  }
+
+  _save() {
+    try {
+      fs.mkdirSync(path.dirname(this._path), { recursive: true });
+      fs.writeFileSync(
+        this._path,
+        JSON.stringify({ iconMode: this._mode }, null, 2) + '\n',
+        'utf8',
+      );
+    } catch (e) {
+      console.warn('[Tray Icon] Write failed:', e.message);
+    }
+  }
+}
+
+// Mode → shouldUseDarkColors. Null means "let caller fall through to
+// Electron's native value". Names describe the icon's colour.
+function modeToDark(mode) {
+  if (mode === 'white') return true;
+  if (mode === 'black') return false;
+  return null;
+}
+
+module.exports = TrayIconSettings;
+module.exports.VALID_MODES = VALID_MODES;
+module.exports.DEFAULT_MODE = DEFAULT_MODE;
+module.exports.MODE_MIGRATIONS = MODE_MIGRATIONS;
+module.exports.modeToDark = modeToDark;
+module.exports.SETTINGS_FILE = SETTINGS_FILE;

--- a/scripts/tray-icon-settings.js
+++ b/scripts/tray-icon-settings.js
@@ -79,16 +79,23 @@ class TrayIconSettings extends EventEmitter {
     return migrated;
   }
 
+  // Atomic write via <path>.tmp + renameSync so a kill mid-write
+  // can't truncate the settings file — _load() is soft-fail, but
+  // renameSync on POSIX guarantees the reader sees either the old
+  // content or the fully-written new content, never a partial one.
   _save() {
+    const tmp = this._path + '.tmp';
     try {
       fs.mkdirSync(path.dirname(this._path), { recursive: true });
       fs.writeFileSync(
-        this._path,
+        tmp,
         JSON.stringify({ iconMode: this._mode }, null, 2) + '\n',
         'utf8',
       );
+      fs.renameSync(tmp, this._path);
     } catch (e) {
       console.warn('[Tray Icon] Write failed:', e.message);
+      try { fs.unlinkSync(tmp); } catch (_) { /* ignore */ }
     }
   }
 }

--- a/tests/tray-icon-settings.test.js
+++ b/tests/tray-icon-settings.test.js
@@ -1,0 +1,234 @@
+'use strict';
+
+// Unit tests for scripts/tray-icon-settings.js persistence and
+// mode-to-bool mapping.
+//
+// Run with:  node --test tests/tray-icon-settings.test.js
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const TrayIconSettings = require(
+  path.join(__dirname, '..', 'scripts', 'tray-icon-settings.js'),
+);
+const {
+  VALID_MODES,
+  DEFAULT_MODE,
+  MODE_MIGRATIONS,
+  modeToDark,
+} = TrayIconSettings;
+
+function mkTmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'tray-settings-'));
+}
+
+function cleanup(tmp) {
+  try { fs.rmSync(tmp, { recursive: true, force: true }); } catch (_) {}
+}
+
+// ---------------------------------------------------------------
+// modeToDark (label = icon colour, not theme)
+// ---------------------------------------------------------------
+
+test('modeToDark: white → true (white icon shown on dark panels)', () => {
+  assert.equal(modeToDark('white'), true);
+});
+
+test('modeToDark: black → false (black icon shown on light panels)', () => {
+  assert.equal(modeToDark('black'), false);
+});
+
+test('modeToDark: auto → null (caller falls back to nativeTheme)', () => {
+  assert.equal(modeToDark('auto'), null);
+});
+
+test('modeToDark: unknown values → null', () => {
+  assert.equal(modeToDark('invalid'), null);
+  assert.equal(modeToDark(undefined), null);
+  assert.equal(modeToDark(null), null);
+  // Legacy names are intentionally NOT resolved by modeToDark — they
+  // are migrated on load (see MODE_MIGRATIONS tests below).
+  assert.equal(modeToDark('dark'), null);
+  assert.equal(modeToDark('light'), null);
+});
+
+// ---------------------------------------------------------------
+// VALID_MODES / DEFAULT_MODE / MODE_MIGRATIONS
+// ---------------------------------------------------------------
+
+test('VALID_MODES: matches submenu radios', () => {
+  assert.deepEqual([...VALID_MODES], ['auto', 'black', 'white']);
+});
+
+test('DEFAULT_MODE: auto (preserves existing behaviour)', () => {
+  assert.equal(DEFAULT_MODE, 'auto');
+});
+
+test('MODE_MIGRATIONS: old dark/light map to new icon-colour names', () => {
+  // old "dark" meant "white icon" (meant for dark panels) → "white"
+  // old "light" meant "black icon" (meant for light panels) → "black"
+  assert.equal(MODE_MIGRATIONS.dark, 'white');
+  assert.equal(MODE_MIGRATIONS.light, 'black');
+});
+
+// ---------------------------------------------------------------
+// Initial load — no settings file yet
+// ---------------------------------------------------------------
+
+test('fresh instance with missing file returns DEFAULT_MODE', () => {
+  const tmp = mkTmp();
+  try {
+    const s = new TrayIconSettings({
+      path: path.join(tmp, 'absent.json'),
+    });
+    assert.equal(s.get(), DEFAULT_MODE);
+  } finally { cleanup(tmp); }
+});
+
+test('fresh instance with corrupt JSON falls back to DEFAULT_MODE', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'corrupt.json');
+    fs.writeFileSync(p, '{ not valid JSON');
+    const s = new TrayIconSettings({ path: p });
+    assert.equal(s.get(), DEFAULT_MODE);
+  } finally { cleanup(tmp); }
+});
+
+test('fresh instance with unknown mode falls back to DEFAULT_MODE', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'garbage-mode.json');
+    fs.writeFileSync(p, JSON.stringify({ iconMode: 'rainbow' }));
+    const s = new TrayIconSettings({ path: p });
+    assert.equal(s.get(), DEFAULT_MODE);
+  } finally { cleanup(tmp); }
+});
+
+test('fresh instance loads saved mode', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'persisted.json');
+    fs.writeFileSync(p, JSON.stringify({ iconMode: 'black' }));
+    const s = new TrayIconSettings({ path: p });
+    assert.equal(s.get(), 'black');
+  } finally { cleanup(tmp); }
+});
+
+test('fresh instance migrates legacy "dark" → "white" and rewrites file', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'legacy-dark.json');
+    fs.writeFileSync(p, JSON.stringify({ iconMode: 'dark' }));
+    const s = new TrayIconSettings({ path: p });
+    assert.equal(s.get(), 'white');
+    // File should be rewritten with the new name.
+    const disk = JSON.parse(fs.readFileSync(p, 'utf8'));
+    assert.equal(disk.iconMode, 'white');
+  } finally { cleanup(tmp); }
+});
+
+test('fresh instance migrates legacy "light" → "black" and rewrites file', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'legacy-light.json');
+    fs.writeFileSync(p, JSON.stringify({ iconMode: 'light' }));
+    const s = new TrayIconSettings({ path: p });
+    assert.equal(s.get(), 'black');
+    const disk = JSON.parse(fs.readFileSync(p, 'utf8'));
+    assert.equal(disk.iconMode, 'black');
+  } finally { cleanup(tmp); }
+});
+
+// ---------------------------------------------------------------
+// set()
+// ---------------------------------------------------------------
+
+test('set: persists value to disk', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'persist.json');
+    const s = new TrayIconSettings({ path: p });
+    assert.equal(s.set('white'), true);
+    const disk = JSON.parse(fs.readFileSync(p, 'utf8'));
+    assert.equal(disk.iconMode, 'white');
+  } finally { cleanup(tmp); }
+});
+
+test('set: creates parent directory if missing', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'nested', 'deeper', 'tray.json');
+    const s = new TrayIconSettings({ path: p });
+    s.set('black');
+    assert.ok(fs.existsSync(p));
+  } finally { cleanup(tmp); }
+});
+
+test('set: rejects invalid values (returns false, no emit)', () => {
+  const tmp = mkTmp();
+  try {
+    const s = new TrayIconSettings({
+      path: path.join(tmp, 'reject.json'),
+    });
+    const events = [];
+    s.on('change', (v) => events.push(v));
+    assert.equal(s.set('not-a-mode'), false);
+    assert.equal(s.get(), DEFAULT_MODE);
+    assert.deepEqual(events, []);
+  } finally { cleanup(tmp); }
+});
+
+test('set: duplicate value is a no-op (no change event, no write)', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'dup.json');
+    fs.writeFileSync(p, JSON.stringify({ iconMode: 'black' }));
+    const s = new TrayIconSettings({ path: p });
+
+    const mtimeBefore = fs.statSync(p).mtimeMs;
+    const events = [];
+    s.on('change', (v) => events.push(v));
+
+    assert.equal(s.set('black'), false);
+    assert.deepEqual(events, []);
+    // File mtime unchanged (no rewrite)
+    assert.equal(fs.statSync(p).mtimeMs, mtimeBefore);
+  } finally { cleanup(tmp); }
+});
+
+test('set: emits change event with new value', () => {
+  const tmp = mkTmp();
+  try {
+    const s = new TrayIconSettings({
+      path: path.join(tmp, 'emit.json'),
+    });
+    const events = [];
+    s.on('change', (v) => events.push(v));
+
+    s.set('black');
+    s.set('white');
+    s.set('auto');
+
+    assert.deepEqual(events, ['black', 'white', 'auto']);
+  } finally { cleanup(tmp); }
+});
+
+// ---------------------------------------------------------------
+// Round-trip across instances
+// ---------------------------------------------------------------
+
+test('round-trip: second instance sees the first instance\'s changes', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'shared.json');
+    const a = new TrayIconSettings({ path: p });
+    a.set('white');
+
+    const b = new TrayIconSettings({ path: p });
+    assert.equal(b.get(), 'white');
+  } finally { cleanup(tmp); }
+});

--- a/tests/tray-icon-settings.test.js
+++ b/tests/tray-icon-settings.test.js
@@ -158,6 +158,20 @@ test('set: persists value to disk', () => {
   } finally { cleanup(tmp); }
 });
 
+test('set: atomic write leaves no leftover .tmp file', () => {
+  const tmp = mkTmp();
+  try {
+    const p = path.join(tmp, 'atomic.json');
+    const s = new TrayIconSettings({ path: p });
+    s.set('black');
+    s.set('white');
+    s.set('auto');
+    const entries = fs.readdirSync(tmp);
+    // Only the final file should exist, never a trailing .tmp
+    assert.deepEqual(entries, ['atomic.json']);
+  } finally { cleanup(tmp); }
+});
+
 test('set: creates parent directory if missing', () => {
   const tmp = mkTmp();
   try {


### PR DESCRIPTION
## Summary

Adds a user-selectable **Icon color** submenu (Auto / Black / White) to the Linux tray context menu, sitting between *Show App* and *Quit*. This gives users explicit control over the tray icon colour for the setups where automatic detection falls short.

As a bonus, the same patch fixes a pre-existing minor bug: changing the desktop theme while Claude is already running used to leave a duplicate tray icon behind.

## Why a feature, not just a fix?

Electron's `nativeTheme.shouldUseDarkColors` reports the **desktop colour scheme**, not the actual panel colour — Chromium reads the xdg-desktop-portal `org.freedesktop.appearance` setting and nothing else. On a lot of real-world setups those two diverge, and the tray icon ends up invisible.

The one that prompted this PR is the out-of-the-box **Fedora Plasma KDE 6** experience with the default Fedora theme: the panel is black by design, but the global colour scheme is light, so Electron picks the black tray icon and it disappears into the panel. Other affected scenarios include:

- KDE users who intentionally override just the panel's colour (dark panel over a light desktop theme, or vice versa)
- Plasma themes whose `xdg-desktop-portal-kde` mapping doesn't line up with the panel's rendered colour (the portal only translates the Breeze family — third-party schemes return "no preference")
- Electron v39's Chromium 142 regression which inverts the value on KDE Plasma 6 + Wayland

<img width="221" height="159" alt="dark_1" src="https://github.com/user-attachments/assets/f4af5be1-3565-495a-9c29-6c771bdd45be" />
Before the fix on Fedora Plasma KDE 6 with the default theme: the tray icon is there, but it's black on a black panel.

Rather than try to paper over every edge case of the detection heuristic, this PR does what apps in similar spots have settled on: hand the choice back to the user while keeping auto-detection as the default.

## How it works for the user

Right-click the tray icon → pick one of:

| Option | Behaviour |
| --- | --- |
| **Auto** (default) | Electron's `nativeTheme.shouldUseDarkColors` picks the icon — identical to pre-PR behaviour |
| **Black** | Force the black icon (`TrayIconTemplate.png`) for light panels |
| **White** | Force the white icon (`TrayIconTemplate-Dark.png`) for dark panels |

The radio labels describe the **icon's own colour**, so "White" means you'll see a white icon — no mental inversion required. The selection is persisted to `~/.config/Claude/linux-tray.json` and survives restarts.

<img width="285" height="195" alt="submenu" src="https://github.com/user-attachments/assets/6821966e-897a-4e54-9f8a-94e81ded7d93" />
The submenu with Auto / Black / White.

## Bonus: duplicate tray icon on OS theme change

Unrelated to the feature, this PR also fixes a long-standing annoyance: if you switched the KDE colour scheme while Claude was open, you'd see **two** tray icons side by side — the old one plus the new one. The pre-existing tray rebuild logic destroys the current `StatusNotifierItem` and immediately registers a new one; on KDE Plasma the new SNI can appear before Plasma has processed the unregister signal for the old one, and both 