### PR TITLE
feat: APT/DNF Worker scaffolding

### DIFF
--- a/.github/workflows/apt-repo-heartbeat.yml
+++ b/.github/workflows/apt-repo-heartbeat.yml
@@ -148,28 +148,24 @@ jobs:
           script: |
             const fmt = process.env.FORMAT;
             const label = `heartbeat-failure-${fmt}`;
-            const title = `APT/DNF repo heartbeat failing (${fmt})`;
-            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const body = `Heartbeat failed for \`${fmt}\` at ${new Date().toISOString()}.\nRun: ${runUrl}`;
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+            const { data: open } = await github.rest.issues.listForRepo({
+              ...context.repo,
               labels: label,
               state: 'open',
             });
-            if (open.data.length === 0) {
+            if (open.length === 0) {
               await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
+                ...context.repo,
+                title: `APT/DNF repo heartbeat failing (${fmt})`,
                 body,
                 labels: [label],
               });
             } else {
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: open.data[0].number,
+                ...context.repo,
+                issue_number: open[0].number,
                 body,
               });
             }
@@ -183,22 +179,19 @@ jobs:
           script: |
             const fmt = process.env.FORMAT;
             const label = `heartbeat-failure-${fmt}`;
-            const open = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+            const { data: open } = await github.rest.issues.listForRepo({
+              ...context.repo,
               labels: label,
               state: 'open',
             });
-            for (const issue of open.data) {
+            for (const issue of open) {
               await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                ...context.repo,
                 issue_number: issue.number,
                 body: `Heartbeat for \`${fmt}\` recovered at ${new Date().toISOString()}; auto-closing.`,
               });
               await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+                ...context.repo,
                 issue_number: issue.number,
                 state: 'closed',
               });

--- a/.github/workflows/apt-repo-heartbeat.yml
+++ b/.github/workflows/apt-repo-heartbeat.yml
@@ -1,0 +1,205 @@
+name: APT/DNF Repo Heartbeat
+
+# Walks the published .deb and .rpm URLs through the full
+# Pages 301 → Worker 302 → Releases 302 → CDN 200 chain daily,
+# asserts ordered hops, asserts size match against the Releases
+# asset, and opens a tracking issue (with a format-specific label)
+# on failure. Auto-closes the issue when the format recovers.
+#
+# Pre-Phase-4a: the gate step skips gracefully when the production
+# Worker isn't live yet. Once Phase 4a is done, the gate passes
+# and the full chain is exercised every day.
+
+on:
+  schedule:
+    - cron: '0 12 * * *'  # daily noon UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  ping:
+    strategy:
+      fail-fast: false
+      matrix:
+        format: [deb, rpm]
+    runs-on: ubuntu-latest
+    env:
+      WORKER_DOMAIN: pkg.claude-desktop-debian.dev
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - name: Skip if Worker not live yet
+        id: gate
+        run: |
+          if curl -fsI --max-time 10 \
+              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+            echo "live=true" >> "$GITHUB_OUTPUT"
+            echo "Worker live; running heartbeat."
+          else
+            echo "live=false" >> "$GITHUB_OUTPUT"
+            echo "Worker not live; heartbeat skipping (expected before Phase 4a)."
+          fi
+
+      - name: Resolve latest release for ${{ matrix.format }}
+        if: steps.gate.outputs.live == 'true'
+        id: latest
+        run: |
+          tag=$(gh release list --limit 1 --json tagName \
+                  --jq '.[0].tagName' \
+                  --repo aaddrick/claude-desktop-debian)
+          repoVer="${tag#v}"; repoVer="${repoVer%+claude*}"
+          claudeVer="${tag#*+claude}"
+          if [[ "${{ matrix.format }}" == "deb" ]]; then
+            asset="claude-desktop_${claudeVer}-${repoVer}_amd64.deb"
+            url="https://aaddrick.github.io/claude-desktop-debian/pool/main/c/claude-desktop/${asset}"
+          else
+            asset="claude-desktop-${claudeVer}-${repoVer}-1.x86_64.rpm"
+            url="https://aaddrick.github.io/claude-desktop-debian/rpm/x86_64/${asset}"
+          fi
+          {
+            echo "tag=${tag}"
+            echo "asset=${asset}"
+            echo "url=${url}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate ordered chain + fetch + size match
+        if: steps.gate.outputs.live == 'true'
+        env:
+          ASSET: ${{ steps.latest.outputs.asset }}
+          URL: ${{ steps.latest.outputs.url }}
+          TAG: ${{ steps.latest.outputs.tag }}
+          FORMAT: ${{ matrix.format }}
+        run: |
+          set -euo pipefail
+
+          # Wait for propagation; fail after 5 min instead of cargo-cult sleep
+          deadline=$((SECONDS + 300))
+          until curl -fsI --max-time 10 "$URL" -o /dev/null; do
+            if [[ $SECONDS -gt $deadline ]]; then
+              echo "::error::Reachability timeout for ${URL}"
+              exit 1
+            fi
+            sleep 10
+          done
+
+          # Walk redirect chain hop-by-hop, asserting each hop's pattern in order
+          expected_hops=(
+            "https://${WORKER_DOMAIN}/"
+            "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/"
+            "https://objects\\.githubusercontent\\.com/"
+          )
+          url="$URL"
+          for i in "${!expected_hops[@]}"; do
+            hop_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+            redirect_url=$(curl -s -o /dev/null -w '%{redirect_url}' "$url")
+            echo "Hop ${i}: ${hop_status} ${url} -> ${redirect_url}"
+            if [[ ! "$hop_status" =~ ^30[12]$ ]]; then
+              echo "::error::Hop ${i}: expected 301/302, got ${hop_status}"
+              exit 1
+            fi
+            if [[ ! "$redirect_url" =~ ^${expected_hops[$i]} ]]; then
+              echo "::error::Hop ${i} mismatch:"
+              echo "::error::  expected: ${expected_hops[$i]}"
+              echo "::error::  got:      ${redirect_url}"
+              exit 1
+            fi
+            url="$redirect_url"
+          done
+
+          # Fetch the asset and validate its format
+          curl -fsSL -o "/tmp/${ASSET}" "$URL"
+
+          if [[ "$FORMAT" == "deb" ]]; then
+            if ! file "/tmp/${ASSET}" | grep -q 'Debian binary package'; then
+              echo "::error::Fetched file is not a valid Debian package"
+              exit 1
+            fi
+          else
+            sudo apt-get update >/dev/null
+            sudo apt-get install -y rpm >/dev/null
+            if ! rpm -qpi "/tmp/${ASSET}" >/dev/null 2>&1; then
+              echo "::error::Fetched file is not a valid RPM"
+              exit 1
+            fi
+          fi
+
+          # Size match against the Releases asset
+          asset_size=$(gh release view "$TAG" \
+            --repo aaddrick/claude-desktop-debian \
+            --json assets \
+            --jq ".assets[] | select(.name == \"${ASSET}\") | .size")
+          local_size=$(stat -c %s "/tmp/${ASSET}")
+          if [[ "$asset_size" != "$local_size" ]]; then
+            echo "::error::Size mismatch: local ${local_size} vs Releases ${asset_size}"
+            exit 1
+          fi
+
+          echo "Heartbeat passed: chain validated, file matches Releases asset."
+
+      - name: Open or update failure issue
+        if: failure() && steps.gate.outputs.live == 'true'
+        uses: actions/github-script@v7
+        env:
+          FORMAT: ${{ matrix.format }}
+        with:
+          script: |
+            const fmt = process.env.FORMAT;
+            const label = `heartbeat-failure-${fmt}`;
+            const title = `APT/DNF repo heartbeat failing (${fmt})`;
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+            const body = `Heartbeat failed for \`${fmt}\` at ${new Date().toISOString()}.\nRun: ${runUrl}`;
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open',
+            });
+            if (open.data.length === 0) {
+              await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: open.data[0].number,
+                body,
+              });
+            }
+
+      - name: Auto-close failure issue on recovery
+        if: success() && steps.gate.outputs.live == 'true'
+        uses: actions/github-script@v7
+        env:
+          FORMAT: ${{ matrix.format }}
+        with:
+          script: |
+            const fmt = process.env.FORMAT;
+            const label = `heartbeat-failure-${fmt}`;
+            const open = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open',
+            });
+            for (const issue of open.data) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: `Heartbeat for \`${fmt}\` recovered at ${new Date().toISOString()}; auto-closing.`,
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      WORKER_DOMAIN: pkg.claude-desktop-debian.dev
 
     steps:
       - name: Checkout gh-pages branch
