### PR TITLE
chore(gitignore): ignore worker/.wrangler/ cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build-reference/
 # Nix build output
 result
 result-*
+
+# Wrangler (Cloudflare Worker dev/deploy cache)
+worker/.wrangler/


### PR DESCRIPTION
## Summary

- Adds `worker/.wrangler/` to `.gitignore`. It's a Cloudflare Wrangler tool cache (regenerated on demand by `wrangler dev` / `wrangler deploy`) and Cloudflare's official guidance is to gitignore it.
- Stops `git status` from showing it as untracked after any local Worker work.

## Test plan

- [ ] Run `wrangler dev` or similar in `worker/` → confirm `git status` stays clean
- [ ] Confirm CI Worker deploy job still functions (the cache is local-only; CI builds fresh each run)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: identified the untracked artifact as a wrangler cache, added the .gitignore entry, deleted the local copy, opened the PR
Human: approved the cleanup approach (separate small PR rather than tacking onto #522)