### PR TITLE
docs(readme): replace cowork callout with APT migration advisory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,9 @@ This project provides build scripts to run Claude Desktop natively on Linux syst
 
 ---
 
-> **⚠️ EXPERIMENTAL: Cowork Mode Support**
-> Cowork mode is **enabled by default** in this build with a pluggable isolation backend:
+> **⚠️ APT migration notice (April 2026)**
 >
-> | Backend | Isolation | Requirements |
-> |---------|-----------|-------------|
-> | **bubblewrap** (default) | Namespace sandbox | `bwrap` installed and functional |
-> | **host** (fallback) | None — runs directly on host | No additional requirements |
->
-> The best available backend is auto-detected at startup. Run `claude-desktop --doctor` to check which backend will be used and which dependencies are missing.
->
-> **Note:** The bubblewrap backend mounts your home directory as read-only (only the project working directory is writable). The host backend provides no isolation — use it only if you understand the security implications.
->
-> **KVM status:** The KVM/QEMU backend code exists but is non-functional — VM file downloads are disabled on Linux to prevent a checksum loop (#337). The backend code remains for potential future use.
+> The APT/DNF repo moved to `pkg.claude-desktop-debian.dev` (#493) — binaries are now served from GitHub Releases via a Cloudflare Worker so they don't hit the 100 MB per-file push cap on `gh-pages`. **DNF users are unaffected.** APT users on the legacy `aaddrick.github.io` sources.list will see a scheme-downgrade error on `apt update`. [One-line `sed` fix](#migrating-from-the-old-aaddrickgithubio-url).
 
 ---
 


### PR DESCRIPTION
## Summary

Swaps the top-of-README EXPERIMENTAL Cowork Mode summary for a short pointer advisory about the Phase 4a APT URL migration. New content is 2 lines + blockquote formatting; the detailed migration instructions still live in the Installation section from #510, so this callout is just a signpost.

## Rationale

The Cowork block accurately describes routine operational behavior that's also surfaced by `claude-desktop --doctor`. The APT migration, by contrast, is an imminent user-visible break on next `apt update` — every existing apt user will hit it until they run one `sed` command. Top-of-README real estate should go to the action item, not the ambient status.

DNF users are called out explicitly ("DNF users are unaffected") so they don't run the `sed` reflexively for no reason.

## Before/after

**Before** — 14-line block with backend table, isolation notes, KVM status

**After** — 3-line blockquote: what moved, who's affected, link to the fix

Refs #493

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>