### PR TITLE
fix(ci): smoke test accepts http:// on Pages 301 hop

### DIFF
--- a/.github/workflows/apt-repo-heartbeat.yml
+++ b/.github/workflows/apt-repo-heartbeat.yml
@@ -85,9 +85,11 @@ jobs:
             sleep 10
           done
 
-          # Walk redirect chain hop-by-hop, asserting each hop's pattern in order
+          # Walk redirect chain hop-by-hop, asserting each hop's pattern
+          # in order. Hop 0 may be http:// (see ci.yml smoke-test comment
+          # for the Pages https_enforced=false background).
           expected_hops=(
-            "https://${WORKER_DOMAIN}/"
+            "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/"
             "https://objects\\.githubusercontent\\.com/"
           )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,8 +529,13 @@ jobs:
           done
 
           # Walk redirect chain hop-by-hop
+          # Hop 0 is Pages' auto-301 from github.io to pkg.<domain>.
+          # Pages emits http:// in the Location because https_enforced
+          # can't be set (DNS points at Cloudflare, not Pages, so Pages
+          # can't provision its own cert). Cloudflare/Worker answers
+          # both schemes, so http vs https is cosmetic here.
           expected_hops=(
-            "https://${WORKER_DOMAIN}/"
+            "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/v${repoVer}\\+claude${claudeVer}/"
             "https://objects\\.githubusercontent\\.com/"
           )
@@ -738,8 +743,13 @@ jobs:
             sleep 10
           done
 
+          # Hop 0 is Pages' auto-301 from github.io to pkg.<domain>.
+          # Pages emits http:// in the Location because https_enforced
+          # can't be set (DNS points at Cloudflare, not Pages, so Pages
+          # can't provision its own cert). Cloudflare/Worker answers
+          # both schemes, so http vs https is cosmetic here.
           expected_hops=(
-            "https://${WORKER_DOMAIN}/"
+            "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/v${repoVer}\\+claude${claudeVer}/"
             "https://objects\\.githubusercontent\\.com/"
           )


### PR DESCRIPTION
## Summary

Third and (hopefully) last follow-up to #503 — the first rerun of `update-apt-repo` for v2.0.3 made it all the way through `reprepro includedeb` + strip + commit + push (v2.0.3 metadata is live on gh-pages now — `Version: 1.3883.0-2.0.3`, 0 `.deb`s in pool, fresh `InRelease`). The **only failure** was the tail-end smoke test at hop 0:

```
Hop 0: 301 https://aaddrick.github.io/.../*.deb
       -> http://pkg.claude-desktop-debian.dev/.../*.deb
::error::Hop 0 mismatch: expected https://pkg..., got http://pkg...
```

## Root cause

Pages emits `http://` in its auto-301 `Location` because `https_enforced: false` on the repo's Pages config — and that can't be set to `true`. DNS for `pkg.claude-desktop-debian.dev` points at Cloudflare (`custom_domain = true` in `wrangler.toml`), so Pages can never pass its domain-verification step to provision a cert. Cloudflare/Worker happily answer both schemes for `pkg.<domain>`, so the scheme in Pages' 301 is cosmetic — the redirect chain still terminates correctly.

Verified manually end-to-end, all three requested schemes:

```
$ curl -IsL https://aaddrick.github.io/claude-desktop-debian/dists/stable/InRelease
HTTP/2 301 → Location: http://pkg.claude-desktop-debian.dev/...
HTTP/1.1 200 OK
```

APT side of the cutover is actually working for real users right now.

## Fix

Relax hop 0's regex to `https?://` in three places:
- `.github/workflows/ci.yml:538` (APT smoke test)
- `.github/workflows/ci.yml:752` (DNF smoke test)
- `.github/workflows/apt-repo-heartbeat.yml:92` (daily heartbeat)

Later hops stay `https://`-only — GitHub's `releases/download/` and `objects.githubusercontent.com` redirects are always HTTPS.

## Post-merge plan

Rerun failed jobs on run 24836419696:
- `update-apt-repo` is idempotent-ish (reprepro remove+re-add, same byte content) → smoke test now passes
- `update-dnf-repo` runs (was skipped this time due to `needs: update-apt-repo`) → exercises #500's `gh release upload --clobber` path for the first time
- If DNF side pushes cleanly, v2.0.3 reaches both apt AND dnf users

Refs #493, #503

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
90% AI / 10% Human
Claude: diagnosed the scheme mismatch from the actual run log, verified gh-pages state post-push (metadata updated, pool stripped) and that the chain works end-to-end, wrote and tested the regex relaxation
Human: delegated Phase 4a-APT cutover autonomously