### PR TITLE
ci: pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/apt-repo-heartbeat.yml
+++ b/.github/workflows/apt-repo-heartbeat.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Open or update failure issue
         if: failure() && steps.gate.outputs.live == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           FORMAT: ${{ matrix.format }}
         with:
@@ -174,7 +174,7 @@ jobs:
 
       - name: Auto-close failure issue on recovery
         if: success() && steps.gate.outputs.live == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           FORMAT: ${{ matrix.format }}
         with:

--- a/.github/workflows/build-amd64.yml
+++ b/.github/workflows/build-amd64.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install dependencies (Fedora)
         if: inputs.artifact_suffix == 'rpm'
@@ -50,7 +50,7 @@ jobs:
           ./build.sh ${{ inputs.build_flags }} $TAG_FLAG
 
       - name: Upload AMD64 Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: package-amd64-${{ inputs.artifact_suffix }}
           path: |

--- a/.github/workflows/build-arm64.yml
+++ b/.github/workflows/build-arm64.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install dependencies (Fedora)
         if: inputs.artifact_suffix == 'rpm'
@@ -50,7 +50,7 @@ jobs:
           ./build.sh ${{ inputs.build_flags }} $TAG_FLAG
 
       - name: Upload ARM64 Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: package-arm64-${{ inputs.artifact_suffix }}
           path: |

--- a/.github/workflows/check-claude-version.yml
+++ b/.github/workflows/check-claude-version.yml
@@ -17,13 +17,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GH_PAT }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,37 +92,37 @@ jobs:
 
     steps:
       - name: Download AMD64 deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-amd64-deb
           path: artifacts/
 
       - name: Download AMD64 rpm artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-amd64-rpm
           path: artifacts/
 
       - name: Download AMD64 AppImage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-amd64-appimage
           path: artifacts/
 
       - name: Download ARM64 deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-arm64-deb
           path: artifacts/
 
       - name: Download ARM64 rpm artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-arm64-rpm
           path: artifacts/
 
       - name: Download ARM64 AppImage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-arm64-appimage
           path: artifacts/
@@ -131,7 +131,7 @@ jobs:
 
       - name: Checkout claude-desktop-versions
         id: checkout_versions
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         continue-on-error: true
         with:
           repository: aaddrick/claude-desktop-versions
@@ -139,14 +139,14 @@ jobs:
 
       - name: Set up Python 3.12
         if: steps.checkout_versions.outcome == 'success'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         continue-on-error: true
         with:
           python-version: "3.12"
 
       - name: Set up Node.js 20
         if: steps.checkout_versions.outcome == 'success'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         continue-on-error: true
         with:
           node-version: "20"
@@ -165,7 +165,7 @@ jobs:
 
       - name: Checkout repo for git history
         id: checkout_repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         continue-on-error: true
         with:
           fetch-depth: 0
@@ -370,7 +370,7 @@ jobs:
 
       - name: Create GitHub Release
         if: ${{ always() }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: artifacts/**/*
           body_path: compare-work/summary.md
@@ -410,19 +410,19 @@ jobs:
 
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: gh-pages
           path: apt-repo
 
       - name: Download AMD64 deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-amd64-deb
           path: incoming/
 
       - name: Download ARM64 deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-arm64-deb
           path: incoming/
@@ -431,7 +431,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y reprepro
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
 
@@ -583,19 +583,19 @@ jobs:
 
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: gh-pages
           path: dnf-repo
 
       - name: Download AMD64 rpm artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-amd64-rpm
           path: incoming/
 
       - name: Download ARM64 rpm artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-arm64-rpm
           path: incoming/
@@ -605,7 +605,7 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.APT_GPG_PRIVATE_KEY }}
 