@@ -455,8 +457,6 @@ jobs:
 
       - name: Strip binaries from pool (gated on Worker liveness)
         working-directory: apt-repo
-        env:
-          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
         run: |
           # The Worker on WORKER_DOMAIN serves /pool/.../*.deb requests by
           # 302-redirecting to GitHub Release assets. When it's live we strip
@@ -494,7 +494,6 @@ jobs:
 
       - name: Smoke test published deb (ordered chain + size)
         env:
-          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |
@@ -560,6 +559,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    env:
+      WORKER_DOMAIN: pkg.claude-desktop-debian.dev
 
     steps:
       - name: Checkout gh-pages branch
@@ -653,8 +654,6 @@ jobs:
 
       - name: Strip RPMs from pool (gated on Worker liveness)
         working-directory: dnf-repo
-        env:
-          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
         run: |
           # Mirror of the APT-side strip. Repodata (signed) stays; the .rpm
           # binaries themselves are deleted because the Worker 302-redirects
@@ -689,7 +688,6 @@ jobs:
 
       - name: Smoke test published rpm (ordered chain + size)
         env:
-          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,6 +453,26 @@ jobs:
             reprepro --section utils --priority optional includedeb stable "$deb"
           done
 
+      - name: Strip binaries from pool (gated on Worker liveness)
+        working-directory: apt-repo
+        env:
+          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
+        run: |
+          # The Worker on WORKER_DOMAIN serves /pool/.../*.deb requests by
+          # 302-redirecting to GitHub Release assets. When it's live we strip
+          # binaries from the gh-pages tree (the metadata's Filename: field
+          # still references pool paths; the Worker intercepts).
+          # When the Worker isn't live (pre-Phase-4a, outage, misconfiguration)
+          # the strip is skipped to avoid serving 404s for binary fetches.
+          probe_url="https://${WORKER_DOMAIN}/dists/stable/InRelease"
+          if curl -fsI --max-time 10 "$probe_url" >/dev/null; then
+            echo "Worker live at ${WORKER_DOMAIN}; stripping binaries from pool"
+            find pool -type f -name '*.deb' -delete
+          else
+            echo "Worker not responding at ${WORKER_DOMAIN}; preserving .debs in pool"
+            echo "(expected before Phase 4a; after that, an error worth investigating)"
+          fi
+
       - name: Commit and push changes
         working-directory: apt-repo
         run: |
@@ -471,6 +491,67 @@ jobs:
             echo "Push failed, retrying in ${wait_time}s... (attempt $i/5)"
             sleep "$wait_time"
           done
