### PR TITLE
docs: point install instructions at pkg.claude-desktop-debian.dev + migration note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,8 +282,8 @@ jobs:
             echo ""
             echo '```bash'
             echo "# First time? Add the repo:"
-            echo "curl -fsSL https://aaddrick.github.io/claude-desktop-debian/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/claude-desktop.gpg"
-            echo 'echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg arch=amd64,arm64] https://aaddrick.github.io/claude-desktop-debian stable main" | sudo tee /etc/apt/sources.list.d/claude-desktop.list'
+            echo "curl -fsSL https://pkg.claude-desktop-debian.dev/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/claude-desktop.gpg"
+            echo 'echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg arch=amd64,arm64] https://pkg.claude-desktop-debian.dev stable main" | sudo tee /etc/apt/sources.list.d/claude-desktop.list'
             echo ""
             echo "# Install or update:"
             echo "sudo apt update && sudo apt install claude-desktop"
@@ -293,7 +293,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "# First time? Add the repo:"
-            echo "sudo curl -fsSL https://aaddrick.github.io/claude-desktop-debian/rpm/claude-desktop.repo -o /etc/yum.repos.d/claude-desktop.repo"
+            echo "sudo curl -fsSL https://pkg.claude-desktop-debian.dev/rpm/claude-desktop.repo -o /etc/yum.repos.d/claude-desktop.repo"
             echo ""
             echo "# Install or update:"
             echo "sudo dnf install claude-desktop"
@@ -340,8 +340,8 @@ jobs:
             echo ""
             echo '```bash'
             echo "# First time? Add the repo:"
-            echo "curl -fsSL https://aaddrick.github.io/claude-desktop-debian/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/claude-desktop.gpg"
-            echo 'echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg arch=amd64,arm64] https://aaddrick.github.io/claude-desktop-debian stable main" | sudo tee /etc/apt/sources.list.d/claude-desktop.list'
+            echo "curl -fsSL https://pkg.claude-desktop-debian.dev/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/claude-desktop.gpg"
+            echo 'echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg arch=amd64,arm64] https://pkg.claude-desktop-debian.dev stable main" | sudo tee /etc/apt/sources.list.d/claude-desktop.list'
             echo ""
             echo "# Install or update:"
             echo "sudo apt update && sudo apt install claude-desktop"
@@ -351,7 +351,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "# First time? Add the repo:"
-            echo "sudo curl -fsSL https://aaddrick.github.io/claude-desktop-debian/rpm/claude-desktop.repo -o /etc/yum.repos.d/claude-desktop.repo"
+            echo "sudo curl -fsSL https://pkg.claude-desktop-debian.dev/rpm/claude-desktop.repo -o /etc/yum.repos.d/claude-desktop.repo"
             echo ""
             echo "# Install or update:"
             echo "sudo dnf install claude-desktop"
@@ -518,6 +518,10 @@ jobs:
           repoVer="${TAG#v}"; repoVer="${repoVer%+claude*}"
           claudeVer="${TAG#*+claude}"
           deb_name="claude-desktop_${claudeVer}-${repoVer}_amd64.deb"
+          # Intentionally starts at the github.io URL: the smoke test
+          # walks the full Pages-301 → Worker-302 → Releases chain to
+          # confirm the legacy redirect path still works for clients
+          # that follow HTTPS→HTTP downgrades (DNF, curl without -L).
           deb_url="https://aaddrick.github.io/claude-desktop-debian/pool/main/c/claude-desktop/${deb_name}"
 
           # Wait for propagation
@@ -660,11 +664,11 @@ jobs:
           printf '%s\n' \
             '[claude-desktop]' \
             'name=Claude Desktop for Fedora/RHEL' \
-            'baseurl=https://aaddrick.github.io/claude-desktop-debian/rpm/$basearch' \
+            'baseurl=https://pkg.claude-desktop-debian.dev/rpm/$basearch' \
             'enabled=1' \
             'gpgcheck=1' \
             'repo_gpgcheck=1' \
