### PR TITLE
docs: add multi-instance profiles guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Model Context Protocol settings are stored in:
 
 For additional configuration options including environment variables and Wayland support, see [docs/CONFIGURATION.md](docs/CONFIGURATION.md).
 
+For running multiple isolated profiles in parallel (one per monitor, separate accounts, color-coded taskbar icons), see [docs/multi-instance/README.md](docs/multi-instance/README.md). Includes a launcher script, sample `.desktop` template, icon recolor recipe, and notes on the `claude://` link-handler quirk.
+
 ## Troubleshooting
 
 Run `claude-desktop --doctor` for built-in diagnostics that check common issues (display server, sandbox permissions, MCP config, stale locks, and more). It also reports cowork mode readiness — which isolation backend will be used, and which dependencies (KVM, QEMU, vsock, socat, virtiofsd, bubblewrap) are installed or missing.

--- a/docs/multi-instance/README.md
+++ b/docs/multi-instance/README.md
@@ -1,0 +1,246 @@
+# Multi-Instance Claude Desktop Profiles
+
+Run **multiple isolated Claude Desktop instances in parallel** on the same Linux machine — each with its own login, its own window, its own taskbar icon — while sharing local Claude Code session history, agent-mode sessions, and other read-mostly state across all profiles.
+
+> Tested on Fedora 43 with GNOME on Wayland, claude-desktop wrapper v2.0.5+ (Electron 41). Should work on any Linux desktop where this RPM/DEB build runs.
+
+---
+
+## Why?
+
+The Claude Desktop Electron app uses a `SingletonLock` in its `userData` directory. Launching it twice with the same `userData` just focuses the existing window instead of opening a second one. This guide shows how to run **N parallel instances** by giving each its own `userData` directory, while symlinking the *session-bearing* subdirectories so all instances see the same chat history and Claude Code sessions.
+
+Useful for:
+
+- Multi-monitor workflows (one Claude per monitor)
+- Logging into different accounts simultaneously without losing state
+- Keeping long-running agent sessions in their own window without losing them when you start something new
+
+---
+
+## Architecture at a glance
+
+| Per-profile (isolated)              | Shared via symlink to main profile   |
+| ----------------------------------- | ------------------------------------ |
+| `SingletonLock` / `SingletonCookie` / `SingletonSocket` | `local-agent-mode-sessions/` |
+| `Cache/`, `Code Cache/`, `GPUCache/`, `Dawn*Cache/`     | `claude-code/`                |
+| `IndexedDB/`, `Local Storage/`, `Session Storage/`     | `claude-code-sessions/`       |
+| `Cookies`, `Cookies-journal` (encrypted, per-profile)  | `claude-code-vm/`             |
+| `Preferences`, `config.json` (incl. `oauth:tokenCache`) | `pending-uploads/`            |
+| `claude_desktop_config.json`         | `git-worktrees.json`                 |
+| `bridge-state.json` (per-profile)    | `buddy-tokens.json` (daily counter)  |
+| `ant-did` (instance UUID)            |                                      |
+| `Crashpad/`, `blob_storage/`         |                                      |
+
+The split keeps Electron singleton-locks separate (so parallel windows work) while the JSON-based session stores can be safely shared (multiple readers, one writer at a time — same as a single-instance install).
+
+---
+
+## Quick start
+
+### 1. Create a second profile
+
+```bash
+MAIN="$HOME/.config/Claude"
+PROFILE="$HOME/.config/Claude-2"
+mkdir -p "$PROFILE/tmp"
+
+# Symlink the shared, session-bearing items
+for item in claude-code claude-code-sessions claude-code-vm \
+            git-worktrees.json local-agent-mode-sessions \
+            pending-uploads buddy-tokens.json; do
+  ln -sfn "$MAIN/$item" "$PROFILE/$item"
+done
+```
+
+### 2. Launch with an isolated `userData`
+
+```bash
+claude-desktop --user-data-dir="$HOME/.config/Claude-2" \
+               --class=Claude-2 --name=Claude-2 &
+```
+
+That's it — a second Claude Desktop window opens. It needs its own login on first launch. Repeat with `Claude-3`, `Claude-4`, … for more profiles.
+
+### 3. (Optional) Add a `.desktop` entry so it shows up in your launcher
+
+See [`claude-desktop-N.desktop.template`](claude-desktop-N.desktop.template). Copy to `$HOME/.local/share/applications/claude-desktop-2.desktop` and substitute `N=2`. Run `update-desktop-database $HOME/.local/share/applications/` afterwards.
+
+---
+
+## Detailed walkthrough
+
+### Why we need `--class` and `--name`
+
+By default every Electron Claude window has `WM_CLASS = "claude", "Claude"`. If you launch three profiles, the desktop environment merges them under a single taskbar icon (because they all match the original `claude-desktop.desktop`'s `StartupWMClass=Claude`). That's not what you want.
+
+The flags `--class=Claude-N --name=Claude-N` set the X11 instance class on **child** windows. Combined with a per-profile `.desktop` file containing `StartupWMClass=Claude-N`, the window manager treats each profile as a distinct application.
+
+> **Caveat:** Electron applies `--class` to dialog/sub windows but the **main BrowserWindow** is currently still labelled by Chromium's internal name. If your taskbar still shows the same icon for all profiles, see [WM_CLASS post-launch fix](#wm_class-post-launch-fix-optional) below.
+
+### Per-profile color-coded icons (optional)
+
+If you've added `.desktop` entries with `Icon=claude-desktop-N`, generate tinted icons via ImageMagick:
+
+```bash
+# See recolor-icon.sh — it produces six sizes from the system icon.
+./recolor-icon.sh 2 100 100 47    # profile 2 — purple/lavender (hue -95°)
+./recolor-icon.sh 3 100 100 167   # profile 3 — green           (hue +120°)
+./recolor-icon.sh 4 110 160 30    # profile 4 — indigo (boosted) (perceptually purple)
+gtk-update-icon-cache -f -t "$HOME/.local/share/icons/hicolor"
+```
+
+The numeric arguments after the profile number are ImageMagick's `-modulate brightness,saturation,hue` parameters (`100,100,100` = no change). Hue values: `100` = 0° shift, `200` = +180°, `0` = -180°. Note that perceived color depends on saturation/brightness too — boosting saturation can shift apparent hue (this is why profile 4's `+30°` looks indigo rather than yellow).
+
+### Launching helper script
+
+[`claude-launch`](claude-launch) is a small Bash wrapper that knows how to:
+
+- create a profile if it does not exist (symlinks + `ant-did`)
+- copy the OAuth token cache from the main profile **only on first run** (not overwrite an existing one — important if you log into different accounts per profile)
+- launch the profile with the right `--class` flag
+- list / kill running instances
+
+```bash
+claude-launch              # main (Profile 1)
+claude-launch 2            # Profile 2
+claude-launch all          # 1 + 2 + 3 + 4 in sequence
+claude-launch status       # list running instances
+claude-launch kill 4       # kill one profile (SIGTERM → SIGKILL fallback)
+claude-launch kill-extras  # kill everything except the main profile
+```
+
+### Adding the icons to your dock (GNOME)
+
+```bash
+# Inspect current favorites
+gsettings get org.gnome.shell favorite-apps
+
+# Add Profile 2/3/4 next to the main entry, e.g. via Python
+python3 - <<'PY'
+import subprocess, ast
+favs = ast.literal_eval(subprocess.check_output(
+    ['gsettings','get','org.gnome.shell','favorite-apps'], text=True).strip())
+i = favs.index('claude-desktop.desktop')
+for n, name in enumerate(['claude-desktop-2.desktop',
+                          'claude-desktop-3.desktop',
+                          'claude-desktop-4.desktop'], 1):
+    if name not in favs:
+        favs.insert(i + n, name)
+subprocess.run(['gsettings', 'set', 'org.gnome.shell', 'favorite-apps',
+                '[' + ', '.join(f"'{f}'" for f in favs) + ']'])
+PY
+```
+
+Other desktops (KDE, XFCE, etc.): use your panel's "add launcher" UI and point it at the `.desktop` file.
+
+---
+
+## The `claude://` link handler problem
+
+`claude.ai`'s OAuth login redirects to `claude://callback?...`. Your browser hands that URL to whatever owns `x-scheme-handler/claude` in xdg-mime. If you have multiple `.desktop` files declaring `MimeType=x-scheme-handler/claude;`, **any of them** can capture the link — usually whichever was registered last. That means OAuth callbacks may end up in the wrong profile.
+
+### Recommended approach: temporary swap during login
+
+```bash
+# 1. Before clicking the login link in profile N's window
+xdg-mime default claude-desktop-N.desktop x-scheme-handler/claude
+
+# 2. Click "Login" → browser opens dialog → "Open with Claude" → callback lands in profile N
+
+# 3. After login completes, restore the default
+xdg-mime default claude-desktop.desktop x-scheme-handler/claude
+```
+
+The cookies are stored per-profile, so once login succeeds you don't need the swap again for that profile.
+
+### Firefox-specific tweak (optional, persistent)
+
+Firefox keeps its own protocol-handler table independently of `xdg-mime`. By default it uses `"action": 4` (alwaysAsk) for unknown schemes, which is what makes the dialog appear. If you'd rather skip the dialog and have Firefox always defer to xdg-mime:
+
+1. Quit Firefox completely (otherwise it overwrites the file on exit).
+2. Edit `~/.mozilla/firefox/<profile>.default-release/handlers.json` and change
+
+   ```json
+   "schemes": { "claude": { "action": 4 } }
+   ```
+
+   to
+
+   ```json
+   "schemes": { "claude": { "action": 1 } }
+   ```
+
+   (`1` = `useSystemDefault`). Now Firefox will silently route `claude://` to whatever xdg-mime says.
+
+3. Start Firefox again.
+
+The temporary-swap method works without this tweak, so do it only if the dialog bothers you.
+
+---
+
+## WM_CLASS post-launch fix (optional)
+
+If after using `--class=Claude-N` your taskbar still shows the orange icon for every profile, the main BrowserWindow is keeping Chromium's default class. You can patch it with `xdotool` immediately after launch:
+
+```bash
+sleep 3   # let the window appear
+PID=$(pgrep -f 'electron.*--user-data-dir='"$HOME/.config/Claude-N" | head -1)
+for wid in $(xdotool search --pid "$PID"); do
+  cur=$(xprop -id "$wid" WM_CLASS 2>/dev/null | sed 's/.*= //')
+  [[ "$cur" == *mutter-x11-frames* ]] && continue
+  xdotool set_window --class "Claude-N" --classname "Claude-N" "$wid"
+done
+```
+
+This only lasts until the window is closed; rerun on every launch (or wrap it in `claude-launch`).
+
+A persistent fix would require patching `app.asar` to call `BrowserWindow({wmClass: …})` — out of scope for this guide.
+
+---
+
+## Anti-patterns
+
+| Don't                                                            | Do                                                              |
+| ---------------------------------------------------------------- | --------------------------------------------------------------- |
+| Symlink the **whole** profile dir (`Claude-N` → `Claude`)        | Only symlink the shared subdirectories listed above             |
+| Symlink `IndexedDB/`, `Cookies`, `Cache/`                         | Keep these per-profile (LevelDB/SQLite hold exclusive locks)    |
+| `pkill claude-desktop` (kills *every* instance)                   | Target by `--user-data-dir` path, e.g. `pkill -f Claude-2`      |
+| Reuse the same `--user-data-dir` for two launches                 | Each parallel instance needs its own `userData`                  |
+| Skip `update-desktop-database` after adding a new `.desktop`      | Run it; otherwise launchers won't see the new entry             |
+| Launch a profile without `--class`                                | Always pass `--class=Claude-N --name=Claude-N`                  |
+| Overwrite `oauth:tokenCache` on every launch                      | Copy it only when the target profile has none (first-run sync)  |
+
+---
+
+## Files in this guide
+
+| File                                          | Purpose                                                  |
+| --------------------------------------------- | -------------------------------------------------------- |
+| [`README.md`](README.md)                      | This document                                            |
+| [`claude-launch`](claude-launch)              | Bash launcher script                                     |
+| [`claude-desktop-N.desktop.template`](claude-desktop-N.desktop.template) | Sample `.desktop` entry              |
+| [`recolor-icon.sh`](recolor-icon.sh)          | ImageMagick recipe for tinted per-profile icons          |
+
+---
+
+## Rolling back
+
+A profile is just a directory under `$HOME/.config/`. To undo everything:
+
+```bash
+# Kill any running instances first
+pkill -f 'user-data-dir='"$HOME/.config/Claude-2"
+
+# Remove the profile
+rm -rf "$HOME/.config/Claude-2"
+
+# Remove the launcher entry
+rm "$HOME/.local/share/applications/claude-desktop-2.desktop"
+update-desktop-database "$HOME/.local/share/applications/"
+
+# Restore the default link handler if you swapped it
+xdg-mime default claude-desktop.desktop x-scheme-handler/claude
+```
+
+Your main profile (`$HOME/.config/Claude/`) is never touched — the symlinks point inward, and writes to shared directories happen the same way they would in a single-instance install.

