### PR TITLE
fix(cowork.sh): allow $ in minified identifier anchors; defensive lastIndexOf

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,10 +250,14 @@ Special thanks to:
 - **[hfyeh](https://github.com/hfyeh)** for diagnosing the Ubuntu 24.04 AppArmor unprivileged-userns block on Cowork bwrap and contributing the AppArmor profile workaround
 - **[davidamacey](https://github.com/davidamacey)** for identifying and fixing the XRDP GPU compositing blank-window issue on remote desktop sessions
 - **[pb3ck](https://github.com/pb3ck)** for diagnosing the Cowork `CLAUDE_CODE_OAUTH_TOKEN` env-strip bug with a working reference diff
+- **[Joost-Maker](https://github.com/Joost-Maker)** for fixing the `$e` fs reference crash in cowork Patch 9 on Claude Desktop 1.3109.0, introducing the `[$\w]+` identifier-capture pattern at `cowork.sh:482-501` (#421)
 - **[aJV99](https://github.com/aJV99)** for exporting `GDK_BACKEND=wayland` in native Wayland mode to fix XWayland fallback blur on HiDPI displays
 - **[Andrej730](https://github.com/Andrej730)**
   - Quick-window regex readability refactor (`String.raw` + `escapeRegExp` helper)
-  - Fixing the visibility-function regex break on Claude Desktop 1.3883.0 (#495)
+  - Fixing the visibility-function regex break on Claude Desktop 1.3883.0 (#496)
+- **[HumboldtJoker](https://github.com/HumboldtJoker)** for diagnosing the cowork Patch 2b silent failure on Claude Desktop 1.5354.0 — identifying that the log line was patched but session init still routed through the Swift addon (#553)
+- **[zabka](https://github.com/zabka)** for identifying that `cowork-vm-service.js` was never auto-spawned on Linux and contributing a systemd-unit workaround that scoped the daemon auto-launch fix (#445)
+- **[sirfaber](https://github.com/sirfaber)** for fixing the `$`-in-minified-identifier breakage of cowork Patch 2b (vm module assignment) and Patch 6 step 2 (retry-delay auto-launch) on Claude Desktop 1.5354.0 (#555)
 
 ## Sponsorship
 

--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -118,7 +118,7 @@ if (vmClientLogMatch) {
     const assignRe = new RegExp(
         '(?<!\\|\\|process\\.platform==="linux"\\)?)' +
         win32Var.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
-        '(\\s*\\?\\s*\\(?\\s*\\w+\\s*=\\s*\\{\\s*vm\\s*:\\s*\\w+\\s*\\}\\s*\\)?)'
+        '(\\s*\\?\\s*\\(?\\s*[\\w$]+\\s*=\\s*\\{\\s*vm\\s*:\\s*[\\w$]+\\s*\\}\\s*\\)?)'
     );
     if (assignRe.test(code)) {
         code = code.replace(assignRe,
@@ -261,7 +261,7 @@ if (!code.includes('"linux":{') && !code.includes("'linux':{") &&
 // silent. Falls back to "ignore" if the log dir can't be opened.
 // ============================================================
 const serviceErrorStr = 'VM service not running. The service failed to start.';
-const serviceErrorIdx = code.indexOf(serviceErrorStr);
+const serviceErrorIdx = code.lastIndexOf(serviceErrorStr);
 if (serviceErrorIdx !== -1) {
     // Step 1: Find the ENOENT check and expand it to include ECONNREFUSED
     // Pattern: VAR.code==="ENOENT"
@@ -293,11 +293,11 @@ if (serviceErrorIdx !== -1) {
 
     // Step 2: Inject auto-launch before the retry delay
     // Re-find serviceErrorStr since indices shifted after step 1
-    const newServiceErrorIdx = code.indexOf(serviceErrorStr);
+    const newServiceErrorIdx = code.lastIndexOf(serviceErrorStr);
     const searchEnd = Math.min(code.length, newServiceErrorIdx + 300);
     const searchRegion = code.substring(newServiceErrorIdx, searchEnd);
     const retryMatch = searchRegion.match(
-        /await new Promise\((\w+)=>\s*setTimeout\(\1,\s*(\w+)\)\)/
+        /await new Promise\(([\w$]+)=>\s*setTimeout\(\1,\s*([\w$]+)\)\)/
     );
     if (retryMatch) {
         const retryStr = retryMatch[0];


### PR DESCRIPTION
On Claude Desktop 1.5354.0, three regex anchors in patch_cowork_linux()
no longer match the upstream minified output, shipping a half-patched
app.asar that fails Cowork startup with "Swift VM addon not available".

Patch 2b (vm: module assignment) and Patch 6 step 2 (retry-delay
auto-launch) silently no-op because the minifier emits identifiers
containing '$' (e.g. C$i, Z$x). JS \w excludes '$', so the inner
captures never match. Widening both inner captures to [\w$]+ fixes
both.

Patch 6 also switched from indexOf to lastIndexOf for serviceErrorStr.
In 1.5354.0 the string occurs once, so the change is a no-op. It is
defensive against future upstream versions that reintroduce the
string in onboarding/sample text far from the real retry-loop site.

Symptoms before fix on 1.5354.0:
- ~/.config/Claude/logs/cowork_vm_node.log: load_swift_api failed
- ~/.config/Claude/logs/cowork_vm_daemon.log: never created
- pgrep -af cowork-vm-service: nothing
- ${XDG_RUNTIME_DIR}/cowork-vm-service.sock: missing

Build log before:  Applied 10 cowork patches (no 2b success line,
"WARNING: Could not find retry delay for auto-launch patch")
Build log after:   Applied 12 cowork patches ("Patched VM module
assignment for Linux", "Added service daemon auto-launch on Linux")

Tested on Fedora 43 Workstation (Wayland/GNOME), x86_64, Cowork
backend bwrap. After rebuild + reinstall + relaunch, the in-app
workspace shell starts and the daemon log is populated as expected.

Two pre-existing warnings remain on this build but are not bugs:
"Could not find reinstall file list array" and "Could not find
mkdtemp("wvm-") for tmpdir patch". Both anchors target upstream
code structures that were refactored in 1.5354.0 (rootfs.img is now
inside Eo.files manifest; "wvm-" was renamed to a constant VHe and
the call already uses the bundle dir). Out of scope for this PR.

Co-Authored-By: Claude <claude@anthropic.com>