+
+      - name: Smoke test published deb (ordered chain + size)
+        env:
+          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! curl -fsI --max-time 10 \
+              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+            echo "Worker not live; skipping smoke test (expected before Phase 4a)"
+            exit 0
+          fi
+
+          # Parse versions from tag (e.g., v2.0.2+claude1.3883.0)
+          repoVer="${TAG#v}"; repoVer="${repoVer%+claude*}"
+          claudeVer="${TAG#*+claude}"
+          deb_name="claude-desktop_${claudeVer}-${repoVer}_amd64.deb"
+          deb_url="https://aaddrick.github.io/claude-desktop-debian/pool/main/c/claude-desktop/${deb_name}"
+
+          # Wait for propagation
+          deadline=$((SECONDS + 300))
+          until curl -fsI --max-time 10 "$deb_url" -o /dev/null; do
+            [[ $SECONDS -gt $deadline ]] \
+              && { echo "::error::Reachability timeout for ${deb_url}"; exit 1; }
+            sleep 10
+          done
+
+          # Walk redirect chain hop-by-hop
+          expected_hops=(
+            "https://${WORKER_DOMAIN}/"
+            "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/v${repoVer}\\+claude${claudeVer}/"
+            "https://objects\\.githubusercontent\\.com/"
+          )
+          url="$deb_url"
+          for i in "${!expected_hops[@]}"; do
+            hop_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+            redirect_url=$(curl -s -o /dev/null -w '%{redirect_url}' "$url")
+            echo "Hop ${i}: ${hop_status} ${url} -> ${redirect_url}"
+            [[ "$hop_status" =~ ^30[12]$ ]] \
+              || { echo "::error::Hop ${i} expected 301/302, got ${hop_status}"; exit 1; }
+            [[ "$redirect_url" =~ ^${expected_hops[$i]} ]] \
+              || { echo "::error::Hop ${i} mismatch: expected ${expected_hops[$i]}, got ${redirect_url}"; exit 1; }
+            url="$redirect_url"
+          done
+
+          # Fetch and validate
+          curl -fsSL -o /tmp/smoke.deb "$deb_url"
+          file /tmp/smoke.deb | grep -q 'Debian binary package' \
+            || { echo "::error::Not a valid Debian package"; exit 1; }
+
+          # Size match against the Releases asset
+          asset_size=$(gh release view "$TAG" \
+            --repo aaddrick/claude-desktop-debian \
+            --json assets \
+            --jq ".assets[] | select(.name == \"${deb_name}\") | .size")
+          local_size=$(stat -c %s /tmp/smoke.deb)
+          [[ "$asset_size" == "$local_size" ]] \
+            || { echo "::error::Size mismatch: ${local_size} vs ${asset_size}"; exit 1; }
+
+          echo "APT smoke test passed: chain validated, file matches Releases asset"
 
   update-dnf-repo:
     name: Update DNF Repository
@@ -570,6 +651,23 @@ jobs:
             'gpgkey=https://aaddrick.github.io/claude-desktop-debian/KEY.gpg' \
             > rpm/claude-desktop.repo
 
+      - name: Strip RPMs from pool (gated on Worker liveness)
+        working-directory: dnf-repo
+        env:
+          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
+        run: |
+          # Mirror of the APT-side strip. Repodata (signed) stays; the .rpm
+          # binaries themselves are deleted because the Worker 302-redirects
+          # /rpm/<arch>/*.rpm requests to GitHub Release assets.
+          probe_url="https://${WORKER_DOMAIN}/dists/stable/InRelease"
+          if curl -fsI --max-time 10 "$probe_url" >/dev/null; then
+            echo "Worker live; stripping RPMs from pool (repodata + signatures retained)"
+            find rpm -type f -name '*.rpm' -delete
+          else
+            echo "Worker not responding; preserving .rpms in pool"
+            echo "(expected before Phase 4a; after that, an error worth investigating)"
+          fi
+
       - name: Commit and push changes
         working-directory: dnf-repo
         run: |
@@ -588,6 +686,62 @@ jobs:
             echo "Push failed, retrying in ${wait_time}s... (attempt $i/5)"
             sleep "$wait_time"
           done