--- a/docs/multi-instance/claude-desktop-N.desktop.template
+++ b/docs/multi-instance/claude-desktop-N.desktop.template
@@ -1,0 +1,16 @@
+[Desktop Entry]
+# Template for a side profile entry. Substitute "N" with 2, 3, 4, ...
+# Save as ~/.local/share/applications/claude-desktop-N.desktop and run:
+#   update-desktop-database ~/.local/share/applications/
+#
+# The --class and --name flags give each profile a distinct WM_CLASS so
+# the desktop environment shows them as separate apps in the taskbar.
+# StartupWMClass must match for window-to-launcher pairing.
+Name=Claude (Profile N)
+Exec=env COWORK_VM_BACKEND=bwrap TMPDIR=/home/USER/.config/Claude-N/tmp /usr/bin/claude-desktop --user-data-dir=/home/USER/.config/Claude-N --class=Claude-N --name=Claude-N %u
+Icon=claude-desktop-N
+Type=Application
+Terminal=false
+Categories=Office;Utility;
+MimeType=x-scheme-handler/claude;
+StartupWMClass=Claude-N

--- a/docs/multi-instance/claude-launch
+++ b/docs/multi-instance/claude-launch
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# claude-launch — multi-instance launcher for Claude Desktop on Linux
+#
+# Usage:
+#   claude-launch              # main profile (~/.config/Claude)
+#   claude-launch 2|3|4|...    # numbered side profile (~/.config/Claude-N)
+#   claude-launch all          # launch main + 2 + 3 + 4
+#   claude-launch status       # list running instances
+#   claude-launch kill 2       # kill a single profile (SIGTERM, then SIGKILL)
+#   claude-launch kill-extras  # kill every profile except the main one
+#
+# Side profiles share local-agent-mode-sessions, claude-code, etc. with the
+# main profile via symlinks. They keep their own Cookies, IndexedDB, Cache,
+# config.json (incl. oauth:tokenCache), and Singleton* — so they run in
+# parallel and can hold separate logins.
+#
+# On first launch of a profile, the script copies the main profile's
+# oauth:tokenCache (if any) so the new instance starts with a fresh token.
+# Subsequent launches leave any existing token alone — log in to a different
+# account in profile N and the script will not overwrite it.
+
+main_dir="${HOME}/.config/Claude"
+bin='/usr/bin/claude-desktop'
+
+# Items the side profile shares with the main profile (symlinks).
+shared_items=(
+	'claude-code'
+	'claude-code-sessions'
+	'claude-code-vm'
+	'git-worktrees.json'
+	'local-agent-mode-sessions'
+	'pending-uploads'
+	'buddy-tokens.json'
+)
+
+ensure_profile() {
+	local profile="$1"
+	local dir="${HOME}/.config/Claude-${profile}"
+
+	[[ -d "$dir" ]] && return 0
+
+	echo "Creating profile Claude-${profile}..."
+	mkdir -p "$dir/tmp"
+
+	local item
+	for item in "${shared_items[@]}"; do
+		ln -sfn "${main_dir}/${item}" "${dir}/${item}"
+	done
+
+	# Seed config.json so Electron's first launch finds a valid file.
+	[[ -f "${main_dir}/config.json" ]] &&
+		cp "${main_dir}/config.json" "${dir}/config.json"
+	[[ -f "${main_dir}/claude_desktop_config.json" ]] &&
+		cp "${main_dir}/claude_desktop_config.json" \
+			"${dir}/claude_desktop_config.json"
+
+	# ant-did is the per-instance UUID Anthropic uses for telemetry.
+	command -v uuidgen >/dev/null &&
+		printf '%s' "$(uuidgen)" | base64 -w0 >"${dir}/ant-did" &&
+		chmod 600 "${dir}/ant-did"
+}
+
+sync_token_first_run() {
+	# First-run-only: if target has no oauth:tokenCache yet, copy from main.
+	# Existing tokens are preserved (so a different account in profile N is OK).
+	local profile="$1"
+	local target="${HOME}/.config/Claude-${profile}/config.json"
+
+	[[ -f "$target" ]] || return 0
+	[[ -f "${main_dir}/config.json" ]] || return 0
+	command -v jq >/dev/null || return 0
+
+	local target_tc
+	target_tc=$(jq -r '."oauth:tokenCache" // empty' "$target")
+	[[ -n "$target_tc" ]] && return 0
+
+	local main_tc
+	main_tc=$(jq -r '."oauth:tokenCache" // empty' "${main_dir}/config.json")
+	[[ -z "$main_tc" ]] && return 0
+
+	local tmp
+	tmp=$(mktemp)
+	jq --arg tc "$main_tc" '."oauth:tokenCache" = $tc' "$target" >"$tmp" &&
+		mv "$tmp" "$target"
+	echo "  (first-run token sync: copied from main to Claude-${profile})"
+}
+
+launch_profile() {
+	local profile="${1:-}"
+
+	if [[ -z "$profile" || "$profile" == '1' ]]; then
+		nohup "$bin" >/dev/null 2>&1 &
+		echo 'Launched main Claude (Profile 1)'
+		return
+	fi
+
+	ensure_profile "$profile"
+	sync_token_first_run "$profile"
+
+	local dir="${HOME}/.config/Claude-${profile}"
+	nohup env COWORK_VM_BACKEND=bwrap TMPDIR="${dir}/tmp" \
+		"$bin" --user-data-dir="$dir" \
+		--class="Claude-${profile}" --name="Claude-${profile}" \
+		>/dev/null 2>&1 &
+	echo "Launched Claude Profile ${profile}"
+}
+
+kill_profile() {
+	local profile="$1"
+	local pat="user-data-dir=${HOME}/.config/Claude-${profile}"
+
+	if pkill -TERM -f "$pat" 2>/dev/null; then
+		echo "Sent SIGTERM to Claude-${profile}"
+	else
+		echo "Claude-${profile} not running"
+		return 0
+	fi
+	sleep 2
+	pkill -KILL -f "$pat" 2>/dev/null || true
+}
+
+list_status() {
+	echo "=== Running Claude Desktop instances ==="
+	local found=0 line pid args profile
+	while IFS= read -r line; do
+		pid="${line%% *}"
+		args="${line#* }"
+		profile='main (Profile 1)'
+		case "$args" in
+			*user-data-dir=*Claude-2*)  profile='Profile 2' ;;
+			*user-data-dir=*Claude-3*)  profile='Profile 3' ;;
+			*user-data-dir=*Claude-4*)  profile='Profile 4' ;;
+			*user-data-dir=*Claude-*)   profile='Profile (other)' ;;
+		esac
+		printf '  PID %-8s  %s\n' "$pid" "$profile"
+		found=1
+	done < <(pgrep -af '/usr/bin/bash /usr/bin/claude-desktop')
+	[[ "$found" == '0' ]] && echo '  (none running)' || true
+}
+
+case "${1:-}" in
+	'' | 1)
+		launch_profile 1
+		;;
+	[2-9] | [1-9][0-9])
+		launch_profile "$1"
+		;;
+	all)
+		launch_profile 1; sleep 1
+		launch_profile 2; sleep 1
+		launch_profile 3; sleep 1
+		launch_profile 4
+		;;
+	status)
+		list_status
+		;;
+	kill)
+		profile="${2:?Usage: claude-launch kill <N>}"
+		kill_profile "$profile"
+		;;
+	kill-extras)
+		# Kill every Claude-N (N=2..99), leave the main alone.
+		pkill -TERM -f 'user-data-dir='"${HOME}"'/.config/Claude-[0-9]' \
+			2>/dev/null && echo 'Sent SIGTERM to side profiles' ||
+			echo '(no side profiles running)'
+		sleep 2
+		pkill -KILL -f 'user-data-dir='"${HOME}"'/.config/Claude-[0-9]' \
+			2>/dev/null || true
+		echo 'Done. Main Claude is untouched.'
+		;;
+	-h | --help | help)
+		sed -n '2,20p' "$0"
+		;;
+	*)
+		echo "Unknown command: $1" >&2
+		echo 'Run: claude-launch --help' >&2
+		exit 1
+		;;
+esac

