### PR TITLE
fix(ci): force primary GPG key for repomd.xml signing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,14 +653,12 @@ jobs:
               echo "Generating repodata for $arch..."
               createrepo_c --update "rpm/$arch/"
 
-              # Sign the repository metadata.
-              #   --yes: overwrite existing signature.
-              #   trailing '!' on keyid: force gpg to sign with the
-              #   primary key, not the most recent signing subkey.
-              #   rpm 4.20+ / zypper verify repomd.xml only against
-              #   the primary key; without '!', gpg silently picks
-              #   the subkey and verification fails (regression of
-              #   #213 — PR #217 added --default-key but missed '!').
+              # Sign repodata. Trailing '!' on keyid forces gpg to use
+              # the primary key; without it gpg picks the most recent
+              # signing subkey, and rpm 4.20+ / zypper reject repomd.xml
+              # signed by anything other than the primary key.
+              # Regression of #213 — PR #217 added --default-key but
+              # dropped the '!'. Do not strip it. --yes overwrites .asc.
               echo "Signing repodata for $arch..."
               gpg --batch --yes --default-key "${{ steps.import_gpg.outputs.keyid }}!" --detach-sign --armor "rpm/$arch/repodata/repomd.xml"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,9 +653,16 @@ jobs:
               echo "Generating repodata for $arch..."
               createrepo_c --update "rpm/$arch/"
 
-              # Sign the repository metadata (--yes to overwrite existing signature)
+              # Sign the repository metadata.
+              #   --yes: overwrite existing signature.
+              #   trailing '!' on keyid: force gpg to sign with the
+              #   primary key, not the most recent signing subkey.
+              #   rpm 4.20+ / zypper verify repomd.xml only against
+              #   the primary key; without '!', gpg silently picks
+              #   the subkey and verification fails (regression of
+              #   #213 — PR #217 added --default-key but missed '!').
               echo "Signing repodata for $arch..."
-              gpg --batch --yes --default-key "${{ steps.import_gpg.outputs.keyid }}" --detach-sign --armor "rpm/$arch/repodata/repomd.xml"
+              gpg --batch --yes --default-key "${{ steps.import_gpg.outputs.keyid }}!" --detach-sign --armor "rpm/$arch/repodata/repomd.xml"
             fi
           done
 


### PR DESCRIPTION
## Summary

- Append `!` to the keyid passed to `gpg --default-key` when signing
  `repomd.xml`, forcing gpg to use the primary key instead of silently
  selecting the most recent signing subkey.
- Re-fixes #213 (regression of #217). Without `!`, `--default-key`
  only chooses an identity; gpg still picks a subkey for the actual
  signature. rpm 4.20+ / zypper verify `repomd.xml` only against the
  primary key, so the subkey-signed `repomd.xml.asc` currently fails
  verification on Fedora 43 (dnf5) and openSUSE Tumbleweed (zypper
  1.14.96 / rpm 4.20.1) with `Signature verification failed for
  repomd.xml`.

Fixes #213

## Reproduction (current `pkg.claude-desktop-debian.dev`)

```
$ sudo zypper addrepo \
    https://pkg.claude-desktop-debian.dev/rpm/claude-desktop.repo
$ sudo zypper --gpg-auto-import-keys refresh claude-desktop
…
Repository 'Claude Desktop for Fedora/RHEL' ist ungültig.
 - Signature verification failed for repomd.xml
```

Inspecting the published signature confirms the subkey is signing:

```
$ curl -s .../repodata/repomd.xml.asc \
    | gpg --list-packets 2>/dev/null | grep keyid
:signature packet: algo 1, keyid 78CE91D72AA9E9B9   # subkey
# Primary key id: 6E29E413B912E0F1
```

## Why `!` is required

`gpg --default-key FPR` selects the **identity** to sign as; gpg then
picks any valid signing-capable key under that identity, preferring
the most recent subkey. The trailing `!` ("exact key" specifier) forces
gpg to use that exact key for the signature operation. See `gpg(1)`
"How to specify a user ID" / "exact key" notation.

## Test plan

Reproduced and validated end-to-end locally against zypper 1.14.96 /
rpm 4.20.1 / gpg 2.x with a test primary+subkey keypair, re-signing
the live `repomd.xml` from `pkg.claude-desktop-debian.dev`:

| Variant | sig keyid | `zypper refresh` |
|---|---|---|
| `--default-key FPR` (current) | subkey | fail: `Signature verification failed for repomd.xml` |
| `--default-key FPR!` (this PR) | primary | OK: `Die angegebenen Repositorys wurden aktualisiert` |

After merge:

- [ ] Next release tag triggers CI; `update-dnf-repo` job signs
      `repomd.xml` with the primary key.
- [ ] `curl -s …/repomd.xml.asc | gpg --list-packets | grep keyid`
      shows the primary key id (`6E29E413B912E0F1`).
- [ ] `sudo zypper addrepo …/claude-desktop.repo && sudo zypper
      refresh claude-desktop` succeeds on openSUSE Tumbleweed.
- [ ] `sudo dnf install claude-desktop` succeeds on Fedora 43 / dnf5.

## Note on RPM package signing

`rpmsign --addsign` (line 617, via `%_gpg_name` and `__gpg_sign_cmd
-u`) is intentionally left alone. RPM package signature verification
validates subkey-bound signatures via the primary key binding signature
imported into the rpmdb, so subkey-signed `.rpm` files verify
correctly. Only repository metadata verification in rpm 4.20+ is
strict-primary-only — that is the path this PR addresses.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: identified missing `!` on `--default-key`, set up test
primary+subkey keypair, reproduced bug 1:1 against live repomd.xml,
verified fix end-to-end with zypper 1.14.96, wrote diff, lint, commit,
PR draft.
Human: directed scope (scalpel, no adjacent refactors), rejected
out-of-scope openSUSE-detection path, ran zypper verification on
openSUSE Tumbleweed, gave explicit go/no-go at each gate.