### PR TITLE
feat(worker): flip route to production for Phase 4a-APT

### DIFF
--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,10 +1,10 @@
 # Cloudflare Worker configuration for the APT/DNF binary redirect.
 # See docs/worker-apt-plan.md for the architecture.
 #
-# Initially deployed to pkg-staging.<domain> only. Phase 4a switches the
-# route to pkg.<domain> after Phase 2 container validation passes. The
-# strip step in .github/workflows/ci.yml gates on the production route's
-# liveness, so the production route's existence is the cutover signal.
+# Production route is live. Phase 2 container validation passed against
+# pkg-staging.<domain>; Phase 4a cuts the Worker over to pkg.<domain>.
+# The strip step in .github/workflows/ci.yml gates on this route's
+# liveness, so flipping here is what unblocks the >100MB .deb push path.
 
 name = "claude-desktop-debian-pkg-redirect"
 main = "src/worker.js"
@@ -12,8 +12,6 @@ compatibility_date = "2026-04-22"
 
 # Custom Domain (auto-DNS) routing. Cloudflare creates the DNS record
 # automatically when this is deployed; no separate dummy A record needed.
-# Switch `pattern` to "pkg.claude-desktop-debian.dev" when cutting to
-# production in Phase 4a.
 routes = [
-	{ pattern = "pkg-staging.claude-desktop-debian.dev", custom_domain = true },
+	{ pattern = "pkg.claude-desktop-debian.dev", custom_domain = true },
 ]


### PR DESCRIPTION
## Summary

Flips `worker/wrangler.toml` from `pkg-staging.claude-desktop-debian.dev` → `pkg.claude-desktop-debian.dev`. This is the Phase 4a-APT cutover step from [`docs/worker-apt-plan.md`](../blob/main/docs/worker-apt-plan.md) — it unblocks #493 by making the strip-binaries liveness probe in `update-apt-repo` / `update-dnf-repo` start succeeding, which lets gh-pages pushes go through without the >100MB `.deb` tripping GitHub's hard cap.

Draft because **there are manual pre-reqs outside this PR** that have to complete before merging. PR body spells them out.

## Validation that got us here

Phase 2 container matrix was re-run against `pkg-staging.claude-desktop-debian.dev` today:

| Container | Result |
|---|---|
| `debian:stable`   | ✅ install via Worker |
| `ubuntu:24.04`    | ✅ install via Worker |
| `debian:testing`  | ✅ install via Worker |
| `fedora:latest`   | ✅ makecache; install fails on #500 sha256 (pre-existing) |
| `rockylinux:9`    | ✅ makecache; install fails on #500 sha256 (pre-existing) |

Rocky 9's "Bad GPG signature" finding from #501 turned out to be a testing artifact (missing `-y` on `dnf makecache` → empty stdin on the key-import prompt → verification against an unimported key). With `-y`, the signature chain verifies and only the #500 sha256 mismatch remains. Posted a correction on that issue: https://github.com/aaddrick/claude-desktop-debian/issues/501#issuecomment-4305034757

#500's fix in #502 (`gh release upload --clobber` of the signed RPM to the Release) has not been exercised by CI yet — `update-dnf-repo` was skipped in the test tag's run because `update-apt-repo` failed at the push step on the 100MB cap. That step is the first thing this PR unblocks.

## Pre-merge checklist (manual)

**Do NOT merge until these are done:**

1. **Add CNAME file to `gh-pages` root** containing `pkg.claude-desktop-debian.dev` (via Settings → Pages → Custom domain, or direct `git push` to `gh-pages`).
2. **Wait for GitHub Pages cert provisioning.** Typical ~1h. Edge cases up to 24h+ per the plan doc. Monitor Settings → Pages for the green cert indicator.
3. **Verify cert works:** `curl -I https://aaddrick.github.io/claude-desktop-debian/dists/stable/InRelease` should return a 301 redirecting to `pkg.claude-desktop-debian.dev`.

Only then merge this PR. `deploy-worker.yml` will deploy the Worker to the new route.

## Post-merge validation

```bash
# Production probe (this is what CI's strip gate uses):
curl -fsI https://pkg.claude-desktop-debian.dev/dists/stable/InRelease

# Re-run the failed v2.0.3 release jobs — simultaneously validates #500
# and lets v2.0.3+claude1.3883.0 reach apt/dnf users:
gh run rerun 24836419696 --failed --repo aaddrick/claude-desktop-debian
```

## Rollback

If the production chain misbehaves:

1. Remove the `CNAME` file from `gh-pages` (via Pages UI). `aaddrick.github.io/claude-desktop-debian/` stops auto-301'ing. Existing `sources.list` URLs continue serving directly from Pages (pre-strip `.deb` history is still there for any version that was already pushed).
2. Unbind the Worker route via Cloudflare dashboard as a fast disable (<1 min) if needed separately.

## Not in scope

- #449 gh-pages orphan-reset (separate follow-up PR per plan doc Phase 5).
- Heartbeat workflow changes (already live; activates automatically when the production probe starts returning 200).

Closes nothing directly — this is Phase 4a-APT tooling; the `.deb` size problem (#493) will close when the first post-cutover release successfully pushes with `.deb`s stripped.

Refs #493, #500, #501

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: ran Phase 2 container re-validation, diagnosed #501 as testing artifact (posted correction comment), drafted wrangler flip + PR body
Human: approved sequencing, triggered the test tag that surfaced the remaining blocker