--- a/docs/multi-instance/recolor-icon.sh
+++ b/docs/multi-instance/recolor-icon.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# recolor-icon.sh — generate a tinted Claude Desktop icon for a side profile.
+#
+# Usage:
+#   ./recolor-icon.sh <profile-N> [brightness] [saturation] [hue]
+#
+# Defaults: brightness=100, saturation=100, hue=100 (no change).
+# ImageMagick's -modulate semantics: 100 = unchanged, 200 = +180° (hue) or
+# +100% (b/s), 0 = the opposite extreme.
+#
+# Examples:
+#   ./recolor-icon.sh 2 100 100 47      # purple/lavender (hue -95°)
+#   ./recolor-icon.sh 3 100 100 167     # green           (hue +120°)
+#   ./recolor-icon.sh 4 110 160 30      # boosted indigo  (perceptually purple)
+#
+# Output: 6 PNGs at standard hicolor sizes under
+# ~/.local/share/icons/hicolor/<size>/apps/claude-desktop-<N>.png
+#
+# After running, refresh the icon cache:
+#   gtk-update-icon-cache -f -t ~/.local/share/icons/hicolor
+
+profile="${1:?profile number required (e.g. 2, 3, 4)}"
+brightness="${2:-100}"
+saturation="${3:-100}"
+hue="${4:-100}"
+
+src_base='/usr/share/icons/hicolor'
+dst_base="${HOME}/.local/share/icons/hicolor"
+sizes=(16 24 32 48 64 256)
+
+if ! command -v magick >/dev/null && ! command -v convert >/dev/null; then
+	echo 'ImageMagick not found. Install it (e.g. `apt install imagemagick`).' >&2
+	exit 1
+fi
+
+magick_cmd='magick'
+command -v magick >/dev/null || magick_cmd='convert'
+
+for size in "${sizes[@]}"; do
+	src="${src_base}/${size}x${size}/apps/claude-desktop.png"
+	dst_dir="${dst_base}/${size}x${size}/apps"
+	dst="${dst_dir}/claude-desktop-${profile}.png"
+
+	if [[ ! -f "$src" ]]; then
+		echo "  [skip] ${size}x${size}: source not found ($src)"
+		continue
+	fi
+
+	mkdir -p "$dst_dir"
+	"$magick_cmd" "$src" \
+		-modulate "${brightness},${saturation},${hue}" \
+		"$dst"
+	echo "  [ok] ${size}x${size} -> ${dst}"
+done
+
+echo
+echo "Done. Refresh icon cache:"
+echo "  gtk-update-icon-cache -f -t ${dst_base}"


