### PR TITLE
fix: strip CRLF from cowork-plugin-shim.sh during staging (#499)

### DIFF
--- a/scripts/staging/cowork-resources.sh
+++ b/scripts/staging/cowork-resources.sh
@@ -14,11 +14,15 @@ copy_cowork_resources() {
 
 	local resources_src="$claude_extract_dir/lib/net45/resources"
 
-	# Copy cowork-plugin-shim.sh (used by app for MCP plugin sandboxing)
+	# Copy cowork-plugin-shim.sh (used by app for MCP plugin sandboxing).
+	# The upstream file ships from the Windows .exe extract with CRLF line
+	# endings; bash exec fails on CRLF shebangs and command lines (issue #499).
 	local shim_src="$resources_src/cowork-plugin-shim.sh"
+	local shim_dest="$electron_resources_dest/cowork-plugin-shim.sh"
 	if [[ -f $shim_src ]]; then
-		cp "$shim_src" "$electron_resources_dest/cowork-plugin-shim.sh"
-		chmod +x "$electron_resources_dest/cowork-plugin-shim.sh"
+		cp "$shim_src" "$shim_dest"
+		sed -i 's/\r$//' "$shim_dest"
+		chmod +x "$shim_dest"
 		echo "Copied cowork-plugin-shim.sh"
 	else
 		echo "Warning: cowork-plugin-shim.sh not found at $shim_src"

--- a/tests/cowork-resources-staging.bats
+++ b/tests/cowork-resources-staging.bats
@@ -1,0 +1,104 @@
+#!/usr/bin/env bats
+#
+# cowork-resources-staging.bats
+# Tests for scripts/staging/cowork-resources.sh — specifically that the
+# cowork-plugin-shim.sh staged into place has LF line endings regardless
+# of what the upstream Windows .exe extract shipped (issue #499).
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+
+setup() {
+	TEST_TMP=$(mktemp -d)
+	export TEST_TMP
+
+	# Fake the staging layout the script expects.
+	claude_extract_dir="$TEST_TMP/extract"
+	electron_resources_dest="$TEST_TMP/dest"
+	architecture='x64'
+	mkdir -p "$claude_extract_dir/lib/net45/resources" \
+		"$electron_resources_dest"
+
+	# shellcheck source=scripts/_common.sh
+	source "$SCRIPT_DIR/../scripts/_common.sh"
+	# shellcheck source=scripts/staging/cowork-resources.sh
+	source "$SCRIPT_DIR/../scripts/staging/cowork-resources.sh"
+}
+
+teardown() {
+	if [[ -n "$TEST_TMP" && -d "$TEST_TMP" ]]; then
+		rm -rf "$TEST_TMP"
+	fi
+}
+
+# Build a shim file at the upstream extract location with the requested
+# line-ending style. Contents are a minimal valid bash script.
+write_shim_src() {
+	local style="$1"
+	local shim="$claude_extract_dir/lib/net45/resources/cowork-plugin-shim.sh"
+	printf '#!/bin/bash\n# Cowork plugin shim.\ncowork_require_token() {\n\treturn 0\n}\n' \
+		> "$shim"
+	if [[ $style == 'crlf' ]]; then
+		sed -i 's/$/\r/' "$shim"
+	fi
+}
+
+# =============================================================================
+# CRLF normalization (issue #499)
+# =============================================================================
+
+@test "copy_cowork_resources: strips CRLF from Windows-encoded shim" {
+	write_shim_src crlf
+
+	# Sanity: source really is CRLF before we run the staging step.
+	run grep -c $'\r$' \
+		"$claude_extract_dir/lib/net45/resources/cowork-plugin-shim.sh"
+	[[ "$status" -eq 0 ]]
+	[[ "$output" -gt 0 ]]
+
+	run copy_cowork_resources
+	[[ "$status" -eq 0 ]]
+
+	local dest="$electron_resources_dest/cowork-plugin-shim.sh"
+	[[ -f "$dest" ]]
+
+	# No carriage returns survive into the staged copy.
+	run grep -c $'\r' "$dest"
+	[[ "$status" -eq 1 ]]
+}
+
+@test "copy_cowork_resources: staged shim is executable and bash-parsable" {
+	write_shim_src crlf
+
+	run copy_cowork_resources
+	[[ "$status" -eq 0 ]]
+
+	local dest="$electron_resources_dest/cowork-plugin-shim.sh"
+	[[ -x "$dest" ]]
+
+	# bash -n would have failed on CRLF ($'\r': command not found).
+	run bash -n "$dest"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "copy_cowork_resources: LF-only shim passes through unchanged" {
+	write_shim_src lf
+
+	local src="$claude_extract_dir/lib/net45/resources/cowork-plugin-shim.sh"
+	local src_sum
+	src_sum=$(sha256sum "$src" | awk '{print $1}')
+
+	run copy_cowork_resources
+	[[ "$status" -eq 0 ]]
+
+	local dest="$electron_resources_dest/cowork-plugin-shim.sh"
+	local dest_sum
+	dest_sum=$(sha256sum "$dest" | awk '{print $1}')
+	[[ "$src_sum" == "$dest_sum" ]]
+}
+
+@test "copy_cowork_resources: missing shim emits warning without failing" {
+	run copy_cowork_resources
+	[[ "$status" -eq 0 ]]
+	[[ "$output" == *'cowork-plugin-shim.sh not found'* ]]
+}

--- a/tests/cowork-resources-staging.bats
+++ b/tests/cowork-resources-staging.bats
@@ -85,15 +85,15 @@ write_shim_src() {
 	write_shim_src lf
 
 	local src="$claude_extract_dir/lib/net45/resources/cowork-plugin-shim.sh"
-	local src_sum
-	src_sum=$(sha256sum "$src" | awk '{print $1}')
+	local src_sum _
+	read -r src_sum _ < <(sha256sum "$src")
 
 	run copy_cowork_resources
 	[[ "$status" -eq 0 ]]
 
 	local dest="$electron_resources_dest/cowork-plugin-shim.sh"
 	local dest_sum
-	dest_sum=$(sha256sum "$dest" | awk '{print $1}')
+	read -r dest_sum _ < <(sha256sum "$dest")
 	[[ "$src_sum" == "$dest_sum" ]]
 }
 


### PR DESCRIPTION
## Summary

- The upstream `cowork-plugin-shim.sh` ships from the Windows `.exe` extract with CRLF line endings. Bash dies on CRLF shebangs and command lines, so the Claude Code subprocess that execs the shim exits with code 1 and every cowork session reports `process_crashed`.
- Reproduced on my own AppImage install at `/tmp/.mount_claude*/usr/lib/node_modules/electron/dist/resources/cowork-plugin-shim.sh` — `file` reports `with CRLF line terminators`. The bug affects every distro, not just Nix; Nix just hits it first because the shim is read-only in the store, while deb/AppImage installs only bite once cowork is actively used.
- Normalises CRLF → LF at the single staging point both `build.sh` and the Nix derivation consume from, so both flows inherit the fix. Conversion is a no-op on LF-only input, so if upstream ever ships LF this patch remains safe.

## Why narrow, not a blanket sweep

The shim is the only script in the Windows resources we hand to the kernel via shebang. The other resources (`smol-bin.*.vhdx`, `ion-dist/`, locale JSON) are consumed by Node or KVM and don't care about line endings. A `find … *.sh -exec sed …` sweep would run against a set of exactly one file today and risk silently touching unrelated scripts the day upstream adds one. Narrow + documented wins.

## Test plan

- [x] Repro confirmed: `file /tmp/.mount_claude*/usr/lib/node_modules/electron/dist/resources/cowork-plugin-shim.sh` → `with CRLF line terminators`.
- [x] New BATS suite `tests/cowork-resources-staging.bats` covering:
  - CRLF source → zero `\r` bytes in staged copy, staged file is executable and passes `bash -n`.
  - LF-only source passes through unchanged (sha256 match).
  - Missing source file emits a warning without failing the build.
- [x] Manual harness run (no bats available locally) — all four cases pass; staged file is detected as `Bourne-Again shell script, ASCII text executable` with zero CR bytes.
- [x] Shellcheck: zero new warnings on `scripts/staging/cowork-resources.sh` (pre-existing SC2148/SC2154 are sourced-globals artifacts and were already there).
- [ ] CI green on this branch.

## Attribution

Reported and diagnosed by @olafkfreund with a one-line fix and clear reproduction in [#499](https://github.com/aaddrick/claude-desktop-debian/issues/499). Implementation and regression test by me.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
20% AI / 80% Human
Claude: drafted the diff, wrote the BATS suite, verified reproduction and fix locally.
Human: scoped the fix (narrow vs blanket sweep), ran contrarian review, approved the test surface, directed the PR.