### PR TITLE
fix(worker): use raw.githubusercontent.com as origin; fix deploy probe hostname

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -27,9 +27,8 @@ jobs:
 
       - name: Verify route is bound and Worker responds
         env:
-          # Probe whichever route wrangler.toml currently binds. Update this
-          # when Phase 4a switches wrangler.toml to the production hostname.
-          PROBE_HOST: pkg-staging.claude-desktop-debian.dev
+          # Must match the hostname in worker/wrangler.toml's route.
+          PROBE_HOST: pkg.claude-desktop-debian.dev
         run: |
           # Wait briefly for deploy + DNS propagation
           sleep 30

--- a/worker/src/worker.js
+++ b/worker/src/worker.js
@@ -10,7 +10,13 @@
 //
 // See docs/worker-apt-plan.md for the full architecture.
 
-const ORIGIN = 'https://aaddrick.github.io/claude-desktop-debian';
+// Raw gh-pages content, bypassing the Pages routing layer. Fetching
+// via aaddrick.github.io auto-301s back to pkg.<domain> once the CNAME
+// is in place (Pages' custom-domain redirect), creating a loop through
+// this Worker. raw.githubusercontent.com serves the same branch content
+// directly and is unaffected by the custom-domain config.
+const ORIGIN =
+	'https://raw.githubusercontent.com/aaddrick/claude-desktop-debian/gh-pages';
 const RELEASES =
 	'https://github.com/aaddrick/claude-desktop-debian/releases/download';
 


### PR DESCRIPTION
## Summary

Two follow-ups to #503, both surfaced minutes after merging:

1. **Worker origin fetch loops via Pages auto-301.** Once the `CNAME` is live on `gh-pages`, Pages 301s every `aaddrick.github.io/claude-desktop-debian/*` request to `http://pkg.claude-desktop-debian.dev/*`. The Worker's `fetch(ORIGIN + path, request)` against `aaddrick.github.io` now receives that 301, passes it to the client, which follows back to `pkg.<domain>`, which runs the Worker again — infinite loop. Observed directly:

   ```
   $ curl -I https://pkg.claude-desktop-debian.dev/dists/stable/InRelease
   HTTP/2 301
   location: http://pkg.claude-desktop-debian.dev/dists/stable/InRelease
   x-github-request-id: 3C94:286425:...
   x-served-by: cache-yyz4566-YYZ
   ```

   Fix: switch `ORIGIN` to `https://raw.githubusercontent.com/aaddrick/claude-desktop-debian/gh-pages`. Same branch content, no Pages routing layer. Verified 200 on all 5 metadata paths (`InRelease`, `Packages`, `KEY.gpg`, `repomd.xml`, `repomd.xml.asc`).

2. **`deploy-worker.yml` post-deploy probe was still pointed at `pkg-staging`** after #503. That's why #503's workflow showed as failed in the Actions UI — wrangler deploy itself succeeded (Worker is live on `pkg.claude-desktop-debian.dev`), but the probe was resolving a hostname wrangler had just removed. `curl` returned exit 6 (couldn't resolve host). Repointed to `pkg.claude-desktop-debian.dev`.

## Test plan

- [x] Verified raw.githubusercontent.com returns 200 on the 5 metadata paths used by apt/dnf
- [ ] Merge triggers a clean deploy-worker.yml run (now probes production, should return 2xx/3xx for metadata)
- [ ] Re-probe `https://pkg.claude-desktop-debian.dev/dists/stable/InRelease` from outside — should return 200 with InRelease content (not a 301 loop)
- [ ] `gh run rerun 24836419696 --failed` for v2.0.3 — strip step's liveness probe should now succeed

Refs #493, #503

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: diagnosed the origin-fetch 301 loop via response headers (x-github-request-id proves Pages returned the 301), verified raw.githubusercontent.com as a loop-free origin, fixed both the Worker ORIGIN and the stale deploy probe
Human: delegated the Phase 4a-APT execution autonomously; this is a diagnosed follow-up, not scope creep