### PR DESCRIPTION
## Summary

Adds documentation and helper scripts for running **multiple isolated Claude Desktop instances in parallel** on the same Linux machine — useful for multi-monitor workflows and keeping separate accounts in their own windows.

The trick is straightforward: give each instance its own `--user-data-dir` so the Electron `SingletonLock` doesn't merge them, then **selectively symlink** the session-bearing subdirectories (`local-agent-mode-sessions/`, `claude-code/`, `claude-code-sessions/`, etc.) so all instances see the same chat history and Claude Code sessions, while keeping `Cookies`, `IndexedDB`, `Cache/`, `config.json` (incl. `oauth:tokenCache`), and `Singleton*` per-profile.

This is a **docs-only contribution** — no install/build flow changes, no patches to the main app.

## What's added

- `docs/multi-instance/README.md` — full walkthrough:
  - architecture (which dirs to share, which to keep isolated)
  - quick-start (3 commands)
  - per-profile color-coded icons (ImageMagick recipe)
  - GNOME dock favorites integration
  - the `claude://` link-handler quirk and the `xdg-mime` swap trick used during login
  - optional Firefox `handlers.json` `action: 1` tweak to skip the dialog
  - WM_CLASS post-launch fix (`xdotool set_window`) for desktops that won't pick up `--class` on the main BrowserWindow
  - anti-patterns and rollback steps
