### PR TITLE
ci: run BATS test suite on push and PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,7 @@
 /scripts/doctor.sh                      @sabiut
 /.github/workflows/test-artifacts.yml   @sabiut
 /.github/workflows/test-flags.yml       @sabiut
+/.github/workflows/tests.yml            @sabiut
 
 # Shared review — either owner can approve.
 # TROUBLESHOOTING is mostly the --doctor user-facing guide; lint

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: BATS Tests
+run-name: |
+  BATS: ${{
+    github.event_name == 'pull_request' && format('PR #{0} by @{1} - {2}', github.event.pull_request.number, github.actor, github.event.pull_request.title) ||
+    github.event_name == 'push' && github.event.head_commit && format('Push by @{0} - {1}', github.actor, github.event.head_commit.message) ||
+    format('{0} triggered by @{1}', github.event_name, github.actor)
+  }}
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tests/**"
+      - "scripts/**"
+      - ".github/workflows/tests.yml"
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bats-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  bats:
+    name: BATS unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install BATS and Node.js
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats nodejs
+
+      - name: Run BATS test suite
+        # Cowork tests load scripts/cowork-vm-service.js via `node` —
+        # the `nodejs` install above is what they need.
+        run: bats --print-output-on-failure tests/*.bats

--- a/tests/cowork-bwrap-config.bats
+++ b/tests/cowork-bwrap-config.bats
@@ -46,6 +46,12 @@ function assertDeepEqual(actual, expected, msg) {
 setup() {
 	TEST_TMP=$(mktemp -d)
 	export TEST_TMP
+
+	# The doctor checks resolve config via ${XDG_CONFIG_HOME:-$HOME/.config}.
+	# Sandboxing HOME alone is insufficient because GitHub Actions runners
+	# (and many user environments) export XDG_CONFIG_HOME ambient, which
+	# overrides the per-test HOME and makes the function read the wrong dir.
+	unset XDG_CONFIG_HOME
 }
 
 teardown() {


### PR DESCRIPTION
## Summary

The `/tests/` directory contains **186 BATS tests** across launcher and cowork suites, but **no CI workflow has ever invoked `bats`** — the entire test suite is currently inert. A regression in `launcher-common.sh` or `cowork-vm-service.js` would not fail any check today. This PR adds a standalone `tests.yml` workflow that actually runs the suite on push and PR.

## The problem

`/tests/` has 6 BATS test files containing 186 tests total:

| File | Owner (CODEOWNERS) |
|------|--------------------|
| `tests/launcher-common.bats` (48 tests) | @sabiut |
| `tests/launcher-xrdp-detection.bats` (8 tests) | @sabiut |
| `tests/cowork-backend-detection.bats` | @RayCharlizard |
| `tests/cowork-bwrap-config.bats` | @RayCharlizard |
| `tests/cowork-path-translation.bats` | @RayCharlizard |
| `tests/cowork-resources-staging.bats` | @RayCharlizard |

Audit on `main` (`6d281c9`):

```
$ grep -rn bats .github/workflows/
(no output)
```

Confirmed: `test-artifacts.yml`, `test-flags.yml`, `ci.yml`, and `shellcheck.yml` all run, but none invokes `bats`. PR #395's recently-merged launcher-common BATS suite (48 tests) landed under that same gap and has never actually executed in CI.

## The fix

Adds **`.github/workflows/tests.yml`** — a standalone workflow that:

- Runs on every PR to `main` (unfiltered, so required-check semantics stay predictable)
- Runs on every push to `main` (path-filtered to `tests/**`, `scripts/**`, and the workflow itself)
- Installs `bats` and `nodejs` via apt — cowork tests shell out to `node` to load `scripts/cowork-vm-service.js`
- Executes `bats --print-output-on-failure tests/*.bats`
- Has a concurrency group to cancel superseded runs
- Declares explicit `permissions: contents: read`

Also updates **`.github/CODEOWNERS`** to claim the new workflow under `@sabiut`, matching the existing pattern for `test-artifacts.yml` and `test-flags.yml`. `/tests/cowork-*.bats` review ownership stays with @RayCharlizard.

## Bug surfaced by wiring CI

The first CI run on this PR caught two pre-existing test failures in `tests/cowork-bwrap-config.bats` (tests 46 and 47 — `doctor: reports custom bwrap mounts` and `doctor: warns about disabled critical mount /usr`).

Root cause: `_doctor_check_bwrap_mounts` in `scripts/doctor.sh` resolves the config dir via `${XDG_CONFIG_HOME:-$HOME/.config}/Claude`. The test `setup()` only sandboxed `HOME` via `TEST_TMP`. GitHub Actions runners export `XDG_CONFIG_HOME` ambient, which overrode the per-test `HOME` and made the function read the runner's real config dir. Assertions silently failed against empty output.

The bug existed on `main` before this PR, but was hidden because the BATS suite never ran in CI — exactly the gap this PR exists to close. Fixed in the second commit (`fix(tests): unset XDG_CONFIG_HOME in cowork-bwrap-config setup`) by adding `unset XDG_CONFIG_HOME` to the test's `setup()`. Verified locally that all 186 tests pass with `XDG_CONFIG_HOME` set ambient (reproduces CI env).

## Why standalone instead of extending `test-artifacts.yml`?

- BATS unit tests should run in seconds on every push, not wait ~10 minutes for a full artifact build.
- Cleaner failure attribution — a red `BATS Tests` check means "your code broke a test", not "the build broke and we never reached tests".
- Smaller blast radius for a first-wiring PR — no `ci.yml` changes to coordinate, easier to roll back.
- Trivial to promote into `ci.yml` as a build gate later once it's proven stable.
