### PR TITLE
feat(lifecycle): notify and offer restart on in-place package upgrade

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -654,6 +654,96 @@ X-GNOME-Autostart-enabled=true
         console.log('[Autostart] XDG Autostart shim installed');
       }
 
+      // Detect in-place package upgrade and prompt for restart.
+      // dpkg/rpm replace app.asar via rename(); the running main
+      // process keeps its in-memory JS, but any BrowserWindow opened
+      // after the swap reads HTML/assets fresh from disk, where the
+      // hashed asset filenames already point at v(N+1) bundles the
+      // in-memory v(N) IPC and preload no longer match. Symptoms
+      // observed: Quick Entry rendering as raw JS text, About
+      // dialog showing minified source, Ctrl+Q intermittently
+      // failing — anything where the post-swap window load crosses
+      // the version boundary. macOS / Windows handle this via
+      // Squirrel; Linux deb/RPM has no equivalent, so we watch the
+      // file ourselves and surface a notification. AppImage is
+      // unaffected (squashfs mount stays pinned to the running
+      // file's contents); Nix store paths are immutable until GC,
+      // so the running inode also stays valid until the user
+      // explicitly relaunches.
+      if (process.platform === 'linux') {
+        try {
+          const fs = require('fs');
+          const asarPath = path.join(process.resourcesPath, 'app.asar');
+          let baseline = null;
+          try { baseline = fs.statSync(asarPath); } catch { /* not present */ }
+          if (baseline) {
+            let notified = false;
+            let debounceTimer = null;
+            const promptRestart = () => {
+              if (notified) return;
+              let cur;
+              try { cur = fs.statSync(asarPath); } catch { return; }
+              // Compare both inode (rename-replace path) and mtime
+              // (in-place rewrite path) so we catch either upgrade
+              // shape. Touching the file with no real content change
+              // would still fire — tolerable; the restart is a no-op
+              // for the user, and dpkg/rpm don't do that in practice.
+              if (cur.ino === baseline.ino
+                && cur.mtimeMs === baseline.mtimeMs) {
+                return;
+              }
+              notified = true;
+              console.log(
+                '[Frame Fix] app.asar replaced — prompting restart');
+              const show = () => {
+                try {
+                  const n = new result.Notification({
+                    title: 'Claude Desktop has been updated',
+                    body: 'Click to restart and apply the update.',
+                  });
+                  // Linux libnotify ignores Electron's `actions`
+                  // (macOS-only per the Notification docs), so the
+                  // whole-notification click is the only affordance.
+                  n.on('click', () => {
+                    result.app.relaunch();
+                    result.app.quit();
+                  });
+                  n.show();
+                } catch (err) {
+                  console.warn(
+                    '[Frame Fix] Restart notification failed:',
+                    err.message);
+                }
+              };
+              if (result.app.isReady()) show();
+              else result.app.whenReady().then(show);
+            };
+            // Watch the parent dir, not the file: fs.watch on the
+            // file loses the inode across a rename-replace, but the
+            // dir watcher reports the new entry via inotify
+            // IN_MOVED_TO / IN_CREATE. Filter by filename so we
+            // ignore unrelated activity in the resources dir.
+            const watcher = fs.watch(path.dirname(asarPath),
+              (_evt, filename) => {
+                if (filename !== 'app.asar') return;
+                if (debounceTimer) clearTimeout(debounceTimer);
+                // dpkg writes app.asar.dpkg-new then renames; rpm
+                // and Nix have similar multi-stage swaps. 5s of
+                // post-event quiet covers the slowest of these
+                // without being noticeably late.
+                debounceTimer = setTimeout(promptRestart, 5000);
+              });
+            // Don't keep the event loop alive on the watcher alone;
+            // the app's other handles drive the lifetime.
+            watcher.unref();
+            console.log('[Frame Fix] Upgrade watcher armed:', asarPath);
+          }
+        } catch (err) {
+          console.warn('[Frame Fix] Upgrade watcher failed to arm:',
+            err.message);
+        }
+      }
+
       console.log('[Frame Fix] Patches built successfully');
     }
 

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -654,94 +654,72 @@ X-GNOME-Autostart-enabled=true
         console.log('[Autostart] XDG Autostart shim installed');
       }
 
