### PR TITLE
launcher: add CLAUDE_GTK_IM_MODULE opt-in override

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -80,6 +80,48 @@ If the global hotkey (Ctrl+Alt+Space) doesn't work, ensure you're not running in
 
 See [CONFIGURATION.md](CONFIGURATION.md) for more details on the `CLAUDE_USE_WAYLAND` environment variable.
 
+### Keyboard Input Doesn't Work (IBus / GTK Input Method)
+
+If typing into the chat does nothing, characters get swallowed, or
+dead-key sequences (e.g. ``` `e ``` → `è`) don't compose, your GTK
+input module integration with the Electron-bundled GTK is broken.
+Common symptoms:
+
+- No characters appear when typing into any text field
+- The first keystroke after focus is dropped, subsequent ones work
+- CJK input methods (IBus, Fcitx) not engaging
+- Compose key / dead-key sequences silently drop
+
+The fastest workaround is to switch the launcher to a different GTK
+input module. Set `CLAUDE_GTK_IM_MODULE` and Claude Desktop will
+propagate it as `GTK_IM_MODULE` to Electron at startup:
+
+```bash
+# Bypass IBus entirely — uses the X Input Method (XIM) protocol
+CLAUDE_GTK_IM_MODULE=xim claude-desktop
+
+# To make it persistent, export it from your shell profile:
+# echo 'export CLAUDE_GTK_IM_MODULE=xim' >> ~/.profile
+```
+
+Valid values: anything your GTK installation supports (`xim`, `ibus`,
+`fcitx`, `simple`, etc.). When the override is active, the launcher
+logs a line to `~/.cache/claude-desktop-debian/launcher.log`:
+
+```
+GTK_IM_MODULE override: ibus -> xim (via CLAUDE_GTK_IM_MODULE)
+```
+
+**Trade-off:** `xim` is the lowest-common-denominator input module
+and does not support advanced IME features like CJK candidate
+windows or rich compose-key sequences. Only use it if your real
+input method (IBus/Fcitx) is broken — for users who don't need
+CJK/compose, `xim` is fine; for users who do, prefer fixing the
+IBus/Fcitx integration over forcing `xim`.
+
+If unset or empty, `GTK_IM_MODULE` is not modified and existing
+behavior is preserved.
+
 ### AppImage Sandbox Warning
 
 AppImages run with `--no-sandbox` due to electron's chrome-sandbox requiring root privileges for unprivileged namespace creation. This is a known limitation of AppImage format with Electron applications.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -114,13 +114,9 @@ GTK_IM_MODULE override: ibus -> xim (via CLAUDE_GTK_IM_MODULE)
 
 **Trade-off:** `xim` is the lowest-common-denominator input module
 and does not support advanced IME features like CJK candidate
-windows or rich compose-key sequences. Only use it if your real
-input method (IBus/Fcitx) is broken — for users who don't need
-CJK/compose, `xim` is fine; for users who do, prefer fixing the
-IBus/Fcitx integration over forcing `xim`.
-
-If unset or empty, `GTK_IM_MODULE` is not modified and existing
-behavior is preserved.
+windows or rich compose-key sequences. Only reach for it if your
+real input method (IBus/Fcitx) is broken; if you depend on CJK or
+compose, prefer fixing the IBus/Fcitx integration instead.
 
 ### AppImage Sandbox Warning
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -316,15 +316,13 @@ setup_electron_env() {
 		export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 	fi
 	# CLAUDE_GTK_IM_MODULE: opt-in override for users hit by broken
-	# IBus integration on Linux (#549). When set non-empty, propagate
-	# the value to GTK_IM_MODULE so users can persist e.g. xim without
-	# editing .desktop Exec lines or wrapping the launcher. Unset/empty
-	# leaves GTK_IM_MODULE alone (no behavior change for everyone else).
+	# IBus integration on Linux (#549). Propagated to GTK_IM_MODULE
+	# so e.g. `xim` can be persisted without wrapping every launch.
 	if [[ -n ${CLAUDE_GTK_IM_MODULE:-} ]]; then
-		local _prev="${GTK_IM_MODULE:-<unset>}"
+		local prev="${GTK_IM_MODULE:-<unset>}"
 		export GTK_IM_MODULE="$CLAUDE_GTK_IM_MODULE"
 		log_message \
-			"GTK_IM_MODULE override: $_prev -> $GTK_IM_MODULE (via CLAUDE_GTK_IM_MODULE)"
+			"GTK_IM_MODULE override: $prev -> $GTK_IM_MODULE (via CLAUDE_GTK_IM_MODULE)"
 	fi
 }
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -315,6 +315,17 @@ setup_electron_env() {
 	if [[ $(_resolve_titlebar_style) != 'hidden' ]]; then
 		export ELECTRON_USE_SYSTEM_TITLE_BAR=1
 	fi
+	# CLAUDE_GTK_IM_MODULE: opt-in override for users hit by broken
+	# IBus integration on Linux (#549). When set non-empty, propagate
+	# the value to GTK_IM_MODULE so users can persist e.g. xim without
+	# editing .desktop Exec lines or wrapping the launcher. Unset/empty
+	# leaves GTK_IM_MODULE alone (no behavior change for everyone else).
+	if [[ -n ${CLAUDE_GTK_IM_MODULE:-} ]]; then
+		local _prev="${GTK_IM_MODULE:-<unset>}"
+		export GTK_IM_MODULE="$CLAUDE_GTK_IM_MODULE"
+		log_message \
+			"GTK_IM_MODULE override: $_prev -> $GTK_IM_MODULE (via CLAUDE_GTK_IM_MODULE)"
+	fi
 }
 
 #===============================================================================

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -355,6 +355,48 @@ teardown() {
 	[[ $ELECTRON_USE_SYSTEM_TITLE_BAR == '1' ]]
 }
 
+@test "setup_electron_env: CLAUDE_GTK_IM_MODULE set propagates to GTK_IM_MODULE" {
+	setup_logging
+	GTK_IM_MODULE='ibus'
+	CLAUDE_GTK_IM_MODULE='xim'
+	setup_electron_env
+	[[ $GTK_IM_MODULE == 'xim' ]]
+	# Override is logged so users can verify it took effect
+	run cat "$log_file"
+	[[ $output == *'GTK_IM_MODULE override: ibus -> xim (via CLAUDE_GTK_IM_MODULE)'* ]]
+}
+
+@test "setup_electron_env: CLAUDE_GTK_IM_MODULE set logs <unset> when GTK_IM_MODULE was unset" {
+	setup_logging
+	# GTK_IM_MODULE unset by setup()
+	CLAUDE_GTK_IM_MODULE='xim'
+	setup_electron_env
+	[[ $GTK_IM_MODULE == 'xim' ]]
+	run cat "$log_file"
+	[[ $output == *'GTK_IM_MODULE override: <unset> -> xim (via CLAUDE_GTK_IM_MODULE)'* ]]
+}
+
+@test "setup_electron_env: CLAUDE_GTK_IM_MODULE unset leaves GTK_IM_MODULE alone" {
+	setup_logging
+	GTK_IM_MODULE='ibus'
+	# CLAUDE_GTK_IM_MODULE unset by setup()
+	setup_electron_env
+	[[ $GTK_IM_MODULE == 'ibus' ]]
+	# No override line should appear in the log
+	run cat "$log_file"
+	[[ $output != *'GTK_IM_MODULE override'* ]]
+}
+
+@test "setup_electron_env: CLAUDE_GTK_IM_MODULE empty leaves GTK_IM_MODULE alone" {
+	setup_logging
+	GTK_IM_MODULE='ibus'
+	CLAUDE_GTK_IM_MODULE=''
+	setup_electron_env
+	[[ $GTK_IM_MODULE == 'ibus' ]]
+	run cat "$log_file"
+	[[ $output != *'GTK_IM_MODULE override'* ]]
+}
+
 # =============================================================================
 # _resolve_titlebar_style
 # =============================================================================


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_GTK_IM_MODULE` opt-in env var. When set non-empty, `setup_electron_env` exports `GTK_IM_MODULE=$CLAUDE_GTK_IM_MODULE` before Electron exec and logs the override.
- Unset/empty leaves `GTK_IM_MODULE` alone — no behavior change for unaffected users.
- TROUBLESHOOTING.md section documents the IBus failure symptom, valid values, and the `xim` trade-off (CJK/compose key impact).
- BATS coverage for set / unset / empty cases plus the `<unset>` prior-value path.

Closes #549. Refs #545.

## Why opt-in (not auto-detect)

Forcing `xim` for every Linux user would silently break CJK input methods, dead-key sequences, and compose-key handling. Affected users persist the workaround via env var instead of editing `.desktop` Exec lines or wrapping the launcher.

## Test plan

- [ ] `bats tests/launcher-common.bats` — 4 new test cases under `setup_electron_env` (set / set-with-no-prior / unset / empty)
- [ ] Manual: launch `CLAUDE_GTK_IM_MODULE=xim claude-desktop` and confirm `~/.cache/claude-desktop-debian/launcher.log` contains the override line
- [ ] Manual: launch without the var and confirm `GTK_IM_MODULE` is unmodified and no override line appears
- [ ] CI green on amd64 + arm64

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
65% AI / 35% Human
Claude: drafted setup_electron_env override branch, BATS cases, TROUBLESHOOTING entry
Human: scoped issue, decided opt-in semantics, reviewed