### PR TITLE
docs(learnings): document MCP double-spawn upstream bug (#526)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The [`docs/learnings/`](docs/learnings/) directory contains hard-won technical k
 - [`plugin-install.md`](docs/learnings/plugin-install.md) — Anthropic & Partners plugin install flow, gate logic, backend endpoints, and DevTools recipes
 - [`apt-worker-architecture.md`](docs/learnings/apt-worker-architecture.md) — APT/DNF binary distribution via Cloudflare Worker + GitHub Releases, redirect chain, credential ownership, heartbeat runbook
 - [`tray-rebuild-race.md`](docs/learnings/tray-rebuild-race.md) — why destroy + recreate on `nativeTheme` updates briefly duplicates the tray icon on KDE Plasma, and the in-place `setImage` + `setContextMenu` fast-path that avoids the SNI re-registration race
-- [`mcp-double-spawn.md`](docs/learnings/mcp-double-spawn.md) — Stdio MCPs spawn 2× when both chat and Code/Agent panels are active; upstream Anthropic bug, MCP-author workaround documented
+- [`mcp-double-spawn.md`](docs/learnings/mcp-double-spawn.md) — Stdio MCPs spawn 2× when chat and Code/Agent panels are both active, root cause in upstream session managers, MCP-author workaround
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ The [`docs/learnings/`](docs/learnings/) directory contains hard-won technical k
 - [`plugin-install.md`](docs/learnings/plugin-install.md) — Anthropic & Partners plugin install flow, gate logic, backend endpoints, and DevTools recipes
 - [`apt-worker-architecture.md`](docs/learnings/apt-worker-architecture.md) — APT/DNF binary distribution via Cloudflare Worker + GitHub Releases, redirect chain, credential ownership, heartbeat runbook
 - [`tray-rebuild-race.md`](docs/learnings/tray-rebuild-race.md) — why destroy + recreate on `nativeTheme` updates briefly duplicates the tray icon on KDE Plasma, and the in-place `setImage` + `setContextMenu` fast-path that avoids the SNI re-registration race
+- [`mcp-double-spawn.md`](docs/learnings/mcp-double-spawn.md) — Stdio MCPs spawn 2× when both chat and Code/Agent panels are active; upstream Anthropic bug, MCP-author workaround documented
 
 ## Code Style
 

--- a/docs/learnings/mcp-double-spawn.md
+++ b/docs/learnings/mcp-double-spawn.md
@@ -40,10 +40,14 @@ external services with single-connection contracts, etc.
 Two parallel session managers live inside Electron main, each
 holding an independent Claude Agent SDK `query`:
 
-| Manager class            | IPC namespace                          | Coordinator       |
-|--------------------------|----------------------------------------|-------------------|
-| `LocalSessions`          | `claude.web_$_LocalSessions_$_*`       | `n2t("ccd")`      |
-| `LocalAgentModeSessions` | `claude.web_$_LocalAgentModeSessions_*`| `n2t("cowork")`   |
+| Manager class            | IPC namespace                            | Coordinator     | Logs prefix |
+|--------------------------|------------------------------------------|-----------------|-------------|
+| `LocalSessions`          | `claude.web_$_LocalSessions_$_*`         | `n2t("ccd")`    | `[CCD]`     |
+| `LocalAgentModeSessions` | `claude.web_$_LocalAgentModeSessions_$_*`| `n2t("cowork")` | `[LAM]`     |
+
+The logs prefixes are what to grep `~/.config/Claude/logs/` for to
+confirm a session is hitting both coordinators (and therefore this
+bug specifically).
 
 Each `query` holds its own SDK transport. The transport's
 `spawnLocalProcess` (`Du.spawn`) launches stdio MCPs **without
@@ -98,6 +102,9 @@ can defend themselves:
 1. **Lockfile + staleness check.** `fs.openSync('wx')` with PID,
    verified live via `process.kill(pid, 0)`. The second instance
    detects a live owner and backs off, or reclaims a stale lock.
+   Reclaim atomically — write the new lock to a temp path and
+   `rename()` over the stale one, never `unlink()` then re-open
+   (a third instance can win the gap).
 2. **Idempotent state writes.** Resolve target files/keys from
    the incoming message payload rather than from in-process
    state, so two instances writing the same broadcast end up at
@@ -113,9 +120,10 @@ The reporter's `baro-voyager` MCP shipped both in commit
   `support@anthropic.com`. The duplication happens in
   closed-source Desktop main.
 - **Secondary:** an SDK-transport-flavored issue on
-  `anthropics/claude-code` is defensible — the spawn path goes
-  through the **Claude Agent SDK's** `query` transport, which is
-  shared surface area with the CLI. Reference the missing `hZ`
+  [`anthropics/claude-agent-sdk-typescript`](https://github.com/anthropics/claude-agent-sdk-typescript)
+  is defensible — the spawn path goes through the **Claude Agent
+  SDK's** `query` transport (`spawnLocalProcess` / `Du.spawn`),
+  which is shared surface area. Reference the missing `hZ`
   consultation explicitly.
 
 The embedded Claude Code CLI subprocess inside Claude Desktop is

--- a/docs/learnings/mcp-double-spawn.md
+++ b/docs/learnings/mcp-double-spawn.md
@@ -1,0 +1,125 @@
+# MCP Double-Spawn (Chat + Code/Agent Panel)
+
+## Why This Exists
+
+When a Claude Desktop session has both the classic chat panel
+and the Code/Agent (Cowork) panel active, **every stdio MCP
+server declared in `~/.config/Claude/claude_desktop_config.json`
+gets spawned twice** by the Electron main process. Reported and
+root-caused in detail in
+[#526](https://github.com/aaddrick/claude-desktop-debian/issues/526).
+
+## Symptoms
+
+`ps -ef` after a session opens both panels shows two batches of
+MCP children of the same Electron main PID, separated by however
+long it took the user to open the second panel:
+
+```
+PID    PPID(electron)  CMD
+372628 372434          python  ← batch 1 (chat panel)
+372633 372434          node
+372648 372434          python
+...
+373288 372434          python  ← batch 2 (Code/Agent panel)
+373296 372434          node
+373327 372434          python
+```
+
+Killing one PID disconnects one panel; the other survives. Two
+independent client↔server pairs, no failover.
+
+Most stdio MCPs don't notice they were doubled — each instance
+talks to its own client and exits cleanly. The bug only surfaces
+when an MCP touches **shared external state**: a single
+WebSocket, files on disk that the other instance also writes,
+external services with single-connection contracts, etc.
+
+## Root Cause (Upstream)
+
+Two parallel session managers live inside Electron main, each
+holding an independent Claude Agent SDK `query`:
+
+| Manager class            | IPC namespace                          | Coordinator       |
+|--------------------------|----------------------------------------|-------------------|
+| `LocalSessions`          | `claude.web_$_LocalSessions_$_*`       | `n2t("ccd")`      |
+| `LocalAgentModeSessions` | `claude.web_$_LocalAgentModeSessions_*`| `n2t("cowork")`   |
+
+Each `query` holds its own SDK transport. The transport's
+`spawnLocalProcess` (`Du.spawn`) launches stdio MCPs **without
+consulting the global registry** that *would* dedupe them
+(`hZ` map, accessed via `oUt(serverName)` /
+`launchMcpServer`). That registry is only used for the
+"internal" cowork in-process MessageChannelMain path.
+
+Net result: 2 coordinators × N configured MCPs = 2N processes.
+
+Symbol names (`n2t`, `hZ`, `oUt`, `LocalSessions`,
+`LocalAgentModeSessions`) are minified and **will rename across
+upstream releases**.
+
+## Status
+
+**Upstream Anthropic Claude Desktop bug. Not patchable in this
+repo.** A fix would require either:
+
+- Routing the SDK stdio transport through `oUt`/`hZ` (the
+  existing serialized-per-name registry), or
+- Sharing one MCP-server registry between the `ccd` and
+  `cowork` coordinators.
+
+Both live inside the closed-source SDK transport / session
+manager wiring. Regex-matching the minified symbols from
+`scripts/patches/` would be fragile against release-to-release
+renames and exceeds this repo's "minimal Linux-compat patches
+only" charter.
+
+## What's Already Verified Clean
+
+- All 7 patches in `scripts/patches/*.sh` — zero references to
+  MCP, mcpServer, LocalSessions, LocalAgentModeSessions,
+  transportToClient, MessageChannelMain, n2t, hZ, oUt.
+- `scripts/launcher-common.sh` — no MCP or config-load logic.
+- `scripts/packaging/{appimage,deb,rpm}.sh` — no MCP or
+  config-load logic.
+- `scripts/doctor.sh:420` — only reads
+  `claude_desktop_config.json` to JSON-lint it for diagnostics;
+  not in the runtime spawn path.
+
+The bug reproduces identically against the unmodified upstream
+asar; no Linux-only init in this packaging contributes to the
+double-load.
+
+## Workaround (For MCP Authors)
+
+Until upstream fixes it, MCPs that touch shared external state
+can defend themselves:
+
+1. **Lockfile + staleness check.** `fs.openSync('wx')` with PID,
+   verified live via `process.kill(pid, 0)`. The second instance
+   detects a live owner and backs off, or reclaims a stale lock.
+2. **Idempotent state writes.** Resolve target files/keys from
+   the incoming message payload rather than from in-process
+   state, so two instances writing the same broadcast end up at
+   the same target instead of cross-contaminating per-process
+   keys.
+
+The reporter's `baro-voyager` MCP shipped both in commit
+`cb7bfbb` as a worked reference.
+
+## Routing Upstream Reports
+
+- **Primary:** in-app feedback (Help → Send Feedback) or
+  `support@anthropic.com`. The duplication happens in
+  closed-source Desktop main.
+- **Secondary:** an SDK-transport-flavored issue on
+  `anthropics/claude-code` is defensible — the spawn path goes
+  through the **Claude Agent SDK's** `query` transport, which is
+  shared surface area with the CLI. Reference the missing `hZ`
+  consultation explicitly.
+
+The embedded Claude Code CLI subprocess inside Claude Desktop is
+**not** the cause — it receives `--mcp-config` only when the
+config map is non-empty, and is empty in this flow. Don't route
+to `anthropics/claude-code` claiming the CLI itself is
+double-spawning MCPs.

--- a/docs/learnings/mcp-double-spawn.md
+++ b/docs/learnings/mcp-double-spawn.md
@@ -60,8 +60,8 @@ upstream releases**.
 
 ## Status
 
-**Upstream Anthropic Claude Desktop bug. Not patchable in this
-repo.** A fix would require either:
+**Upstream Claude Desktop bug. Not patchable in this repo.** A
+fix would require either:
 
 - Routing the SDK stdio transport through `oUt`/`hZ` (the
   existing serialized-per-name registry), or


### PR DESCRIPTION
## Summary

Adds `docs/learnings/mcp-double-spawn.md` capturing [#526](https://github.com/aaddrick/claude-desktop-debian/issues/526)'s root-cause analysis so future contributors hitting the symptom find a quick pointer instead of re-investigating from zero.

The bug: stdio MCP servers in `claude_desktop_config.json` get spawned twice when both the chat panel and the Code/Agent (Cowork) panel are active. Reporter (`@communitytranslations`) traced it to two parallel session managers in upstream Electron main (`LocalSessions` and `LocalAgentModeSessions`) each holding an independent Claude Agent SDK `query` whose stdio transport (`Du.spawn`) bypasses the global MCP registry (`hZ` map / `oUt` accessor) that *would* dedupe them.

I independently verified our packaging is not implicated:
- All 7 patches in `scripts/patches/*.sh` — zero references to MCP, mcpServer, LocalSessions, LocalAgentModeSessions, transportToClient, MessageChannelMain, n2t, hZ, oUt
- `scripts/launcher-common.sh` and `scripts/packaging/*.sh` — no MCP or config-load logic
- `scripts/doctor.sh:420` only reads the config to JSON-lint it; not in the runtime spawn path

The entry documents:
- Symptoms with example `ps -ef` output
- Upstream root cause with the relevant minified symbols (flagged as drift-prone)
- Status: **upstream Anthropic bug, not patchable here** — explicitly waves off future contributors from regex-patching minified symbols
- Workaround for affected MCP authors (lockfile + idempotent writes, per reporter's `cb7bfbb`)
- Routing guidance: primary venue is in-app feedback or `support@anthropic.com`; `anthropics/claude-code` defensible as secondary since the SDK transport is shared surface area; the embedded CLI is **not** the cause

Also adds the entry to the `docs/learnings/` index in `CLAUDE.md`.

## Test plan

- [x] `docs/learnings/mcp-double-spawn.md` renders cleanly
- [x] `CLAUDE.md` learnings index includes the new entry in the right position
- [x] No code paths touched; no patch surface modified

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
70% AI / 30% Human
Claude: surveyed patches to verify packaging exoneration, drafted the learnings entry, wrote the comment plan
Human: routed the issue, caught a missed contrarian pass and triggered the policy update, approved scope and tone