-      // Detect in-place package upgrade and prompt for restart.
-      // dpkg/rpm replace app.asar via rename(); the running main
-      // process keeps its in-memory JS, but any BrowserWindow opened
-      // after the swap reads HTML/assets fresh from disk, where the
-      // hashed asset filenames already point at v(N+1) bundles the
-      // in-memory v(N) IPC and preload no longer match. Symptoms
-      // observed: Quick Entry rendering as raw JS text, About
-      // dialog showing minified source, Ctrl+Q intermittently
-      // failing — anything where the post-swap window load crosses
-      // the version boundary. macOS / Windows handle this via
-      // Squirrel; Linux deb/RPM has no equivalent, so we watch the
-      // file ourselves and surface a notification. AppImage is
-      // unaffected (squashfs mount stays pinned to the running
-      // file's contents); Nix store paths are immutable until GC,
-      // so the running inode also stays valid until the user
-      // explicitly relaunches.
-      if (process.platform === 'linux') {
-        try {
-          const fs = require('fs');
-          const asarPath = path.join(process.resourcesPath, 'app.asar');
-          let baseline = null;
-          try { baseline = fs.statSync(asarPath); } catch { /* not present */ }
-          if (baseline) {
-            let notified = false;
-            let debounceTimer = null;
-            const promptRestart = () => {
-              if (notified) return;
-              let cur;
-              try { cur = fs.statSync(asarPath); } catch { return; }
-              // Compare both inode (rename-replace path) and mtime
-              // (in-place rewrite path) so we catch either upgrade
-              // shape. Touching the file with no real content change
-              // would still fire — tolerable; the restart is a no-op
-              // for the user, and dpkg/rpm don't do that in practice.
-              if (cur.ino === baseline.ino
-                && cur.mtimeMs === baseline.mtimeMs) {
-                return;
-              }
-              notified = true;
-              console.log(
-                '[Frame Fix] app.asar replaced — prompting restart');
-              const show = () => {
-                try {
-                  const n = new result.Notification({
-                    title: 'Claude Desktop has been updated',
-                    body: 'Click to restart and apply the update.',
-                  });
-                  // Linux libnotify ignores Electron's `actions`
-                  // (macOS-only per the Notification docs), so the
-                  // whole-notification click is the only affordance.
-                  n.on('click', () => {
-                    result.app.relaunch();
-                    result.app.quit();
-                  });
-                  n.show();
-                } catch (err) {
-                  console.warn(
-                    '[Frame Fix] Restart notification failed:',
-                    err.message);
-                }
-              };
-              if (result.app.isReady()) show();
-              else result.app.whenReady().then(show);
-            };
-            // Watch the parent dir, not the file: fs.watch on the
-            // file loses the inode across a rename-replace, but the
-            // dir watcher reports the new entry via inotify
-            // IN_MOVED_TO / IN_CREATE. Filter by filename so we
-            // ignore unrelated activity in the resources dir.
-            const watcher = fs.watch(path.dirname(asarPath),
-              (_evt, filename) => {
-                if (filename !== 'app.asar') return;
-                if (debounceTimer) clearTimeout(debounceTimer);
-                // dpkg writes app.asar.dpkg-new then renames; rpm
-                // and Nix have similar multi-stage swaps. 5s of
-                // post-event quiet covers the slowest of these
-                // without being noticeably late.
-                debounceTimer = setTimeout(promptRestart, 5000);
+      // Detect in-place package upgrade (dpkg/rpm rename-replace of
+      // app.asar) and offer a restart, since post-swap window loads
+      // mix v(N+1) HTML/assets with the v(N) IPC/preload still in
+      // memory. AppImage and Nix are immune (immutable running file);
+      // the watcher just no-ops there. Fixes: see PR #564.
+      const armUpgradeWatcher = () => {
+        if (process.platform !== 'linux') return;
+        const fs = require('fs');
+        const asarPath = path.join(process.resourcesPath, 'app.asar');
+        let baseline;
+        try { baseline = fs.statSync(asarPath); } catch { return; }
+
+        let notified = false;
+        let debounceTimer = null;
+        const promptRestart = () => {
+          if (notified) return;
+          let cur;
+          try { cur = fs.statSync(asarPath); } catch { return; }
+          // ino catches rename-replace; mtime catches in-place
+          // rewrite. Either is sufficient on its own for dpkg/rpm,
+          // but checking both keeps us honest against odd packagers.
+          if (cur.ino === baseline.ino
+            && cur.mtimeMs === baseline.mtimeMs) return;
+          notified = true;
+          console.log('[Frame Fix] app.asar replaced — prompting restart');
+          // whenReady() resolves immediately if already ready, so no
+          // isReady() branch needed. Linux libnotify ignores
+          // Notification.actions (macOS-only), so whole-notification
+          // click is the only restart affordance.
+          result.app.whenReady().then(() => {
+            try {
+              const n = new result.Notification({
+                title: 'Claude Desktop has been updated',
+                body: 'Click to restart and apply the update.',
               });
-            // Don't keep the event loop alive on the watcher alone;
-            // the app's other handles drive the lifetime.
-            watcher.unref();
-            console.log('[Frame Fix] Upgrade watcher armed:', asarPath);
-          }
-        } catch (err) {
-          console.warn('[Frame Fix] Upgrade watcher failed to arm:',
-            err.message);
-        }
+              n.on('click', () => {
+                result.app.relaunch();
+                result.app.quit();
+              });
+              n.show();
+            } catch (err) {
+              console.warn('[Frame Fix] Restart notification failed:',
+                err.message);
+            }
+          });
+        };
+
+        // Watch the parent dir, not the file: file-level fs.watch
+        // loses the inode across rename-replace. Filename filter
+        // ignores unrelated activity in the resources dir; 5s
+        // debounce covers dpkg's .dpkg-new → rename dance and
+        // similar multi-stage swaps in rpm/Nix.
+        const watcher = fs.watch(path.dirname(asarPath),
+          (_evt, filename) => {
+            if (filename !== 'app.asar') return;
+            if (debounceTimer) clearTimeout(debounceTimer);
+            debounceTimer = setTimeout(promptRestart, 5000);
+          });
+        // App's other handles drive process lifetime; the watcher
+        // shouldn't keep the loop alive on its own.
+        watcher.unref();
+        console.log('[Frame Fix] Upgrade watcher armed:', asarPath);
+      };
+      try { armUpgradeWatcher(); } catch (err) {
+        console.warn('[Frame Fix] Upgrade watcher failed to arm:',
+          err.message);
       }
 
       console.log('[Frame Fix] Patches built successfully');


### PR DESCRIPTION
## Summary

Watch `app.asar` for in-place dpkg/rpm replacement; on detection, show a click-to-restart notification. Fixes the Quick Entry "raw JS" / About "minified source" / Ctrl+Q "intermittent" symptom cluster that traces to the running v(N) main process loading v(N+1) renderer assets after an upgrade. Linux only; AppImage and Nix immutable-store paths are inert as expected.

## The bug

dpkg/rpm replace `app.asar` via `rename()` while the main process keeps its in-memory JS. Any `BrowserWindow` opened after the swap reads HTML/asset files fresh from disk, where the hashed asset filenames now point at v(N+1) bundles that the in-memory v(N) IPC and preload no longer match. Symptoms observed across recent triage:

- Quick Entry rendering as raw JS text (renderer's bundled JS shown in `<body>` because the v(N)-shaped HTML→asset path landed in a v(N+1) renderer)
- About dialog showing minified source (#481)
- Ctrl+Q intermittently failing (any path crossing the in-memory↔on-disk boundary)

Before this PR users had no signal that the running process was stale. The macOS / Windows clients get this from Squirrel; Linux deb/RPM has no equivalent.

## The fix

Inserted in `scripts/frame-fix-wrapper.js` as a sibling to the autostart shim — same "main-process boot" surface, runs once on first `require('electron')`.

- **Watch the parent dir, not the file.** File-level `fs.watch` loses the inode across rename-replace; dir-level inotify reports the new entry via `IN_MOVED_TO` / `IN_CREATE`. Filename-filtered to `app.asar` so unrelated activity in the resources dir is ignored.
- **5s debounce past the last event** to clear dpkg's `.dpkg-new` → rename dance and similar multi-stage swaps in rpm / Nix.
- **Compare both `ino` and `mtimeMs`** so the rename-replace path *and* the (rare) in-place-rewrite path both register as a real change.
- **Notification deferred behind `whenReady`** if the app hasn't reached ready when the swap fires; click → `app.relaunch(); app.quit()`. Linux libnotify ignores Electron's `actions` array per the API docs, so whole-notification click is the only affordance — that matches what the macOS client does anyway.
- **Best-effort.** Stat failures and missing-asar paths (AppImage's squashfs mount, dev runs, unusual installs) silently skip arming the watcher.

## Test plan

- [ ] Build deb v(N), install, run from terminal
- [ ] `sudo apt install ./claude-desktop_v(N+1).deb` while it's running
- [ ] Notification appears within ~5s
- [ ] Click → app cleanly relaunches into v(N+1) (verify via launcher.log)
- [ ] AppImage build: confirm watcher arms but never fires (squashfs mount stays pinned to running file's contents)
- [ ] No tests added — `frame-fix-wrapper.js` has no existing test harness in this repo (the autostart shim it sits next to is also untested). Open to wiring up a node mock-test if the maintainer wants one before merge.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
~100% AI / minimal Human
Claude: diagnosed root cause (running-process / on-disk asset version mismatch after upgrade), designed and implemented the watcher, wrote commit and PR body
Human: filed the bug report, ran the launch-context test that ruled out `CLAUDE_TITLEBAR_STYLE` as the culprit, pointed at the macOS restart-prompt UX as the model to follow