### PR TITLE
launcher: log session/IME env block at startup

### DIFF
--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -245,6 +245,7 @@ cleanup_stale_cowork_socket
 log_message '--- Claude Desktop Launcher Start (NixOS) ---'
 log_message "Timestamp: $(date)"
 log_message "Arguments: $@"
+log_session_env
 
 # Check for display
 if ! check_display; then

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -16,6 +16,39 @@ log_message() {
 	echo "$1" >> "$log_file"
 }
 
+# Log the session/IME environment vars that drive display and input
+# decisions, so bug reports include enough context to reason about
+# them without round-trip env-dump requests (#548).
+#
+# Emits one block:
+#     env={
+#       KEY=value
+#       ...
+#     }
+#
+# Empty or unset values are emitted as `KEY=` so absence is
+# unambiguous (vs. silently omitted). Caller must run setup_logging
+# first.
+log_session_env() {
+	local key
+	log_message 'env={'
+	for key in \
+		XDG_SESSION_TYPE \
+		WAYLAND_DISPLAY \
+		DISPLAY \
+		XDG_CURRENT_DESKTOP \
+		GTK_IM_MODULE \
+		XMODIFIERS \
+		QT_IM_MODULE \
+		CLAUDE_USE_WAYLAND \
+		CLAUDE_TITLEBAR_STYLE \
+		CLAUDE_GTK_IM_MODULE
+	do
+		log_message "  $key=${!key:-}"
+	done
+	log_message '}'
+}
+
 # Detect display backend (Wayland vs X11)
 # Sets: is_wayland, use_x11_on_wayland
 detect_display_backend() {

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -98,6 +98,7 @@ log_message '--- Claude Desktop AppImage Start ---'
 log_message "Timestamp: $(date)"
 log_message "Arguments: $@"
 log_message "APPDIR: $appdir"
+log_session_env
 
 # Path to the bundled Electron executable and app
 electron_exec="$appdir/usr/lib/node_modules/electron/dist/electron"

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -114,6 +114,7 @@ cleanup_stale_cowork_socket
 log_message '--- Claude Desktop Launcher Start ---'
 log_message "Timestamp: \$(date)"
 log_message "Arguments: \$@"
+log_session_env
 
 # Check for display
 if ! check_display; then

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -97,6 +97,7 @@ cleanup_stale_cowork_socket
 log_message '--- Claude Desktop Launcher Start ---'
 log_message "Timestamp: \$(date)"
 log_message "Arguments: \$@"
+log_session_env
 
 # Check for display
 if ! check_display; then

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -110,57 +110,42 @@ teardown() {
 	log_session_env
 
 	run cat "$log_file"
-	[[ $output == *'env={'* ]]
-	[[ $output == *'XDG_SESSION_TYPE=wayland'* ]]
-	[[ $output == *'WAYLAND_DISPLAY=wayland-0'* ]]
-	[[ $output == *'DISPLAY=:0'* ]]
-	[[ $output == *'XDG_CURRENT_DESKTOP=KDE'* ]]
-	[[ $output == *'GTK_IM_MODULE=ibus'* ]]
-	[[ $output == *'XMODIFIERS=@im=ibus'* ]]
-	[[ $output == *'QT_IM_MODULE=ibus'* ]]
-	[[ $output == *'CLAUDE_USE_WAYLAND=1'* ]]
-	[[ $output == *'CLAUDE_TITLEBAR_STYLE=hybrid'* ]]
-	[[ $output == *'CLAUDE_GTK_IM_MODULE=xim'* ]]
+	# Exact-line match locks block structure (open/close braces on
+	# their own lines) and per-key formatting in one pass.
+	[[ "${lines[0]}"  == 'env={' ]]
+	[[ "${lines[1]}"  == '  XDG_SESSION_TYPE=wayland' ]]
+	[[ "${lines[2]}"  == '  WAYLAND_DISPLAY=wayland-0' ]]
+	[[ "${lines[3]}"  == '  DISPLAY=:0' ]]
+	[[ "${lines[4]}"  == '  XDG_CURRENT_DESKTOP=KDE' ]]
+	[[ "${lines[5]}"  == '  GTK_IM_MODULE=ibus' ]]
+	[[ "${lines[6]}"  == '  XMODIFIERS=@im=ibus' ]]
+	[[ "${lines[7]}"  == '  QT_IM_MODULE=ibus' ]]
+	[[ "${lines[8]}"  == '  CLAUDE_USE_WAYLAND=1' ]]
+	[[ "${lines[9]}"  == '  CLAUDE_TITLEBAR_STYLE=hybrid' ]]
+	[[ "${lines[10]}" == '  CLAUDE_GTK_IM_MODULE=xim' ]]
+	[[ "${lines[11]}" == '}' ]]
 }
 
-@test "log_session_env: unset values are emitted as KEY= (not omitted)" {
+@test "log_session_env: unset/empty values render as 'KEY=' (no value)" {
 	setup_logging
-	# All env vars left unset by the test setup
-	log_session_env
-
-	run cat "$log_file"
-	# Each required key must appear with an empty value, not be missing
-	[[ $output == *'XDG_SESSION_TYPE='* ]]
-	[[ $output == *'WAYLAND_DISPLAY='* ]]
-	[[ $output == *'DISPLAY='* ]]
-	[[ $output == *'XDG_CURRENT_DESKTOP='* ]]
-	[[ $output == *'GTK_IM_MODULE='* ]]
-	[[ $output == *'XMODIFIERS='* ]]
-	[[ $output == *'QT_IM_MODULE='* ]]
-	[[ $output == *'CLAUDE_USE_WAYLAND='* ]]
-	[[ $output == *'CLAUDE_TITLEBAR_STYLE='* ]]
-	[[ $output == *'CLAUDE_GTK_IM_MODULE='* ]]
-}
-
-@test "log_session_env: empty value is emitted as KEY= (same as unset)" {
-	setup_logging
+	# All vars unset by setup() except this one, which exercises the
+	# empty-string branch (must be indistinguishable from unset).
 	GTK_IM_MODULE=''
 	log_session_env
 
 	run cat "$log_file"
-	# `KEY=` line must be present with no value after the equals sign
-	[[ $output =~ GTK_IM_MODULE=$'\n' || $output =~ GTK_IM_MODULE=$ ]]
-}
-
-@test "log_session_env: emits opening and closing braces on their own lines" {
-	setup_logging
-	log_session_env
-
-	run cat "$log_file"
-	# Opening brace
-	[[ "${lines[0]}" == 'env={' ]]
-	# Closing brace as final line
-	[[ "${lines[${#lines[@]}-1]}" == '}' ]]
+	# Exact-line match proves the line ends right after '=' — a
+	# substring like *'KEY='* would also match 'KEY=value'.
+	[[ "${lines[1]}"  == '  XDG_SESSION_TYPE=' ]]
+	[[ "${lines[2]}"  == '  WAYLAND_DISPLAY=' ]]
+	[[ "${lines[3]}"  == '  DISPLAY=' ]]
+	[[ "${lines[4]}"  == '  XDG_CURRENT_DESKTOP=' ]]
+	[[ "${lines[5]}"  == '  GTK_IM_MODULE=' ]]
+	[[ "${lines[6]}"  == '  XMODIFIERS=' ]]
+	[[ "${lines[7]}"  == '  QT_IM_MODULE=' ]]
+	[[ "${lines[8]}"  == '  CLAUDE_USE_WAYLAND=' ]]
+	[[ "${lines[9]}"  == '  CLAUDE_TITLEBAR_STYLE=' ]]
+	[[ "${lines[10]}" == '  CLAUDE_GTK_IM_MODULE=' ]]
 }
 
 # =============================================================================

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -35,10 +35,15 @@ setup() {
 	unset CLAUDE_USE_WAYLAND
 	unset NIRI_SOCKET
 	unset XDG_CURRENT_DESKTOP
+	unset XDG_SESSION_TYPE
 	unset CLAUDE_MENU_BAR
 	unset CLAUDE_TITLEBAR_STYLE
 	unset COWORK_VM_BACKEND
 	unset ELECTRON_USE_SYSTEM_TITLE_BAR
+	unset GTK_IM_MODULE
+	unset XMODIFIERS
+	unset QT_IM_MODULE
+	unset CLAUDE_GTK_IM_MODULE
 
 	# shellcheck source=scripts/launcher-common.sh
 	source "$SCRIPT_DIR/../scripts/launcher-common.sh"
@@ -84,6 +89,78 @@ teardown() {
 	run cat "$log_file"
 	[[ "${lines[0]}" == "test message one" ]]
 	[[ "${lines[1]}" == "test message two" ]]
+}
+
+# =============================================================================
+# log_session_env
+# =============================================================================
+
+@test "log_session_env: emits env={ ... } block with all required keys" {
+	setup_logging
+	XDG_SESSION_TYPE='wayland'
+	WAYLAND_DISPLAY='wayland-0'
+	DISPLAY=':0'
+	XDG_CURRENT_DESKTOP='KDE'
+	GTK_IM_MODULE='ibus'
+	XMODIFIERS='@im=ibus'
+	QT_IM_MODULE='ibus'
+	CLAUDE_USE_WAYLAND='1'
+	CLAUDE_TITLEBAR_STYLE='hybrid'
+	CLAUDE_GTK_IM_MODULE='xim'
+	log_session_env
+
+	run cat "$log_file"
+	[[ $output == *'env={'* ]]
+	[[ $output == *'XDG_SESSION_TYPE=wayland'* ]]
+	[[ $output == *'WAYLAND_DISPLAY=wayland-0'* ]]
+	[[ $output == *'DISPLAY=:0'* ]]
+	[[ $output == *'XDG_CURRENT_DESKTOP=KDE'* ]]
+	[[ $output == *'GTK_IM_MODULE=ibus'* ]]
+	[[ $output == *'XMODIFIERS=@im=ibus'* ]]
+	[[ $output == *'QT_IM_MODULE=ibus'* ]]
+	[[ $output == *'CLAUDE_USE_WAYLAND=1'* ]]
+	[[ $output == *'CLAUDE_TITLEBAR_STYLE=hybrid'* ]]
+	[[ $output == *'CLAUDE_GTK_IM_MODULE=xim'* ]]
+}
+
+@test "log_session_env: unset values are emitted as KEY= (not omitted)" {
+	setup_logging
+	# All env vars left unset by the test setup
+	log_session_env
+
+	run cat "$log_file"
+	# Each required key must appear with an empty value, not be missing
+	[[ $output == *'XDG_SESSION_TYPE='* ]]
+	[[ $output == *'WAYLAND_DISPLAY='* ]]
+	[[ $output == *'DISPLAY='* ]]
+	[[ $output == *'XDG_CURRENT_DESKTOP='* ]]
+	[[ $output == *'GTK_IM_MODULE='* ]]
+	[[ $output == *'XMODIFIERS='* ]]
+	[[ $output == *'QT_IM_MODULE='* ]]
+	[[ $output == *'CLAUDE_USE_WAYLAND='* ]]
+	[[ $output == *'CLAUDE_TITLEBAR_STYLE='* ]]
+	[[ $output == *'CLAUDE_GTK_IM_MODULE='* ]]
+}
+
+@test "log_session_env: empty value is emitted as KEY= (same as unset)" {
+	setup_logging
+	GTK_IM_MODULE=''
+	log_session_env
+
+	run cat "$log_file"
+	# `KEY=` line must be present with no value after the equals sign
+	[[ $output =~ GTK_IM_MODULE=$'\n' || $output =~ GTK_IM_MODULE=$ ]]
+}
+
+@test "log_session_env: emits opening and closing braces on their own lines" {
+	setup_logging
+	log_session_env
+
+	run cat "$log_file"
+	# Opening brace
+	[[ "${lines[0]}" == 'env={' ]]
+	# Closing brace as final line
+	[[ "${lines[${#lines[@]}-1]}" == '}' ]]
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `log_session_env` in `scripts/launcher-common.sh`, called once per launch from each packaging target (deb, rpm, AppImage, Nix).
- Emits a single `env={ ... }` block covering display, IME, and Claude-specific overrides — see issue #548 for the full key list.
- Empty/unset values are written as `KEY=` rather than omitted so absence is unambiguous in bug reports.
- Pure observability — no behavior change.

Closes #548.

## Test plan

- [ ] `bats tests/launcher-common.bats` passes (4 new test cases under `log_session_env`)
- [ ] Local build (`./build.sh --build appimage --clean no`) and confirm `~/.cache/claude-desktop-debian/launcher.log` contains an `env={ ... }` block on launch
- [ ] Confirm unset vars render as `KEY=` (e.g. by launching with `XMODIFIERS` unset)
- [ ] CI green on amd64 + arm64

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
60% AI / 40% Human
Claude: drafted env-block helper, wired into all four launchers, wrote BATS coverage
Human: scoped issue, decided on three-PR sequence, reviewed