@@ -793,7 +793,7 @@ jobs:
 
     steps:
       - name: Download AMD64 AppImage artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: package-amd64-appimage
           path: artifacts/

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -24,8 +24,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Annotate locations with typos
-        uses: codespell-project/codespell-problem-matcher@v1
+        uses: codespell-project/codespell-problem-matcher@b80729f885d32f78a716c2f107b4db1025001c42 # v1
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -16,10 +16,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -88,12 +88,12 @@ jobs:
       ISSUE_NUMBER: ${{ needs.gate.outputs.issue_number }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -1893,7 +1893,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: triage-v2-phase-4-issue-${{ needs.gate.outputs.issue_number }}
           path: /tmp/triage/

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -103,10 +103,10 @@ jobs:
       confidence: ${{ steps.classify.outputs.confidence }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -199,7 +199,7 @@ jobs:
           echo "Classification: $classification (skip=$skip_comment, investigate=$needs_investigation, confidence=$confidence)"
 
       - name: Upload triage context
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: triage-context
           path: /tmp/triage-context/
@@ -217,7 +217,7 @@ jobs:
       && needs.classify.outputs.skip_comment != 'true'
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -271,7 +271,7 @@ jobs:
           echo "Total files: $(find app-extracted -type f | wc -l)"
 
       - name: Upload reference source
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: reference-source
           path: /tmp/ref-source/app-extracted/
@@ -290,10 +290,10 @@ jobs:
       has_findings: ${{ steps.investigate.outputs.has_findings }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -301,13 +301,13 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Download triage context
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: triage-context
           path: /tmp/triage-context/
 
       - name: Download reference source
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: reference-source
           path: /tmp/ref-source/app-extracted/
@@ -434,7 +434,7 @@ jobs:
 
       - name: Upload investigation findings
         if: steps.investigate.outputs.has_findings == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: investigation-findings
           path: /tmp/investigation.txt
@@ -456,7 +456,7 @@ jobs:
             -o /tmp/voice-profile.md
 
       - name: Upload voice profile
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: voice-profile
           path: /tmp/voice-profile.md
@@ -479,10 +479,10 @@ jobs:
       comment_posted: ${{ steps.post.outputs.comment_posted }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
 
@@ -490,21 +490,21 @@ jobs:
         run: npm install -g @anthropic-ai/claude-code
 
       - name: Download triage context
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: triage-context
           path: /tmp/triage-context/
 
       - name: Download investigation findings
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: investigation-findings
           path: /tmp/investigation/
 
       - name: Download voice profile
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: voice-profile
           path: /tmp/voice/
@@ -617,7 +617,7 @@ jobs:
       && needs.classify.result == 'success'
     steps:
       - name: Download triage context
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: triage-context
           path: /tmp/triage-context/

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install dependencies
         run: |
           sudo apt update && sudo apt install -y shellcheck

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ matrix.artifact }}
           path: artifacts/

--- a/.github/workflows/test-flags.yml
+++ b/.github/workflows/test-flags.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     # FUSE install removed - not needed for --test-flags
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install BATS and Node.js
         run: |

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ secrets.GH_PAT }}
 
       - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v21
+        uses: DeterminateSystems/nix-installer-action@c5a866b6ab867e88becbed4467b93592bce69f8a # v21
 
       - name: Update flake.lock
         run: nix flake update --flake .


### PR DESCRIPTION
Replaces mutable tag refs (e.g. @v4) with full commit SHAs across all
workflows, with the version retained as a trailing comment for
readability and dependabot compatibility.

Motivation: the March 2026 trivy-action supply-chain attack poisoned 75
of 76 version tags in a single repo. Any consumer using @vX-style
references ran the compromised code automatically. SHA pinning makes
that class of attack a no-op for us — a hijacked tag cannot point at
new code without the SHA also changing.

Pinned actions:
  actions/checkout@v4, actions/upload-artifact@v4,
  actions/download-artifact@v4, actions/setup-python@v5,
  actions/setup-node@v4, actions/github-script@v7,
  softprops/action-gh-release@v2, crazy-max/ghaction-import-gpg@v6,
  codespell-project/codespell-problem-matcher@v1,
  codespell-project/actions-codespell@v2,
  cloudflare/wrangler-action@v3,
  DeterminateSystems/nix-installer-action@v21

Co-Authored-By: Claude <claude@anthropic.com>