-            'gpgkey=https://aaddrick.github.io/claude-desktop-debian/KEY.gpg' \
+            'gpgkey=https://pkg.claude-desktop-debian.dev/KEY.gpg' \
             > rpm/claude-desktop.repo
 
       - name: Re-upload signed RPMs to GitHub Release
@@ -734,6 +738,8 @@ jobs:
           repoVer="${TAG#v}"; repoVer="${repoVer%+claude*}"
           claudeVer="${TAG#*+claude}"
           rpm_name="claude-desktop-${claudeVer}-${repoVer}-1.x86_64.rpm"
+          # Intentionally starts at the github.io URL — see APT smoke
+          # test comment above for why.
           rpm_url="https://aaddrick.github.io/claude-desktop-debian/rpm/x86_64/${rpm_name}"
 
           deadline=$((SECONDS + 300))

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Add the repository for automatic updates via `apt`:
 
 ```bash
 # Add the GPG key
-curl -fsSL https://aaddrick.github.io/claude-desktop-debian/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/claude-desktop.gpg
+curl -fsSL https://pkg.claude-desktop-debian.dev/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/claude-desktop.gpg
 
 # Add the repository
-echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg arch=amd64,arm64] https://aaddrick.github.io/claude-desktop-debian stable main" | sudo tee /etc/apt/sources.list.d/claude-desktop.list
+echo "deb [signed-by=/usr/share/keyrings/claude-desktop.gpg arch=amd64,arm64] https://pkg.claude-desktop-debian.dev stable main" | sudo tee /etc/apt/sources.list.d/claude-desktop.list
 
 # Update and install
 sudo apt update
@@ -68,13 +68,30 @@ Add the repository for automatic updates via `dnf`:
 
 ```bash
 # Add the repository
-sudo curl -fsSL https://aaddrick.github.io/claude-desktop-debian/rpm/claude-desktop.repo -o /etc/yum.repos.d/claude-desktop.repo
+sudo curl -fsSL https://pkg.claude-desktop-debian.dev/rpm/claude-desktop.repo -o /etc/yum.repos.d/claude-desktop.repo
 
 # Install
 sudo dnf install claude-desktop
 ```
 
 Future updates will be installed automatically with your regular system updates (`sudo dnf upgrade`).
+
+#### Migrating from the old `aaddrick.github.io` URL
+
+If you installed claude-desktop before April 2026, your repo config points at `https://aaddrick.github.io/claude-desktop-debian`. That URL now auto-redirects to `pkg.claude-desktop-debian.dev` — DNF follows the redirect transparently, but **apt refuses it as a security downgrade**, so `apt update` fails. Update your sources list to the new URL:
+
+```bash
+# APT (Debian/Ubuntu)
+sudo sed -i 's|https://aaddrick\.github\.io/claude-desktop-debian|https://pkg.claude-desktop-debian.dev|g' \
+  /etc/apt/sources.list.d/claude-desktop.list
+sudo apt update
+
+# DNF (Fedora/RHEL) — optional refresh; the old URL still works but pointing directly at the new host is cleaner
+sudo curl -fsSL https://pkg.claude-desktop-debian.dev/rpm/claude-desktop.repo \
+  -o /etc/yum.repos.d/claude-desktop.repo
+```
+
+Background: binaries for recent releases are no longer committed to the `gh-pages` branch — `.deb` files grew past GitHub's 100 MB per-file cap (#493). The new URL is fronted by a small Cloudflare Worker that serves the existing metadata directly and 302-redirects package downloads to the corresponding GitHub Release asset. Bandwidth and package bytes still come from GitHub; the Worker just handles the routing.
 
 ### Using AUR (Arch Linux)
 


### PR DESCRIPTION
## Summary

Finishes the Phase 4a-APT cutover by updating install instructions so users land on the new domain directly, skipping the Pages auto-301 entirely.

## Background — why the docs need changing

