### PR TITLE
fix(ci): resolve DNF Worker chain blockers (#500, #501)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -435,6 +435,16 @@ jobs:
         with:
           gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
 
+      - name: Publish KEY.gpg with all public keys from keyring
+        # Fix #501: APT InRelease and DNF repomd.xml are signed with
+        # different keys from the same keyring. Export every public key
+        # so strict clients (e.g. rockylinux:9) can verify both.
+        working-directory: apt-repo
+        run: |
+          gpg --armor --export > KEY.gpg
+          echo "Keys published in KEY.gpg:"
+          gpg --show-keys < KEY.gpg
+
       - name: Add packages to repository
         working-directory: apt-repo
         run: |
@@ -651,6 +661,24 @@ jobs:
             'repo_gpgcheck=1' \
             'gpgkey=https://aaddrick.github.io/claude-desktop-debian/KEY.gpg' \
             > rpm/claude-desktop.repo
+
+      - name: Re-upload signed RPMs to GitHub Release
+        # Fix #500: rpmsign --addsign mutates the RPM in place. The release
+        # job (needs: release) already uploaded the unsigned build artifact.
+        # Clobber it with the signed copy so the sha256 in repodata matches
+        # the binary the Worker redirects to.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: dnf-repo
+        run: |
+          for arch in x86_64 aarch64; do
+            if ls "rpm/$arch/"*.rpm 1> /dev/null 2>&1; then
+              gh release upload "${{ github.ref_name }}" \
+                "rpm/$arch/"*.rpm \
+                --repo aaddrick/claude-desktop-debian \
+                --clobber
+            fi
+          done
 
       - name: Strip RPMs from pool (gated on Worker liveness)
         working-directory: dnf-repo


### PR DESCRIPTION
## Summary

Two narrow fixes to `.github/workflows/ci.yml` that together unblock DNF cutover in Phase 4a of the Worker plan. Both were surfaced by the Phase 2 container matrix in PR #498. APT is unaffected and continues to work end-to-end through the staging Worker.

## Changes

### Fix #500 — re-upload signed RPMs to the Release

`rpmsign --addsign` mutates the RPM in place (GPG signature embedded in the header). The release job runs *before* `update-dnf-repo` and uploads the **unsigned** build artifact. Repodata then references the sha256 of the *signed* file, so the Worker-redirected Release asset diverges from what dnf expects:

```
gh-pages:  signed    sha256:8c8cafa8cd97…
Releases:  unsigned  sha256:6a342e35014b…  <- what the Worker redirects to
```

Fix: after the existing `rpmsign --addsign` loop in `update-dnf-repo`, clobber the Release asset with the signed copy via `gh release upload … --clobber`. Smallest CI delta.

### Fix #501 — publish full keyring as KEY.gpg

The imported keyring from `secrets.APT_GPG_PRIVATE_KEY` contains two keys. `reprepro` signs `InRelease` with one (`8749…B912E0F1`), and `rpmsign`/`gpg --detach-sign` signs `repomd.xml.asc` with the other (`F7A1…E9B9`, the keyring default `import_gpg.outputs.keyid`). But only *one* key was in the published `KEY.gpg`, so strict clients (rockylinux:9) rejected DNF metadata with `Bad GPG signature`.

Fix: after GPG import in `update-apt-repo`, `gpg --armor --export > KEY.gpg` (no uid filter) writes every public key in the keyring to the published file. Both signatures now verify against the same bundle.

This is Option A from issue #501. Option B (converge on one canonical key) is a cleaner longer-term end state and can follow separately.

## Test plan

- [ ] Cut a throwaway test tag to exercise the full `release` → `update-apt-repo` → `update-dnf-repo` chain
- [ ] Verify `KEY.gpg` contains both fingerprints: `gpg --show-keys < KEY.gpg` lists `8749…B912E0F1` and `F7A1…E9B9`
- [ ] Verify sha256 match: the RPM at `gh-pages/rpm/x86_64/…` matches the Release asset download
- [ ] Re-run Phase 2 fedora container test — `dnf install claude-desktop` should succeed (was "All mirrors were tried")
- [ ] Re-run Phase 2 rocky container test — `dnf makecache` should succeed (was "Bad GPG signature")
- [ ] Confirm APT side still works (`debian:stable`, `ubuntu:24.04`, `debian:testing`) — these already verified against the same KEY.gpg key, so the added second key in the bundle should be inert for APT

Closes #500
Closes #501

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
90% AI / 10% Human
Claude: analysed both issue reports, located the failure points in `update-apt-repo` / `update-dnf-repo`, wrote the two-step diff, ran actionlint, opened PR
Human: flagged the issues for knockout, set scope