+
+      - name: Smoke test published rpm (ordered chain + size)
+        env:
+          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if ! curl -fsI --max-time 10 \
+              "https://${WORKER_DOMAIN}/dists/stable/InRelease" >/dev/null; then
+            echo "Worker not live; skipping smoke test (expected before Phase 4a)"
+            exit 0
+          fi
+
+          repoVer="${TAG#v}"; repoVer="${repoVer%+claude*}"
+          claudeVer="${TAG#*+claude}"
+          rpm_name="claude-desktop-${claudeVer}-${repoVer}-1.x86_64.rpm"
+          rpm_url="https://aaddrick.github.io/claude-desktop-debian/rpm/x86_64/${rpm_name}"
+
+          deadline=$((SECONDS + 300))
+          until curl -fsI --max-time 10 "$rpm_url" -o /dev/null; do
+            [[ $SECONDS -gt $deadline ]] \
+              && { echo "::error::Reachability timeout for ${rpm_url}"; exit 1; }
+            sleep 10
+          done
+
+          expected_hops=(
+            "https://${WORKER_DOMAIN}/"
+            "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/v${repoVer}\\+claude${claudeVer}/"
+            "https://objects\\.githubusercontent\\.com/"
+          )
+          url="$rpm_url"
+          for i in "${!expected_hops[@]}"; do
+            hop_status=$(curl -s -o /dev/null -w '%{http_code}' "$url")
+            redirect_url=$(curl -s -o /dev/null -w '%{redirect_url}' "$url")
+            echo "Hop ${i}: ${hop_status} ${url} -> ${redirect_url}"
+            [[ "$hop_status" =~ ^30[12]$ ]] \
+              || { echo "::error::Hop ${i} expected 301/302, got ${hop_status}"; exit 1; }
+            [[ "$redirect_url" =~ ^${expected_hops[$i]} ]] \
+              || { echo "::error::Hop ${i} mismatch: expected ${expected_hops[$i]}, got ${redirect_url}"; exit 1; }
+            url="$redirect_url"
+          done
+
+          curl -fsSL -o /tmp/smoke.rpm "$rpm_url"
+          rpm -qpi /tmp/smoke.rpm >/dev/null \
+            || { echo "::error::Not a valid RPM"; exit 1; }
+
+          asset_size=$(gh release view "$TAG" \
+            --repo aaddrick/claude-desktop-debian \
+            --json assets \
+            --jq ".assets[] | select(.name == \"${rpm_name}\") | .size")
+          local_size=$(stat -c %s /tmp/smoke.rpm)
+          [[ "$asset_size" == "$local_size" ]] \
+            || { echo "::error::Size mismatch: ${local_size} vs ${asset_size}"; exit 1; }
+
+          echo "DNF smoke test passed: chain validated, file matches Releases asset"
 
   update-aur-repo:
     name: Update AUR Package

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,49 @@
+name: Deploy Worker
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'worker/**'
+      - '.github/workflows/deploy-worker.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: worker
+
+      - name: Verify route is bound and Worker responds
+        env:
+          # Probe whichever route wrangler.toml currently binds. Update this
+          # when Phase 4a switches wrangler.toml to the production hostname.
+          PROBE_HOST: pkg-staging.claude-desktop-debian.dev
+        run: |
+          # Wait briefly for deploy + DNS propagation
+          sleep 30
+
+          # Worker proxies metadata path through to gh-pages; expect any
+          # 2xx/3xx. A 5xx or 521/523/530 means the route isn't bound or
+          # the Worker errored at edge.
+          status=$(curl -s -o /dev/null -w '%{http_code}' \
+            --max-time 30 \
+            "https://${PROBE_HOST}/dists/stable/InRelease")
+          echo "Probe status: ${status}"
+          if [[ ! "$status" =~ ^[23] ]]; then
+            echo "::error::Worker probe at ${PROBE_HOST} returned ${status}"
+            echo "::error::Expected 2xx or 3xx (route bound + Worker responding)"
+            exit 1
+          fi
+          echo "Route bound, Worker responding."

--- a/docs/worker-apt-plan.md
+++ b/docs/worker-apt-plan.md
@@ -1,6 +1,6 @@
 # Plan: APT/DNF binary distribution via Cloudflare Worker → GitHub Releases
 
