### PR TITLE
fix(ci): smoke test accepts release-assets.githubusercontent.com CDN

### DIFF
--- a/.github/workflows/apt-repo-heartbeat.yml
+++ b/.github/workflows/apt-repo-heartbeat.yml
@@ -91,7 +91,7 @@ jobs:
           expected_hops=(
             "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/"
-            "https://objects\\.githubusercontent\\.com/"
+            "https://(objects|release-assets)\\.githubusercontent\\.com/"
           )
           url="$URL"
           for i in "${!expected_hops[@]}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,7 +537,7 @@ jobs:
           expected_hops=(
             "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/v${repoVer}\\+claude${claudeVer}/"
-            "https://objects\\.githubusercontent\\.com/"
+            "https://(objects|release-assets)\\.githubusercontent\\.com/"
           )
           url="$deb_url"
           for i in "${!expected_hops[@]}"; do
@@ -751,7 +751,7 @@ jobs:
           expected_hops=(
             "https?://${WORKER_DOMAIN}/"
             "https://github\\.com/aaddrick/claude-desktop-debian/releases/download/v${repoVer}\\+claude${claudeVer}/"
-            "https://objects\\.githubusercontent\\.com/"
+            "https://(objects|release-assets)\\.githubusercontent\\.com/"
           )
           url="$rpm_url"
           for i in "${!expected_hops[@]}"; do


### PR DESCRIPTION
## Summary

v2.0.4 CI surfaced the next smoke-test mismatch — at hop 2:

```
Hop 2: 302 .../releases/download/v2.0.4+claude1.3883.0/...deb
       -> https://release-assets.githubusercontent.com/...
::error::Hop 2 mismatch: expected https://objects\.githubusercontent\.com/,
         got https://release-assets.githubusercontent.com/...
```

GitHub migrated Release assets from `objects.githubusercontent.com` → `release-assets.githubusercontent.com`. Both have served in the past; `release-assets` is current. Accept either via alternation:

```diff
-"https://objects\\.githubusercontent\\.com/"
+"https://(objects|release-assets)\\.githubusercontent\\.com/"
```

Same fix applied to all three sites:
- `.github/workflows/ci.yml:540` (APT smoke test)
- `.github/workflows/ci.yml:754` (DNF smoke test)
- `.github/workflows/apt-repo-heartbeat.yml:94` (daily heartbeat)

## Validation

Hops 0 and 1 already pass with #506's scheme fix — the v2.0.4 run log confirms. This PR completes the chain walker so v2.0.4's update-apt-repo smoke test will pass and `update-dnf-repo` will finally run (was skipped both on v2.0.3 and v2.0.4 due to `needs: update-apt-repo`).

## Post-merge

Cut v2.0.5 to re-exercise the full pipeline with the fix — same as v2.0.4 flow but this time both jobs should complete cleanly and test the #500 `gh release upload --clobber` path for the first time.

`docs/worker-apt-plan.md` has historical references to `objects.githubusercontent.com` — a docs-only cleanup in a follow-up.

Refs #493, #503

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude: walked through v2.0.3 → #506 → v2.0.4 → this; each iteration surfaced the next assumption in the plan that no longer matched GitHub's current behavior
Human: delegated Phase 4a-APT cutover autonomously