- `docs/multi-instance/claude-launch` — launcher script following the repo style guide (tabs, `[[ ]]`, lowercase vars, no `set -e`/`eval`). Subcommands: `1|2|3|N`, `all`, `status`, `kill <N>`, `kill-extras`. Includes a first-run-only `oauth:tokenCache` sync that does **not** overwrite an existing token (so users can log into different accounts per profile).
- `docs/multi-instance/claude-desktop-N.desktop.template` — sample `.desktop` entry with placeholders for `N` and the user's home path
- `docs/multi-instance/recolor-icon.sh` — ImageMagick recipe that produces the 6 standard hicolor sizes for a tinted profile icon
- One-line link from the main `README.md` Configuration section

## Test plan

- [x] All scripts pass `bash -n` and `shellcheck` cleanly
- [x] Tested on Fedora 43 + GNOME on Wayland with claude-desktop wrapper v2.0.5+ (Electron 41) running 4 parallel profiles
- [x] Each profile launches with its own `WM_CLASS` and gets its own taskbar icon (after applying the `xdotool` post-launch tweak documented in the guide for the main BrowserWindow)
- [x] `claude://` callbacks reach the intended profile via the temporary `xdg-mime default claude-desktop-N.desktop x-scheme-handler/claude` swap during login
- [x] `claude-launch kill N` and `kill-extras` correctly target only side profiles, leave the main untouched
- [x] No hardcoded usernames, emails, UUIDs, tokens, hostnames, or PIDs in any of the new files (paths use `${HOME}` / `$USER`)

Happy to iterate on tone, structure, or scope — for example, splitting the script into `scripts/` if that's preferred over keeping everything under `docs/multi-instance/`.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: drafted the documentation, the `claude-launch` script, and the recolor recipe based on the user's session-by-session debugging of multi-profile parallelism. Ran shellcheck, syntax checks, and a credential-leak audit before commit.
Human: discovered the requirement, validated the symlink boundary and the `xdg-mime` swap pattern in practice on their own machine across all four profiles, and reviewed every step before approving the push.