### PR TITLE
docs(readme): credit cbonnissent for bwrap {src, dst} mount form

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Special thanks to:
   - Fixing the KVM startup blocker
   - Fixing RPC response id echoing for persistent connections
   - Configurable bwrap mount points via a dedicated Linux config file
+  - `{src, dst}` mount form in `coworkBwrapMounts` for distinct host/sandbox paths (e.g. persistent `/tmp` across Bash tool calls)
 - **[joekale-pp](https://github.com/joekale-pp)** for adding `--doctor` support to the RPM launcher
 - **[ecrevisseMiroir](https://github.com/ecrevisseMiroir)** for the bwrap backend sandbox isolation with tmpfs-based minimal root
 - **[arauhala](https://github.com/arauhala)** for detailed root cause analysis of the NixOS `isPackaged` regression


### PR DESCRIPTION
## Summary

- Adds a bullet under cbonnissent's existing Acknowledgments entry for the `coworkBwrapMounts` `{src, dst}` polymorphic mount form merged in #531 (closed #530).
- Standard chronological-credit update — appended to their existing entry per the convention used elsewhere in the list.

## Test plan

- [x] README renders cleanly (single-line addition, no markdown breakage)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
10% AI / 90% Human
Claude: drafted the bullet text describing the merged feature
Human: directed the merge of #531, identified the contributor-credit policy applies, and chose to append under the existing entry (vs. a new entry) per the project's clustering convention