### PR TITLE
test(launcher-common): stub pgrep so cleanup_stale_cowork_socket test passes when daemon is alive

### DIFF
--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -349,8 +349,11 @@ s.bind(sys.argv[1])
 s.close()
 " "$sock" 2>/dev/null || skip "Cannot create test unix socket"
 
+	# Stub pgrep so a live host daemon doesn't satisfy the daemon-alive
+	# guard in cleanup_stale_cowork_socket and skip the rm path.
+	pgrep() { return 1; }
+
 	setup_logging
-	# socat connection should fail since nothing is listening
 	cleanup_stale_cowork_socket
 	[[ ! -S "$sock" ]]
 }


### PR DESCRIPTION
## Summary

Fixes #533. The `cleanup_stale_cowork_socket: removes stale socket file` BATS test fails on any developer machine that has a live `cowork-vm-service.js` daemon (i.e., Claude Desktop running). CI passes only because no daemon runs there.

`cleanup_stale_cowork_socket` ([scripts/launcher-common.sh:233-235](scripts/launcher-common.sh#L233-L235)) intentionally bails out early when a daemon is alive — that part is correct. The test, however, doesn't isolate from host process state, so on a developer machine `pgrep` finds the real daemon, the function returns without `rm`, and the `[[ ! -S "$sock" ]]` assertion fails.

This PR stubs `pgrep` inside the test so it returns nonzero, isolating the test from host state and exercising the stale-socket removal path.

I also dropped the misleading `# socat connection should fail since nothing is listening` comment — the current implementation uses `pgrep`, not `socat`.

## Test plan

- [x] Verified repro on host with live daemon: `pgrep -f 'cowork-vm-service\.js'` returns a PID.
- [x] Before fix: test 34 fails (`[[ ! -S "$sock" ]]' failed`).
- [x] After fix: `bats tests/launcher-common.bats` — all 48 tests pass with daemon alive.
- [x] No new shellcheck warnings introduced.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
20% AI / 80% Human
Claude: Reproduced the failure on a host with live daemon, applied the pgrep stub fix per the issue's proposed pattern, ran the full bats suite to confirm green.
Human: Filed the issue with diagnosis & proposed fix; directed the change.