### PR TITLE
fix(dnf): set metadata_expire=1h on generated .repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,6 +669,7 @@ jobs:
             'gpgcheck=1' \
             'repo_gpgcheck=1' \
             'gpgkey=https://pkg.claude-desktop-debian.dev/KEY.gpg' \
+            'metadata_expire=1h' \
             > rpm/claude-desktop.repo
 
       - name: Re-upload signed RPMs to GitHub Release


### PR DESCRIPTION
## Summary

DNF defaults to a 48h metadata cache when `metadata_expire` is unset. After a fresh release, users running `dnf install/reinstall claude-desktop` keep seeing the previous version's metadata for up to two days unless they manually `dnf clean expire-cache` first. Hit this just now on Fedora 42 right after `v2.0.7+claude1.5354.0` shipped — repo metadata was correct upstream, client cache was stale.

Setting `metadata_expire=1h` on the generated `.repo` file caps that staleness at an hour, which matches the cadence we already promise via the APT chain (clients refresh on every `apt update`) and lines up with what other fast-moving third-party RPM repos do (Microsoft and Google use 5min, RPM Fusion uses 7d, Fedora updates uses 6h — 1h sits in the right neighborhood for a project that ships every few weeks).

## What changed

- `.github/workflows/ci.yml` — adds `metadata_expire=1h` to the printf that writes `rpm/claude-desktop.repo` during the DNF repo update step.

The line takes effect on the next push to `main` (the `update-dnf-repo` job runs there), so existing v2.0.7 installs will start picking up the new TTL the next time they refresh against `pkg.claude-desktop-debian.dev/rpm/claude-desktop.repo`.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` passes
- [ ] CI's `update-dnf-repo` job succeeds and the deployed `claude-desktop.repo` includes the new line
- [x] On a Fedora client with the new `.repo` installed: `cat /etc/yum.repos.d/claude-desktop.repo` shows `metadata_expire=1h`, and a release published within the last hour is visible to `dnf info claude-desktop` without an explicit `--refresh`

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
70% AI / 30% Human
Claude: root-cause analysis (DNF default 48h vs observed stale install), repo file edit, PR write-up
Human: spotted the symptom on Fedora client, directed the fix