-**Status:** Draft (post-contrarian-review revision 3)
+**Status:** Draft (post-contrarian-review revision 3, domain locked in)
 **Issue:** [#493](https://github.com/aaddrick/claude-desktop-debian/issues/493)
 **Trigger:** [run 24811974733](https://github.com/aaddrick/claude-desktop-debian/actions/runs/24811974733) — `update-apt-repo` push rejected because `.deb` exceeds GitHub's 100 MB per-file cap
 **Relationship to #449:** This plan addresses the **forward** component of #449's gh-pages clone-bloat (no new `.deb` accumulation after Phase 4b). Backfill — shrinking the existing history — is a mandatory follow-up via one-time orphan-reset of `gh-pages`, not optional. The previously-drafted `gh-pages-split-plan.md` is deleted in this branch; the split-into-separate-repo machinery is no longer required.
@@ -21,9 +21,10 @@ Reference architecture: Cloudflare's own apt/yum repo at [`pkg.cloudflare.com`](
 
 | Decision | Value |
 |---|---|
-| Custom domain | New domain, registered for this purpose (~$10–15/yr) |
-| Cloudflare account | Free tier; new account if none exists, owned by a non-personal email |
-| Worker route | `apt.<domain>/*` |
+| Custom domain | `claude-desktop-debian.dev` (registered at Cloudflare Registrar) |
+| Cloudflare account | Free tier; account email aliased to `cf-pkg@claude-desktop-debian.dev` |
+| Worker route (production) | `pkg.claude-desktop-debian.dev/*` |
+| Worker route (staging, initial) | `pkg-staging.claude-desktop-debian.dev/*` |
 | Worker source | `worker/` directory in this repo, version-controlled, deployed via CI |
 | Worker deploy creds | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` as repo secrets |
 | RPM filename regex | Verify against actual CI-produced filename in Phase 1 |
@@ -38,7 +39,7 @@ existing user with old sources.list
        ▼
 github.io/.../foo.deb
    ↓ 301 (Pages auto-redirect from CNAME file)
-apt.<domain>/.../foo.deb
+pkg.claude-desktop-debian.dev/.../foo.deb
    ↓ Worker route handler
    ├─ /dists/*, /KEY.gpg, /index.html, /repodata/*  →  fetch() from gh-pages origin (200)
    └─ /pool/.../*.deb, /rpm/*/*.rpm                  →  302 to github.com/.../releases/download/<tag>/<asset>
@@ -91,7 +92,7 @@ Two surgical edits to `.github/workflows/ci.yml`. The first adds a step to both 
 +      - name: Strip binaries from pool (gated on Worker liveness)
 +        working-directory: apt-repo
 +        env:
-+          WORKER_DOMAIN: apt.<domain>
++          WORKER_DOMAIN: pkg.claude-desktop-debian.dev
 +        run: |
 +          probe_url="https://${WORKER_DOMAIN}/dists/stable/InRelease"
 +          if curl -fsI --max-time 10 "$probe_url" >/dev/null; then
@@ -112,7 +113,7 @@ The second adds a smoke-test step at the end of each repo-update job that **walk
 ```yaml
       - name: Smoke test published deb (ordered chain + size)
         env:
-          WORKER_DOMAIN: apt.<domain>  # the registered custom domain
+          WORKER_DOMAIN: pkg.claude-desktop-debian.dev  # the registered custom domain
           GH_TOKEN: ${{ github.token }}
         run: |
           deb_name="claude-desktop_${CLAUDE_VERSION}-${REPO_VERSION}_amd64.deb"
@@ -187,11 +188,15 @@ The honest reality: `@aaddrick` is the sole maintainer for everything outside co
 - **CI-only deploys:** `wrangler` credentials live as repo secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`), never on a single workstation. Deploys happen via CI from any pushed commit, not from `aaddrick`'s laptop. This eliminates the "lost workstation" failure mode without requiring a second human
 - **Recovery runbook:** `docs/learnings/apt-worker-architecture.md` (created in Phase 5) documents which Cloudflare account and which registrar own what, plus exact steps for a future maintainer to take over (rotate API token, point registrar contact at new email, update DNS if migrating accounts)
 
-**Cloudflare API token scopes** (for the `CLOUDFLARE_API_TOKEN` repo secret):
+**Cloudflare API token scopes** (for the `CLOUDFLARE_API_TOKEN` repo secret).
 
-- `Account.Workers Scripts:Edit` — required to deploy Worker code
-- `Zone.Workers Routes:Edit` — required to bind the Worker to `apt.<domain>/*`
-- `Zone.Zone:Read` — required by `wrangler` to enumerate zones during deploy
+Recommended path: use the **"Edit Cloudflare Workers" template** in Cloudflare's Custom Token creation UI. It bundles all required permissions plus Workers KV / R2 Storage edit (broader than strictly needed today, harmless if you don't use those resources, and avoids needing to rotate the token if you add KV/R2 later). Cloudflare maintains the template and updates it as API changes happen.
+
+Minimum-viable explicit alternative (current as of 2026-04, having survived a recent dropdown rename — the previously-documented `Zone.Zone:Read` is no longer the right label):
+
+- Account → `Workers Scripts` → **Edit** (deploy Worker code)
+- Account → `Account Settings` → **Read** (wrangler validates account context during deploy)
+- Zone → `Workers Routes` → **Edit** (bind Worker to `pkg.claude-desktop-debian.dev/*`)
 
 A token missing `Workers Routes:Edit` will deploy the Worker successfully but fail silently to bind the route — the Worker will exist but receive no traffic. Phase 3's post-deploy probe catches this.
 
@@ -204,7 +209,7 @@ compatibility_date = "2026-04-22"
 account_id = "<from CLOUDFLARE_ACCOUNT_ID secret at deploy time>"
 
 routes = [
-  { pattern = "apt.<domain>/*", zone_name = "<domain>" }
+  { pattern = "pkg.claude-desktop-debian.dev/*", zone_name = "claude-desktop-debian.dev" }
 ]
 ```
 
@@ -237,7 +242,7 @@ Exit: both `curl` checks succeed against the previously-published version; RPM r
 
 ### Phase 2 — Test domain validation (broad container matrix)
 
-- Deploy Worker to `apt-test.<domain>/*`, no production traffic
+- Deploy Worker to `pkg-staging.claude-desktop-debian.dev/*`, no production traffic
 - Container matrix expanded beyond happy-path distros to catch real-world configurations:
 
 | Container | Why |
@@ -248,9 +253,9 @@ Exit: both `curl` checks succeed against the previously-published version; RPM r
 | `fedora:latest` | DNF baseline |
 | `rockylinux:9` | RHEL-family compat |
 | `debian:stable` + `apt-cacher-ng` | Caching proxy in front of apt — RFC says don't cache 302s, in practice some configs do |
-| `debian:stable` --network with IPv6-only | Confirm `apt.<domain>` and `objects.githubusercontent.com` resolve AAAA |
+| `debian:stable` --network with IPv6-only | Confirm `pkg.claude-desktop-debian.dev` and `objects.githubusercontent.com` resolve AAAA |
 
-For each container, drop a temporary `sources.list` pointing at `apt-test.<domain>`, run `apt update && apt install claude-desktop` (or DNF equivalent). Specifically validate a `.deb > 100 MB` install (use 1.3883.0).
+For each container, drop a temporary `sources.list` pointing at `pkg-staging.claude-desktop-debian.dev`, run `apt update && apt install claude-desktop` (or DNF equivalent). Specifically validate a `.deb > 100 MB` install (use 1.3883.0).
 
 **`apt-secure` origin-change check** — requires a **two-step run** because `apt` only emits the "changed its 'Origin'" warning when comparing against a previously-cached state. A fresh container has no prior origin recorded, so the warning never fires regardless of behavior. The check has to establish baseline first, then change URL, then re-update:
 
@@ -262,7 +267,7 @@ echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg] https://aaddrick.gi
 apt-get update
 
 # Step 2: switch sources.list to the test custom domain directly
-echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg] https://apt-test.<domain> stable main" \
+echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg] https://pkg-staging.claude-desktop-debian.dev stable main" \
   > /etc/apt/sources.list.d/claude-desktop.list
 
 # Step 3: re-update with debug; this is when the warning would surface
@@ -280,10 +285,10 @@ Exit: all containers install successfully with the >100 MB `.deb`; no `apt-secur
 
 ### Phase 3 — CI plumbing PR (NOT YET ENABLING THE PRODUCTION DOMAIN)
 
-- PR adds the Worker source under `worker/` with `wrangler.toml` (route bound to staging `apt-test.<domain>/*` initially), and a CI workflow `.github/workflows/deploy-worker.yml` that runs `wrangler deploy` on push to `main` when `worker/**` changes. Workflow needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets
+- PR adds the Worker source under `worker/` with `wrangler.toml` (route bound to staging `pkg-staging.claude-desktop-debian.dev/*` initially), and a CI workflow `.github/workflows/deploy-worker.yml` that runs `wrangler deploy` on push to `main` when `worker/**` changes. Workflow needs `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` repo secrets
 - PR adds the **liveness-probed** strip step (`curl -fsI` against `https://${WORKER_DOMAIN}/dists/stable/InRelease`) to both `update-apt-repo` and `update-dnf-repo`. Gating mechanism: the destructive `find ... -delete` runs only if the probe succeeds. Before Phase 4a, the production Worker doesn't exist, so the probe fails harmlessly and binaries stay in pool. After Phase 4a, the probe succeeds and binaries get stripped. **No env-var gating** — the gate is the actual reachability of the production endpoint
 - PR adds smoke-test step (deb + rpm versions) to each repo-update job, also implicitly gated by Worker existence
-- PR adds a **post-Worker-deploy probe** to `deploy-worker.yml` that confirms the Worker received the update and the route resolves: `curl -fsI https://apt-test.<domain>/dists/stable/InRelease` (against the staging route during this phase)
+- PR adds a **post-Worker-deploy probe** to `deploy-worker.yml` that confirms the Worker received the update and the route resolves: `curl -fsI https://pkg-staging.claude-desktop-debian.dev/dists/stable/InRelease` (against the staging route during this phase)
 
 Manually trigger CI on a test tag (e.g., `v0.0.0-test+claude0.0.0`) to confirm:
 - Worker deploys to staging route successfully
@@ -296,10 +301,10 @@ Exit: CI green on test tag; staging Worker deployed and reachable; strip step co
 
 The critical insight from contrarian review: **don't strip `.deb`s from gh-pages until the Worker path is proven live in production.** Otherwise there's a guaranteed user-visible outage between strip and Worker enable.
 
-- Add `CNAME` file to `gh-pages` root containing `apt.<domain>` (Pages settings UI)
+- Add `CNAME` file to `gh-pages` root containing `pkg.claude-desktop-debian.dev` (Pages settings UI)
 - Wait for Let's Encrypt cert provisioning. Typical: ~1h. Edge cases: 24h+ for DNS CAA records, registrar propagation delays, Let's Encrypt rate limits. Monitor in Pages settings UI
-- Update `wrangler.toml` route from staging (`apt-test.<domain>/*`) to production (`apt.<domain>/*`) and merge — CI deploys the Worker to the production route
-- **Important correction from earlier draft:** once the CNAME is live, GitHub Pages auto-301s **all** `aaddrick.github.io/claude-desktop-debian/...` traffic to `apt.<domain>/...`. So the "direct path" via github.io is no longer directly serving — the auto-301 makes the Worker the active path for all traffic. The `.deb`s remaining in gh-pages are not actively serving most users; they exist as a **cold standby for rollback only** (if we unbind the Worker route, gh-pages still has the binaries to serve directly via the github.io URL, since CNAME removal stops the auto-301)
+- Update `wrangler.toml` route from staging (`pkg-staging.claude-desktop-debian.dev/*`) to production (`pkg.claude-desktop-debian.dev/*`) and merge — CI deploys the Worker to the production route
+- **Important correction from earlier draft:** once the CNAME is live, GitHub Pages auto-301s **all** `aaddrick.github.io/claude-desktop-debian/...` traffic to `pkg.claude-desktop-debian.dev/...`. So the "direct path" via github.io is no longer directly serving — the auto-301 makes the Worker the active path for all traffic. The `.deb`s remaining in gh-pages are not actively serving most users; they exist as a **cold standby for rollback only** (if we unbind the Worker route, gh-pages still has the binaries to serve directly via the github.io URL, since CNAME removal stops the auto-301)
 - Validation, on each container in Phase 2's matrix: clean install with original `sources.list` succeeds via the Worker chain
 - Validation: `curl -IL https://aaddrick.github.io/claude-desktop-debian/dists/stable/InRelease` shows the 301 chain landing on the custom domain
 
@@ -348,7 +353,7 @@ jobs:
         format: [deb, rpm]
     runs-on: ubuntu-latest
     env:
-      WORKER_DOMAIN: apt.<domain>
+      WORKER_DOMAIN: pkg.claude-desktop-debian.dev
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Resolve latest release for ${{ matrix.format }}
@@ -499,7 +504,7 @@ docker run --rm -it fedora:latest bash -c '
 | Filename regex divergence between deb and rpm | Phase 1 dev with both filename samples in hand; both smoke tests in CI |
 | Apt-secure origin-change warnings | Phase 2 explicit check with `Debug::Acquire::http=true`; do not exit Phase 2 with this unresolved |
 | `apt-cacher-ng` caches 302 incorrectly | Phase 2 matrix entry; if regression, document workaround or flag as known issue |
-| IPv6-only network breaks chain | Phase 2 matrix entry; both `apt.<domain>` and `objects.githubusercontent.com` must have AAAA records |
+| IPv6-only network breaks chain | Phase 2 matrix entry; both `pkg.claude-desktop-debian.dev` and `objects.githubusercontent.com` must have AAAA records |
 | Domain registrar lapse | Auto-renewal + secondary contact email + heartbeat catches |
 | GitHub Releases per-account egress throttle (503) | Heartbeat catches; if persistent, consider authenticated CDN (rare in practice for desktop-app traffic) |
 | GitHub changes Releases asset URL format | Smoke test catches first failed release; documented mitigation: update Worker `RELEASES` constant |
@@ -511,7 +516,7 @@ docker run --rm -it fedora:latest bash -c '
 If Phase 4b cutover causes user-visible breakage:
 
 1. **Cold-standby restore via CNAME removal** (Pages settings, ~5 min): remove the CNAME file from `gh-pages`. github.io URL stops 301-ing. Apt fetches directly from gh-pages — and because the strip step's liveness probe targets the *production* Worker URL (which now no longer 301s into existence), future CI runs will see the probe fail and stop stripping binaries. The pre-Phase-4a `.deb`s still in gh-pages history serve direct-from-Pages until the next release re-pushes binaries
-2. **Fast Worker disable** (Cloudflare dashboard, <1 min): unbind the Worker from `apt.<domain>/*`. Custom domain still resolves but Cloudflare returns Pages content directly. Useful for isolating "is this a Worker bug?" — but if the most recent release already stripped `.deb`s from gh-pages (Phase 4b succeeded), binary fetches still 404. Combine with #1 if user impact is ongoing
+2. **Fast Worker disable** (Cloudflare dashboard, <1 min): unbind the Worker from `pkg.claude-desktop-debian.dev/*`. Custom domain still resolves but Cloudflare returns Pages content directly. Useful for isolating "is this a Worker bug?" — but if the most recent release already stripped `.deb`s from gh-pages (Phase 4b succeeded), binary fetches still 404. Combine with #1 if user impact is ongoing
 3. **Recovery if architecture is fundamentally broken**: rollback via #1, then accept that the next upstream growth triggers the original cap problem, and pursue one of the documented fallbacks (split-package, R2, commercial CDN)
 
 The critical invariant: Phase 4a completing successfully (cert + Worker live + container tests pass with original `sources.list`) means Phase 4b is a low-risk *release trigger* (no PR-merge required — the strip step's liveness probe activates automatically once the production Worker is up). Phases 2 + 4a must catch issues before Phase 4b. Once 4b ships and the smoke test passes, the path forward from a regression is forward (fix Worker bug, push new release) or backward via rollback #1.

--- a/worker/src/worker.js
+++ b/worker/src/worker.js
@@ -16,28 +16,24 @@ const RELEASES =
 
 // claude-desktop_<claudeVer>-<repoVer>_<arch>.deb
 const DEB_RE = new RegExp(
-	'^/pool/main/c/claude-desktop/(claude-desktop_' +
-		'(?<claudeVer>[^-]+)-(?<repoVer>[^_]+)_(?<arch>amd64|arm64)\\.deb)$'
+	'^/pool/main/c/claude-desktop/(?<asset>claude-desktop_' +
+		'(?<claudeVer>[^-]+)-(?<repoVer>[^_]+)_(?:amd64|arm64)\\.deb)$'
 );
 
 // claude-desktop-<claudeVer>-<repoVer>-<rpmRelease>.<arch>.rpm
 const RPM_RE = new RegExp(
-	'^/rpm/(?<arch>x86_64|aarch64)/(claude-desktop-' +
+	'^/rpm/(?:x86_64|aarch64)/(?<asset>claude-desktop-' +
 		'(?<claudeVer>[\\d.]+)-(?<repoVer>[\\d.]+)-\\d+\\.[^.]+\\.rpm)$'
 );
-
-function tagFor(claudeVer, repoVer) {
-	return `v${repoVer}+claude${claudeVer}`;
-}
 
 export default {
 	async fetch(request) {
 		const url = new URL(request.url);
 		const m = DEB_RE.exec(url.pathname) || RPM_RE.exec(url.pathname);
 		if (m) {
-			const { claudeVer, repoVer } = m.groups;
-			const releaseUrl = `${RELEASES}/${tagFor(claudeVer, repoVer)}/${m[1]}`;
-			return Response.redirect(releaseUrl, 302);
+			const { asset, claudeVer, repoVer } = m.groups;
+			const tag = `v${repoVer}+claude${claudeVer}`;
+			return Response.redirect(`${RELEASES}/${tag}/${asset}`, 302);
 		}
 		return fetch(ORIGIN + url.pathname + url.search, request);
 	},

--- a/worker/src/worker.js
+++ b/worker/src/worker.js
@@ -1,0 +1,44 @@
+// APT/DNF binary distribution Worker.
+//
+// Pass-through requests for repo metadata (dists/, KEY.gpg, repodata/, etc.)
+// to the gh-pages origin. 302-redirect requests for binary packages
+// (pool/.../*.deb, rpm/*/*.rpm) to GitHub Release assets, which CI publishes
+// for every tagged release.
+//
+// The Worker only emits redirect responses; binary bytes flow directly from
+// objects.githubusercontent.com to the user, never crossing Cloudflare.
+//
+// See docs/worker-apt-plan.md for the full architecture.
+
+const ORIGIN = 'https://aaddrick.github.io/claude-desktop-debian';
+const RELEASES =
+	'https://github.com/aaddrick/claude-desktop-debian/releases/download';
+
+// claude-desktop_<claudeVer>-<repoVer>_<arch>.deb
+const DEB_RE = new RegExp(
+	'^/pool/main/c/claude-desktop/(claude-desktop_' +
+		'(?<claudeVer>[^-]+)-(?<repoVer>[^_]+)_(?<arch>amd64|arm64)\\.deb)$'
+);
+
+// claude-desktop-<claudeVer>-<repoVer>-<rpmRelease>.<arch>.rpm
+const RPM_RE = new RegExp(
+	'^/rpm/(?<arch>x86_64|aarch64)/(claude-desktop-' +
+		'(?<claudeVer>[\\d.]+)-(?<repoVer>[\\d.]+)-\\d+\\.[^.]+\\.rpm)$'
+);
+
+function tagFor(claudeVer, repoVer) {
+	return `v${repoVer}+claude${claudeVer}`;
+}
+
+export default {
+	async fetch(request) {
+		const url = new URL(request.url);
+		const m = DEB_RE.exec(url.pathname) || RPM_RE.exec(url.pathname);
+		if (m) {
+			const { claudeVer, repoVer } = m.groups;
+			const releaseUrl = `${RELEASES}/${tagFor(claudeVer, repoVer)}/${m[1]}`;
+			return Response.redirect(releaseUrl, 302);
+		}
+		return fetch(ORIGIN + url.pathname + url.search, request);
+	},
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,19 @@
+# Cloudflare Worker configuration for the APT/DNF binary redirect.
+# See docs/worker-apt-plan.md for the architecture.
+#
+# Initially deployed to pkg-staging.<domain> only. Phase 4a switches the
+# route to pkg.<domain> after Phase 2 container validation passes. The
+# strip step in .github/workflows/ci.yml gates on the production route's
+# liveness, so the production route's existence is the cutover signal.
+
+name = "claude-desktop-debian-pkg-redirect"
+main = "src/worker.js"
+compatibility_date = "2026-04-22"
+
+# Custom Domain (auto-DNS) routing. Cloudflare creates the DNS record
+# automatically when this is deployed; no separate dummy A record needed.
+# Switch `pattern` to "pkg.claude-desktop-debian.dev" when cutting to
+# production in Phase 4a.
+routes = [
+	{ pattern = "pkg-staging.claude-desktop-debian.dev", custom_domain = true },
+]


### PR DESCRIPTION
## Summary

Implementation scaffolding for the Cloudflare Worker that fronts the APT/DNF repo, per the plan in `docs/worker-apt-plan.md` (merged in #494). This is the Phase 3 deliverable — Worker source, wrangler config, deploy workflow, heartbeat workflow, and the gated CI changes that make the strip step + smoke tests safe to land before Phase 4a.

Tracks: #493

### What ships

**Worker:**
- `worker/src/worker.js` — redirects `/pool/.../*.deb` and `/rpm/*/*.rpm` to GitHub Release assets via 302; passes metadata (`/dists/*`, `/KEY.gpg`, `/repodata/*`) through to the gh-pages origin via `fetch()`
- `worker/wrangler.toml` — bound to `pkg-staging.claude-desktop-debian.dev` initially via Cloudflare Custom Domain (auto-DNS); Phase 4a switches the route to `pkg.claude-desktop-debian.dev`

**Workflows:**
- `.github/workflows/deploy-worker.yml` — runs `wrangler deploy` on push to `main` when `worker/**` or this workflow itself changes; post-deploy probe asserts the route resolves with a 2xx/3xx
- `.github/workflows/apt-repo-heartbeat.yml` — daily cron + matrix `[deb, rpm]`; walks the full Pages 301 → Worker 302 → Releases 302 → CDN 200 chain hop-by-hop, asserts ordered hops, asserts size match against the `gh release view` asset, opens a tracking issue with format-specific label (`heartbeat-failure-deb` / `heartbeat-failure-rpm`) on failure, auto-closes on recovery

**`ci.yml` changes:**
- `update-apt-repo`: added gated strip step (`find pool -name '*.deb' -delete` only fires if `curl -fsI https://pkg.claude-desktop-debian.dev/dists/stable/InRelease` succeeds) + smoke test gated on the same probe
- `update-dnf-repo`: mirror — strip + RPM smoke test

### Why this is safe to merge before Phase 4a

The destructive operations are gated on a **positive liveness probe** of the production Worker hostname (`pkg.claude-desktop-debian.dev`), which doesn't exist yet. So every gate falls through to the no-op branch:

- Strip step: probe fails → `.debs`/`.rpms` are pushed to gh-pages exactly as today
- Smoke test: probe fails → step exits 0 with a "skipping" message
- Heartbeat: gate step writes `live=false` → all subsequent steps skip → no failure issues created

After Phase 4a (CNAME on Pages + Worker bound to production route + cert provisioned), the same probe starts succeeding and all the gated behavior activates without further code change.

### What still needs human action before Phase 4a

- Repo secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` (already done per offline confirmation; first push to `worker/**` will exercise them on the staging route)
- Phase 1 verification: I'll run `wrangler dev` locally and confirm both deb and rpm regex resolve correctly against the existing v2.0.2 release assets
- Phase 2 container matrix: clean-container `apt`/`dnf` install end-to-end against the staging route

## Test plan

- [ ] `actionlint` clean on the three workflow files (verified locally; only pre-existing `if: false` warning unrelated to this PR)
- [ ] `worker/src/worker.js` regex verified against existing release asset names (`claude-desktop_1.3883.0-2.0.2_amd64.deb` and `claude-desktop-1.3883.0-2.0.2-1.x86_64.rpm`) — confirmed during planning
- [ ] First push to `main` after merge triggers `deploy-worker.yml` and Worker deploys to `pkg-staging.claude-desktop-debian.dev` successfully
- [ ] Post-deploy probe in `deploy-worker.yml` confirms the route is bound (2xx/3xx response)
- [ ] `wrangler dev` locally returns 302 for `/pool/main/c/claude-desktop/claude-desktop_1.3561.0-2.0.1_amd64.deb` (Phase 1 exit criterion)
- [ ] Tag a no-op release with the strip step skipping, confirming current behavior is unchanged before Phase 4a

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
55% AI / 45% Human
Claude: wrote Worker source + regex, drafted wrangler.toml + deploy/heartbeat workflows + ci.yml diffs, baked in real domain values, ran actionlint, drafted commit + PR copy
Human: registered claude-desktop-debian.dev at Cloudflare Registrar, set up Cloudflare account + Email Routing alias + 2FA, generated scoped API token + stored repo secrets, made the call to use pkg.claude-desktop-debian.dev as production hostname (and pkg-staging for initial route), drove every architecture decision feeding into this scaffolding