### PR TITLE
fix(cowork): WARNING on Patch 2a/2b inner anchor miss (#559)

### DIFF
--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -109,6 +109,13 @@ if (vmClientLogMatch) {
             '(' + win32Var + '||process.platform==="linux")$1');
         console.log('  Patched VM client log check for Linux');
         patchCount++;
+    } else if (code.includes(
+        '||process.platform==="linux")?"vmClient (TypeScript)"'
+    )) {
+        console.log('  VM client log gate already applied (Patch 2a)');
+    } else {
+        console.log('  WARNING: Could not find anchor for VM client log' +
+            ' gate (Patch 2a) — half-patched asar will fail Cowork startup');
     }
 
     // 2b: Patch the actual module assignment
@@ -125,6 +132,12 @@ if (vmClientLogMatch) {
             '(' + win32Var + '||process.platform==="linux")$1');
         console.log('  Patched VM module assignment for Linux');
         patchCount++;
+    } else if (/\|\|process\.platform==="linux"\)\??\(?[\w$]+=\{vm:[\w$]+\}/.test(code)) {
+        console.log('  VM module assignment already applied (Patch 2b)');
+    } else {
+        console.log('  WARNING: Could not find anchor for VM module' +
+            ' assignment (Patch 2b) — half-patched asar will fail' +
+            ' Cowork startup (PR #555 failure mode)');
     }
 } else {
     console.log('  WARNING: Could not find vmClient variable for module loading patch');


### PR DESCRIPTION
## Summary

PR #555 was the third recurrence of `\w+` silently truncating a `$`-containing minified identifier in `cowork.sh`. Two of the three failed gates had no `else` branch on the inner anchor regex, so a miss silently shipped a half-patched asar — the build log printed `Applied 10 cowork patches` with no warning, and diagnosis happened from runtime symptoms hours later. Patch 6's inner gate already logged on miss, which is why that one was the easier of the three to find.

This PR retrofits the canonical three-branch pattern (regex matches → patch + log; post-patch literal already in place → "already applied"; otherwise → `WARNING:` naming the site) onto the two genuine silent no-op sites: Patch 2a's `logRe` at line 107 and Patch 2b's `assignRe` at line 123. Shape mirrors Patch 4b at lines 227-234. I walked the file line by line during #559 review — the other inner-gate candidates (`platformGateRe`, `vmClientLogMatch` outer, `pipeMatch`, `enoentRe`, `quitFnRe`) all already log on miss (FATAL+exit at 82-87, WARNING at 130/151/290/630), and the same applied to `quick-window.sh:112` and `claude-code.sh`. So D5 is locked to these two sites, not the speculative ~5 from the issue body's first cut.

The empirical-validation step from the #559 plan ran against pinned 1.5354.0:

- **Broken 2a anchor.** Mutated the `"vmClient (TypeScript)"` literal inside `logRe` so the regex can't match. Build log fires `WARNING: Could not find anchor for VM client log gate (Patch 2a) — half-patched asar will fail Cowork startup`. `verify-cowork-patches.sh` from #575 catches the missing `vmclient-log-gate` marker and exits 2.
- **Broken 2b anchor.** Mutated `\\s*vm\\s*:` to `\\s*NOPE\\s*:` in `assignRe`. New `WARNING: Could not find anchor for VM module assignment (Patch 2b) — half-patched asar will fail Cowork startup (PR #555 failure mode)` fires. Verify catches the missing `vm-assignment-linux-gate` marker.
- **Baseline.** Fresh upstream — no new WARNINGs, all 12 cowork patches apply, verify exits 0.

#575 is the load-bearing prerequisite for that argument; this PR shouldn't have landed without it, which is why I split the followup into three.

One thing worth flagging for review: re-running on an already-patched asar produces pre-existing warnings from the *outer* `vmClientLogMatch` regex at line 94, not from these inner gates. The outer block short-circuits before the inner sites on a fully-patched file, so the new "already applied" branches only trigger when the outer regex matches but the inner one doesn't — exactly the #555 failure mode they're meant to surface. The pre-existing outer-block idempotency hole is out of scope; not a regression from this PR.

References #559.

## Test plan

- [x] Fresh build on 1.5354.0 — no new WARNINGs, `Applied 12 cowork patches`, `verify-cowork-patches.sh` exits 0
- [x] Deliberate-break 2a anchor — new WARNING fires, verify exits 2 on missing `vmclient-log-gate` marker
- [x] Deliberate-break 2b anchor — new WARNING fires, verify exits 2 on missing `vm-assignment-linux-gate` marker
- [x] `shellcheck scripts/patches/cowork.sh` clean (only pre-existing SC2148/SC2154 warnings on this sourced library file, unchanged from main)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
80% AI / 20% Human
Claude: drafted the #559 followup comment that locked the retrofit to these two sites, wrote and validated the patch, ran the deliberate-break empirical tests, drafted the PR.
Human: approved the plan, scoped to D5, reviewed the diff and the empirical-validation results.
