### PR TITLE
Set desktopName for Wayland grouping

### DIFF
--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -37,16 +37,21 @@ EOFENTRY
 
 	# Update package.json
 	echo 'Modifying package.json to load frame fix and add node-pty...'
+	local desktop_name='claude-desktop.desktop'
+	if [[ ${build_format:-} == 'appimage' ]]; then
+		desktop_name='io.github.aaddrick.claude-desktop-debian.desktop'
+	fi
 	node -e "
 const fs = require('fs');
 const pkg = require('./app.asar.contents/package.json');
 pkg.originalMain = pkg.main;
 pkg.main = 'frame-fix-entry.js';
+pkg.desktopName = process.argv[1];
 pkg.optionalDependencies = pkg.optionalDependencies || {};
 pkg.optionalDependencies['node-pty'] = '^1.0.0';
 fs.writeFileSync('./app.asar.contents/package.json', JSON.stringify(pkg, null, 2));
-console.log('Updated package.json: main entry and node-pty dependency');
-"
+console.log('Updated package.json: main entry, desktopName, and node-pty dependency');
+" "$desktop_name"
 
 	# Create stub native module
 	echo 'Creating stub native module...'

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -94,7 +94,7 @@ assert_contains "$appdir/AppRun" 'build_electron_args' \
 
 # --- App contents (asar) ---
 resources_dir="$appdir/usr/lib/node_modules/electron/dist/resources"
-validate_app_contents "$resources_dir"
+validate_app_contents "$resources_dir" "${component_id}.desktop"
 
 # --- Cleanup ---
 rm -rf "$extract_dir"

--- a/tests/test-artifact-common.sh
+++ b/tests/test-artifact-common.sh
@@ -59,8 +59,10 @@ assert_command_succeeds() {
 
 # Validate app contents inside an Electron resources directory.
 # $1 = path to the resources/ dir containing app.asar
+# $2 = expected desktopName in app/package.json
 validate_app_contents() {
 	local resources_dir="$1"
+	local expected_desktop_name="${2:-claude-desktop.desktop}"
 
 	assert_file_exists "$resources_dir/app.asar"
 	assert_dir_exists "$resources_dir/app.asar.unpacked"
@@ -94,6 +96,11 @@ validate_app_contents() {
 		assert_contains "$extract_dir/app/package.json" \
 			'frame-fix-entry.js' \
 			"package.json main field references frame-fix-entry.js"
+
+		# package.json desktopName matches the installed desktop file
+		assert_contains "$extract_dir/app/package.json" \
+			"\"desktopName\": \"$expected_desktop_name\"" \
+			"package.json desktopName matches $expected_desktop_name"
 
 		# .vite/build/index.js exists (main process code)
 		assert_file_exists "$extract_dir/app/.vite/build/index.js"


### PR DESCRIPTION
## Summary

This sets `desktopName` in the packaged `app.asar` `package.json` during the Linux repack step so native Wayland compositors can match the running Electron app to `claude-desktop.desktop`.

## Root cause

The repack step already rewrites `app.asar.contents/package.json` for Linux-specific behavior, but it did not set Electron's Linux desktop file metadata. On KDE Plasma Wayland, that leaves the running app without a matching desktop-file identity and Plasma can group it as a separate generic Electron app instead of reusing the pinned Claude launcher.

## Changes

- set `pkg.desktopName = 'claude-desktop.desktop'` in `scripts/patches/app-asar.sh`
- add an artifact-level regression assertion in `tests/test-artifact-common.sh`

## Validation

- `bash -n scripts/patches/app-asar.sh`
- `git diff --check`

Full package build/runtime validation was not run in this checkout.

Closes #561.
