### PR TITLE
fix(deps): pin electron to ^41 to restore postinstall binary fetch (#584)

### DIFF
--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -215,7 +215,11 @@ setup_electron_asar() {
 
 	if [[ $install_needed == true ]]; then
 		echo "Installing Electron and Asar locally into $work_dir..."
-		if ! npm install --no-save electron @electron/asar; then
+		# Pin to electron 41.x: electron@42.0.0 (2026-05-06) dropped the
+		# postinstall that fetches the prebuilt binary into dist/, leaving
+		# node_modules/electron/dist absent and the build aborting (#584).
+		# A durable fix using @electron/get is tracked separately.
+		if ! npm install --no-save 'electron@^41' @electron/asar; then
 			echo 'Failed to install Electron and/or Asar locally.' >&2
 			cd "$project_root" || exit 1
 			exit 1


### PR DESCRIPTION
## Summary

Hotfix for #584 — `build.sh` started failing for everyone building from source today because `electron@42.0.0` (published 2026-05-06) dropped the `postinstall` script that downloads the prebuilt binary into `node_modules/electron/dist/`.

`scripts/setup/dependencies.sh:218` resolves `electron` to whatever is `latest`, so `npm install` succeeds but `dist/` is never created, and the existence check at line 233 aborts with `Failed to find Electron distribution directory`.

This PR pins to `electron@^41` so the postinstall still runs. A more durable fix using `@electron/get` to fetch the binary explicitly will land as a follow-up — kept separate so this one-character risk can ship immediately.

```diff
-if ! npm install --no-save electron @electron/asar; then
+if ! npm install --no-save 'electron@^41' @electron/asar; then
```

## Scope

- Source builders (deb / rpm / appimage / NixOS / AUR / manual) on any arch — affected, this fixes it.
- Users installing prebuilt artifacts from Releases — unaffected; electron is already bundled.
- The two CI workflow `npm install` calls (`issue-triage.yml`, `ci.yml`) only install `@electron/asar`, not `electron` itself, so they need no change.

## Test plan

- [ ] `./build.sh --build deb` completes on amd64
- [ ] `./build.sh --build appimage` completes on amd64
- [ ] `./build.sh --build rpm` completes on amd64
- [ ] CI green on this branch (verifies arm64 + all three formats)

Credit to @BlueManCZ for the diagnosis and suggested fix in #584.

Refs #584

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: investigated the issue, verified the call site is the only affected install, drafted hotfix vs. durable-fix tradeoffs, applied the pin, ran shellcheck, wrote commit and PR copy.
Human: directed the strategy (hotfix first, durable fix as a follow-up PR), reviewed the proposed approach.

---
_Generated by [Claude Code](https://claude.ai/code/session_018rzaM6GRdQJZZEKNcGQKJf)_