Phase 2 validation against `pkg-staging` passed for all 5 distros. Phase 4a production cutover (#503 + #504 + #506 + #509) brought the Worker live on `pkg.claude-desktop-debian.dev`, and the first full release through the new pipeline (v2.0.5) exercised every code path, including the #500 `gh release upload --clobber` RPM fix — DNF install through the Worker chain is green on both `fedora:latest` and `rockylinux:9`.

The last piece is a real problem I surfaced via `debian:stable` / `ubuntu:24.04` / `debian:testing` testing:

```
Err:5 https://aaddrick.github.io/claude-desktop-debian stable Release
  Redirection from https to 'http://pkg.claude-desktop-debian.dev/dists/stable/Release' is forbidden
E: The repository does not have a Release file.
```

GitHub Pages' auto-301 to `pkg.<domain>` uses `http://` because Pages can't provision a cert for `pkg.<domain>` — DNS points at Cloudflare Workers (`custom_domain = true`), so Pages never passes domain verification. `gh api -X PUT .../pages -F https_enforced=true` is explicitly rejected: `"The certificate does not exist yet"` (HTTP 404). `apt` refuses to follow HTTPS→HTTP redirects as a security policy (non-configurable). DNF happily follows the downgrade, so DNF users don't see this.

## What this PR does

### User-facing install changes (`README.md`)

Install snippets now point at `https://pkg.claude-desktop-debian.dev` directly for both APT and DNF. New users never hit the Pages 301, no scheme downgrade, clean HTTPS end-to-end.

Added a `#### Migrating from the old aaddrick.github.io URL` subsection with one-line `sed` for existing APT users (and an optional refresh for DNF users who want to tidy up). Short paragraph at the end explains why the change was needed — binaries grew past GitHub's 100 MB push cap (#493), the Worker fronts the new URL.

### CI — release notes templates and `.repo` file

Both release-notes blocks (upstream-wrapper and fallback) and the generated `claude-desktop.repo` file (`baseurl` + `gpgkey`) now point at `pkg.<domain>`. Fresh installs following the auto-generated instructions get the same clean URL as README readers.

### CI — smoke tests deliberately unchanged

The APT and DNF smoke-test chain walkers (`deb_url` / `rpm_url`) still start at `aaddrick.github.io/claude-desktop-debian/...` on purpose. They're `curl`-based, not `apt`-based, so they happily follow the downgrade, and testing the full 3-hop chain validates that DNF-via-github.io (which real users don't hit for installs, but does surface in heartbeat) still works.

## Not in scope

- Any change to the strip-binaries gating in `update-apt-repo` / `update-dnf-repo`. Per explicit decision, we're not keeping the legacy route serving — existing users get a clean break + one-line fix.
- `docs/worker-apt-plan.md` has historical references to `aaddrick.github.io/claude-desktop-debian` as the canonical URL. The plan doc is design history; I'll sweep those in a separate docs cleanup if useful.

## Session context

This is the 5th PR in today's Phase 4a-APT cutover chain:

| # | What |
|---|---|
| #503 | `wrangler.toml` staging → production route |
| #504 | Worker origin to `raw.githubusercontent.com` (fix Pages-301 loop), fix deploy probe hostname |
| #506 | Smoke test accepts `http://` on hop 0 |
| #509 | Smoke test accepts `release-assets.githubusercontent.com` on hop 2 |
| #510 (this) | README + install-snippet URLs + migration note |

Test tags cut during the process: v2.0.3, v2.0.4, v2.0.5. v2.0.5 is the first fully-working release end-to-end (AUR, APT-via-pkg, DNF) and is currently the `gh release list --limit 1` winner. v2.0.3 and v2.0.4 are supersede-able but not harmful.

Closes nothing directly — #493 technically stays open until confirmed-working in production, but the v2.0.5 pipeline has made it through the strip-and-push path cleanly.

Refs #493, #503

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
Claude: ran full 5-distro production validation via fresh distroboxes, diagnosed the scheme-downgrade failure on APT, drafted README migration section in @aaddrick's voice + documented the background
Human: made the explicit call to not serve the legacy github.io route and ship README migration instead