### PR TITLE
chore(monitoring): hourly Quad9 DNS check for pkg.claude-desktop-debian.dev

### DIFF
--- a/.github/workflows/dns-monitor-quad9.yml
+++ b/.github/workflows/dns-monitor-quad9.yml
@@ -1,0 +1,44 @@
+name: DNS Monitor — Quad9 block on pkg.claude-desktop-debian.dev
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  actions: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      ISSUE: '524'
+      DOMAIN: pkg.claude-desktop-debian.dev
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Resolve via Quad9
+        id: dig
+        run: |
+          ip=$(dig +short "$DOMAIN" @9.9.9.9)
+          ts=$(date -u '+%Y-%m-%d %H:%M UTC')
+          if [[ -z "$ip" ]]; then
+            line="- ❌ ${ts} — NXDOMAIN on Quad9 (still blocked)"
+            echo "resolved=false" >> "$GITHUB_OUTPUT"
+          else
+            line="- ✅ ${ts} — resolved to ${ip} on Quad9 — @aaddrick domain is back, stopping monitor"
+            echo "resolved=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "line=$line" >> "$GITHUB_OUTPUT"
+
+      - name: Append to issue body
+        run: |
+          body=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json body -q .body)
+          new_body="${body}"$'\n'"${{ steps.dig.outputs.line }}"
+          gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "$new_body"
+
+      - name: Disable workflow on resolution
+        if: steps.dig.outputs.resolved == 'true'
+        run: |
+          gh workflow disable .github/workflows/dns-monitor-quad9.yml \
+            --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/dns-monitor-quad9.yml
+++ b/.github/workflows/dns-monitor-quad9.yml
@@ -32,9 +32,11 @@ jobs:
           echo "line=$line" >> "$GITHUB_OUTPUT"
 
       - name: Append to issue body
+        env:
+          LINE: ${{ steps.dig.outputs.line }}
         run: |
           body=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json body -q .body)
-          new_body="${body}"$'\n'"${{ steps.dig.outputs.line }}"
+          new_body="${body}"$'\n'"${LINE}"
           gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "$new_body"
 
       - name: Disable workflow on resolution


### PR DESCRIPTION
## Summary

Adds `.github/workflows/dns-monitor-quad9.yml` — a transient monitoring workflow for the active Quad9 NXDOMAIN incident (#521).

- Cron `'0 * * * *'` — fires hourly; `workflow_dispatch` available for on-demand triggering.
- `dig +short pkg.claude-desktop-debian.dev @9.9.9.9` → empty result logs ❌ NXDOMAIN, IP result logs ✅ with the resolved address.
- Appends each result as a new line to the body of #524.
- On first ✅, the resolved-line includes `@aaddrick` and the workflow self-disables via `gh workflow disable` so it stops eating CI minutes once the block clears.

## Why a workflow and not a remote Claude cron

Reliable `gh` auth via `secrets.GITHUB_TOKEN`, free for public repos, follows the existing `apt-repo-heartbeat.yml` pattern, and self-cleanup is straightforward. A scheduled remote Claude agent would have burned API credit per fire and required out-of-band auth provisioning for `gh`.

## Lint

- `actionlint`: clean
- YAML parse: clean

## Test plan

- [ ] After merge, trigger via `gh workflow run "DNS Monitor — Quad9 block on pkg.claude-desktop-debian.dev"` to confirm the cron-driven flow works on the first manual run
- [ ] Confirm a new line appears at the bottom of #524's body
- [ ] Wait for one scheduled hourly fire, confirm cadence and idempotent appending
- [ ] If/when delisting clears, confirm the ✅ branch tags @aaddrick and the workflow auto-disables

## Manual disable (if needed)

```bash
gh workflow disable .github/workflows/dns-monitor-quad9.yml
```

Or via Actions tab → "DNS Monitor — Quad9 block..." → "..." → Disable workflow.

## Refs

- #521 — original incident discussion (Quad9 block via ThreatSTOP feed)
- #524 — monitoring issue this workflow appends to

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: drafted the workflow, validated with actionlint, opened the PR, designed self-disable logic
Human: scoped the requirement (hourly check, append-edit semantics, tag-on-resolution), chose workflow over remote-cron mechanism, authorized PR