### PR TITLE
fix: update visibility function regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,9 @@ Special thanks to:
 - **[davidamacey](https://github.com/davidamacey)** for identifying and fixing the XRDP GPU compositing blank-window issue on remote desktop sessions
 - **[pb3ck](https://github.com/pb3ck)** for diagnosing the Cowork `CLAUDE_CODE_OAUTH_TOKEN` env-strip bug with a working reference diff
 - **[aJV99](https://github.com/aJV99)** for exporting `GDK_BACKEND=wayland` in native Wayland mode to fix XWayland fallback blur on HiDPI displays
-- **[Andrej730](https://github.com/Andrej730)** for the quick-window regex readability refactor (`String.raw` + `escapeRegExp` helper)
+- **[Andrej730](https://github.com/Andrej730)**
+  - Quick-window regex readability refactor (`String.raw` + `escapeRegExp` helper)
+  - Fixing the visibility-function regex break on Claude Desktop 1.3883.0 (#495)
 
 ## Sponsorship
 

--- a/scripts/patches/quick-window.sh
+++ b/scripts/patches/quick-window.sh
@@ -69,7 +69,7 @@ console.log('  Found focus check function: ' + focusFn);
 // Find the sibling isVisible function defined near the focus function
 const focusFnIdx = code.indexOf('function ' + focusFn + '(');
 const nearbyCode = code.substring(focusFnIdx, focusFnIdx + 500);
-const visFnRe = /function (\w+)\(\)\{return!\w+\|\|\w+\.isDestroyed\(\)\?!1:\w+\.isVisible\(\)/;
+const visFnRe = /function (\w+)\(\)\{var e;return!\w+\|\|\w+\.isDestroyed\(\)\?!1:\w+\.isVisible\(\)/;
 const visMatch = nearbyCode.match(visFnRe);
 if (!visMatch) {
     console.log('  WARNING: Could not find visibility function near ' +

--- a/scripts/patches/quick-window.sh
+++ b/scripts/patches/quick-window.sh
@@ -66,10 +66,15 @@ if (!focusedMatch) {
 const focusFn = focusedMatch[1];
 console.log('  Found focus check function: ' + focusFn);
 
-// Find the sibling isVisible function defined near the focus function
+// Find the sibling isVisible function defined near the focus function.
+// Tolerate the optional `var <name>(,<name>)*;` declaration the
+// minifier hoists when the function body uses optional chaining
+// (1.3883.0+ shape: `function aZA(){var e;return!Qt...}`). Older
+// builds don't declare anything before `return!`. The non-capturing
+// group keeps the prefix optional in either case.
 const focusFnIdx = code.indexOf('function ' + focusFn + '(');
 const nearbyCode = code.substring(focusFnIdx, focusFnIdx + 500);
-const visFnRe = /function (\w+)\(\)\{var e;return!\w+\|\|\w+\.isDestroyed\(\)\?!1:\w+\.isVisible\(\)/;
+const visFnRe = /function (\w+)\(\)\{(?:var \w+(?:,\w+)*;)?return!\w+\|\|\w+\.isDestroyed\(\)\?!1:\w+\.isVisible\(\)/;
 const visMatch = nearbyCode.match(visFnRe);
 if (!visMatch) {
     console.log('  WARNING: Could not find visibility function near ' +


### PR DESCRIPTION
This function is now starts with `var e;` (e.g. `function aZA(){var e;return!Qt||Qt.isDestroyed()?!1:Qt.isVisible()`)

Can confirm that the change resolves https://github.com/aaddrick/claude-desktop-debian/issues/495 for me.
