### PR TITLE
test: isolate cleanup_stale_cowork_socket BATS from host pgrep state

### DIFF
--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -349,6 +349,12 @@ s.bind(sys.argv[1])
 s.close()
 " "$sock" 2>/dev/null || skip "Cannot create test unix socket"
 
+	# Stub pgrep so the test is isolated from host process state:
+	# a real cowork-vm-service daemon on the developer machine would
+	# trip the function's "daemon alive, leave socket alone" branch.
+	pgrep() { return 1; }
+	export -f pgrep
+
 	setup_logging
 	# socat connection should fail since nothing is listening
 	cleanup_stale_cowork_socket

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -353,10 +353,8 @@ s.close()
 	# a real cowork-vm-service daemon on the developer machine would
 	# trip the function's "daemon alive, leave socket alone" branch.
 	pgrep() { return 1; }
-	export -f pgrep
 
 	setup_logging
-	# socat connection should fail since nothing is listening
 	cleanup_stale_cowork_socket
 	[[ ! -S "$sock" ]]
 }


### PR DESCRIPTION
## Summary

Fixes #533. The BATS test `cleanup_stale_cowork_socket: removes stale socket file` (`tests/launcher-common.bats:341`) fails on any developer machine running Claude Desktop because it never stubs `pgrep`.

`cleanup_stale_cowork_socket` (`scripts/launcher-common.sh:224`) intentionally bails out early if a `cowork-vm-service.js` daemon is alive — that's correct behavior. The test, however, was written to exercise the "no daemon → remove stale socket" branch but used real `pgrep`, so the developer's own running daemon would trip the early-return path and the assertion `[[ ! -S "$sock" ]]` would fail.

This PR stubs `pgrep` inside the test to always return nonzero, isolating the test from host process state.

## Test plan

- [x] `bats tests/launcher-common.bats --filter cleanup_stale_cowork_socket` — 2/2 pass with Claude Desktop running on the host (PID confirmed via `pgrep -af 'cowork-vm-service\.js'`)
- [x] `bats tests/*.bats` — 186/186 pass
- [x] `shellcheck -x tests/launcher-common.bats` — no new findings (preexisting SC2053 on line 16 unrelated)