### PR TITLE
chore(issue-template): funnel apt-update legacy-URL reports to migration docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,6 +11,21 @@ body:
         anything you wouldn't put on a public issue tracker. See the
         [Privacy section in the README](https://github.com/aaddrick/claude-desktop-debian/blob/main/README.md#privacy)
         for what the bot does with your issue.
+  - type: markdown
+    attributes:
+      value: |
+        **Is `apt update` failing?** If you're seeing
+        `Redirection from https to 'http://pkg.claude-desktop-debian.dev/...' is forbidden`,
+        your sources.list still points at the legacy `aaddrick.github.io` URL —
+        no need to file a bug. Run:
+
+        ```bash
+        sudo sed -i 's|https://aaddrick\.github\.io/claude-desktop-debian|https://pkg.claude-desktop-debian.dev|g' \
+          /etc/apt/sources.list.d/claude-desktop.list
+        sudo apt update
+        ```
+
+        Background: [README — Migrating from the old `aaddrick.github.io` URL](https://github.com/aaddrick/claude-desktop-debian/blob/main/README.md#migrating-from-the-old-aaddrickgithubio-url).
   - type: textarea
     id: doctor
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,10 @@
 blank_issues_enabled: false
 contact_links:
+  - name: "apt update fails: 'Redirection from https to http... is forbidden'"
+    url: https://github.com/aaddrick/claude-desktop-debian/blob/main/README.md#migrating-from-the-old-aaddrickgithubio-url
+    about: |
+      Your sources.list points at the legacy aaddrick.github.io URL.
+      The README has a one-line sed fix to migrate to the new host.
   - name: Questions / usage help
     url: https://github.com/aaddrick/claude-desktop-debian/discussions
     about: General questions belong in Discussions.


### PR DESCRIPTION
## Summary

- Adds a dedicated `contact_link` on the New Issue chooser so users hitting the apt scheme-downgrade error see the migration command before they ever reach the bug template. Title uses the literal apt error fragment so anyone scanning for their symptom recognizes it.
- Adds a second `markdown` block to `bug_report.yml` (right after the existing privacy notice) with the symptom + inline sed one-liner + README link. Catches users who blew past the chooser.

Targets the false-positive bug-report path that produced #516 and #519. The README migration anchor exists already; this just routes affected users to it before they file.

## Why this and not a doctor-side check

Doctor-detection of the legacy sources.list URL would only reach users who can pull a new client — which is exactly the cohort whose `apt update` is broken. Issue-template routing is the only preventive lever that reaches the affected users on their *current* install.

## Test plan

- [ ] Confirm the YAML parses (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge, visit https://github.com/aaddrick/claude-desktop-debian/issues/new/choose and confirm the new contact link renders with the literal-error label
- [ ] Click the link, confirm it lands on the README migration anchor
- [ ] Open the bug template, confirm the apt callout renders cleanly above the doctor field

## Refs

- Closes neither #516 nor #519 directly — those need user confirmation that the migration sed cleared their state. This PR is the upstream prevention.
- Related migration trail: #493 / #498 / #514

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: drafted the funnel design, wrote both YAML edits, validated parsing, opened the PR
Human: caught that doctor-side detection wouldn't reach the affected cohort and steered the design toward the issue-template lever; reviewed and approved the wording before commit