### PR TITLE
fix(deps): fetch electron binary via @electron/get, drop ^41 pin

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -41,6 +41,17 @@ The build script automatically detects your distribution and selects the appropr
 | Arch Linux | `.AppImage` (via AUR) | yay/paru |
 | Other | `.AppImage` | - |
 
+## Build Environment Variables
+
+The build pulls the Electron prebuilt binary from `github.com/electron/electron/releases` via `@electron/get`. Two upstream environment variables let you redirect that fetch:
+
+- `ELECTRON_MIRROR` — base URL to fetch Electron releases from instead of GitHub. Useful for mirrors or local proxies. Example: `ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/`.
+- `ELECTRON_CUSTOM_DIR` — overrides the path segment after the mirror. Defaults to `v{version}`.
+
+The cache location is fixed at `~/.cache/electron/` (resolved by `@electron/get` via `envPaths`) and is reused across builds. `ELECTRON_CACHE` is **not** read by `@electron/get` — set `ELECTRON_MIRROR` if you need to avoid the public CDN.
+
+The pinned Electron version lives in `scripts/setup/dependencies.sh` (`electron_version`) and must match `build-reference/app-extracted/package.json` — the upstream Claude Desktop `app.asar` is built against a specific Electron major and running a different one is unsupported.
+
 ## Installing the Built Package
 
 ### For .deb packages (Debian/Ubuntu)

--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -215,16 +215,25 @@ setup_electron_asar() {
 
 	if [[ $install_needed == true ]]; then
 		echo "Installing Electron and Asar locally into $work_dir..."
-		# Pin to electron 41.x: electron@42.0.0 (2026-05-06) dropped the
-		# postinstall that fetches the prebuilt binary into dist/, leaving
-		# node_modules/electron/dist absent and the build aborting (#584).
-		# A durable fix using @electron/get is tracked separately.
-		if ! npm install --no-save 'electron@^41' @electron/asar; then
+		if ! npm install --no-save \
+			electron @electron/asar @electron/get extract-zip; then
 			echo 'Failed to install Electron and/or Asar locally.' >&2
 			cd "$project_root" || exit 1
 			exit 1
 		fi
 		echo 'Electron and Asar installation command finished.'
+
+		# electron@42+ no longer ships a postinstall script that fetches
+		# the prebuilt binary into dist/. If npm didn't populate it, fetch
+		# the matching binary explicitly via @electron/get. See #584.
+		if [[ ! -d $electron_dist_path ]]; then
+			echo 'Electron postinstall did not populate dist/; fetching binary explicitly...'
+			if ! node "$project_root/scripts/setup/fetch-electron-binary.js"; then
+				echo 'Failed to fetch Electron binary via @electron/get.' >&2
+				cd "$project_root" || exit 1
+				exit 1
+			fi
+		fi
 	else
 		echo 'Local Electron distribution and Asar binary already present.'
 	fi

--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -198,6 +198,13 @@ setup_nodejs() {
 setup_electron_asar() {
 	section_header 'Electron & Asar Handling'
 
+	# Pin Electron to the exact version upstream Claude Desktop ships
+	# (build-reference/app-extracted/package.json). The shipped app.asar
+	# binds to specific V8/NAPI ABI, Chromium pairing, and node-pty
+	# native surface — running a different Electron major against this
+	# asar is unsupported. Bump when upstream bumps.
+	local electron_version='41.5.0'
+
 	echo "Ensuring local Electron and Asar installation in $work_dir..."
 	cd "$work_dir" || exit 1
 
@@ -214,9 +221,9 @@ setup_electron_asar() {
 	[[ ! -f $asar_bin_path ]] && echo 'Asar binary not found.' && install_needed=true
 
 	if [[ $install_needed == true ]]; then
-		echo "Installing Electron and Asar locally into $work_dir..."
+		echo "Installing electron@${electron_version} and Asar locally into $work_dir..."
 		if ! npm install --no-save \
-			electron @electron/asar @electron/get extract-zip; then
+			"electron@${electron_version}" @electron/asar @electron/get extract-zip; then
 			echo 'Failed to install Electron and/or Asar locally.' >&2
 			cd "$project_root" || exit 1
 			exit 1
@@ -226,13 +233,21 @@ setup_electron_asar() {
 		# electron@42+ no longer ships a postinstall script that fetches
 		# the prebuilt binary into dist/. If npm didn't populate it, fetch
 		# the matching binary explicitly via @electron/get. See #584.
+		# Retry once on transient CDN failures (503, network drops).
 		if [[ ! -d $electron_dist_path ]]; then
 			echo 'Electron postinstall did not populate dist/; fetching binary explicitly...'
-			if ! node "$project_root/scripts/setup/fetch-electron-binary.js"; then
-				echo 'Failed to fetch Electron binary via @electron/get.' >&2
-				cd "$project_root" || exit 1
-				exit 1
-			fi
+			local fetch_attempts=0
+			while ! node "$project_root/scripts/setup/fetch-electron-binary.js"; do
+				fetch_attempts=$((fetch_attempts + 1))
+				if (( fetch_attempts >= 2 )); then
+					echo 'Failed to fetch Electron binary via @electron/get after 2 attempts.' >&2
+					echo 'For air-gapped or mirrored builds set ELECTRON_MIRROR or ELECTRON_CUSTOM_DIR; see docs/BUILDING.md.' >&2
+					cd "$project_root" || exit 1
+					exit 1
+				fi
+				echo "Retrying Electron binary fetch (attempt $((fetch_attempts + 1))/2)..."
+				sleep 2
+			done
 		fi
 	else
 		echo 'Local Electron distribution and Asar binary already present.'

--- a/scripts/setup/fetch-electron-binary.js
+++ b/scripts/setup/fetch-electron-binary.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+// Fetches the Electron prebuilt binary into node_modules/electron/dist/.
+//
+// electron@42.0.0 (2026-05-06) removed the postinstall script that
+// historically populated dist/ during `npm install`. This helper restores
+// that behavior using @electron/get + extract-zip, so the rest of the
+// build pipeline (which depends on the dist/ layout) keeps working.
+//
+// Run from the directory containing node_modules/electron. Reads the
+// installed electron version from its package.json and downloads the
+// matching binary for the host platform/arch.
+//
+// See: https://github.com/aaddrick/claude-desktop-debian/issues/584
+
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+async function main() {
+	const cwd = process.cwd();
+	const electronModuleDir = path.join(cwd, 'node_modules', 'electron');
+	const distDir = path.join(electronModuleDir, 'dist');
+
+	if (!fs.existsSync(electronModuleDir)) {
+		throw new Error(
+			`Electron module not found at ${electronModuleDir}; ` +
+			"run 'npm install electron' first.",
+		);
+	}
+
+	const pkgPath = path.join(electronModuleDir, 'package.json');
+	const { version } = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+	if (!version) {
+		throw new Error(`Could not read version from ${pkgPath}`);
+	}
+
+	const platform = 'linux';
+	// node's process.arch values map cleanly to electron release archs,
+	// except 'arm' which electron publishes as 'armv7l'.
+	const arch = process.arch === 'arm' ? 'armv7l' : process.arch;
+
+	const { downloadArtifact } = require('@electron/get');
+	const extractZip = require('extract-zip');
+
+	console.log(`Fetching electron@${version} for ${platform}-${arch}...`);
+	const zipPath = await downloadArtifact({
+		version,
+		platform,
+		arch,
+		artifactName: 'electron',
+	});
+
+	console.log(`Extracting ${zipPath} into ${distDir}`);
+	fs.mkdirSync(distDir, { recursive: true });
+	await extractZip(zipPath, { dir: distDir });
+
+	const electronBin = path.join(distDir, 'electron');
+	if (fs.existsSync(electronBin)) {
+		fs.chmodSync(electronBin, 0o755);
+	}
+
+	console.log('Electron binary fetched and extracted successfully.');
+}
+
+main().catch((err) => {
+	console.error(err && err.stack ? err.stack : err);
+	process.exit(1);
+});

--- a/scripts/setup/fetch-electron-binary.js
+++ b/scripts/setup/fetch-electron-binary.js
@@ -40,6 +40,14 @@ async function main() {
 	// except 'arm' which electron publishes as 'armv7l'.
 	const arch = process.arch === 'arm' ? 'armv7l' : process.arch;
 
+	const supportedArchs = ['x64', 'arm64', 'armv7l', 'ia32'];
+	if (!supportedArchs.includes(arch)) {
+		throw new Error(
+			`Unsupported architecture: ${arch}. ` +
+			`Electron publishes Linux binaries for ${supportedArchs.join(', ')}.`,
+		);
+	}
+
 	const { downloadArtifact } = require('@electron/get');
 	const extractZip = require('extract-zip');
 

--- a/scripts/setup/fetch-electron-binary.js
+++ b/scripts/setup/fetch-electron-binary.js
@@ -16,6 +16,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const { createRequire } = require('node:module');
 
 async function main() {
 	const cwd = process.cwd();
@@ -48,8 +49,12 @@ async function main() {
 		);
 	}
 
-	const { downloadArtifact } = require('@electron/get');
-	const extractZip = require('extract-zip');
+	// Resolve @electron/get and extract-zip from the work-dir's
+	// node_modules. The script lives at scripts/setup/ so a plain
+	// require() walks up from there and never sees work_dir/.
+	const workDirRequire = createRequire(path.join(cwd, 'package.json'));
+	const { downloadArtifact } = workDirRequire('@electron/get');
+	const extractZip = workDirRequire('extract-zip');
 
 	console.log(`Fetching electron@${version} for ${platform}-${arch}...`);
 	const zipPath = await downloadArtifact({


### PR DESCRIPTION
## Summary

Follow-up to #586. The hotfix pinned `electron@^41` to avoid the missing-postinstall regression in `electron@42.0.0`. This PR keeps the version pin (now `41.5.0` exact, matching upstream `build-reference/app-extracted/package.json`) but stops relying on electron's postinstall to populate `dist/`. We fetch the binary ourselves so a future postinstall removal or behavior change doesn't break the build again.

- **New helper** `scripts/setup/fetch-electron-binary.js` — uses `@electron/get` to download the matching prebuilt binary for the host platform/arch, then `extract-zip` to unpack it into `node_modules/electron/dist/`. Reads the version from the just-installed electron's `package.json` so it tracks whatever the pin resolves to.
- **`setup_electron_asar`** runs the helper only when `npm install` leaves `dist/` missing. If electron ever restores the postinstall, this becomes a no-op.
- **Pins `electron@41.5.0` exact** in `scripts/setup/dependencies.sh`, hoisted to a named `electron_version` local. Upstream Claude Desktop's `app.asar` binds to a specific V8/NAPI ABI, Chromium pairing, and `node-pty` native surface. Running a different Electron major against it is unsupported. Bump it when upstream bumps.
- **Retry once on transient CDN failures.** A 503 from `github.com/electron/electron/releases` shouldn't red the whole build.
- **Arch whitelist** in `fetch-electron-binary.js` (`x64`, `arm64`, `armv7l`, `ia32`) so an exotic-arch host gets an actionable error instead of a 404 from electron's release server.

## Why two new npm deps

`@electron/get` returns a path to a downloaded zip; it doesn't extract. `extract-zip` is the same library electron's own (now-removed) `install.js` used, and it's already a transitive dep of `@electron/get`. Installing it explicitly makes the dependency surface obvious rather than relying on hoisting.

The alternative was shelling out to `unzip(1)`, which would add a system-package dep that isn't used anywhere else in this repo.

## Mirror / cache env vars

`@electron/get` reads `ELECTRON_MIRROR` and `ELECTRON_CUSTOM_DIR`; both are documented in `docs/BUILDING.md`. **`ELECTRON_CACHE` is NOT honored** — the cache lives at `~/.cache/electron/` (resolved via `envPaths`). Earlier versions of this PR body claimed `ELECTRON_CACHE` worked. That was wrong.

## Failure modes considered

| Scenario | Behavior |
|---|---|
| electron postinstall returns | Helper never runs (`dist/` already present) — no-op. |
| Transient 503 from electron CDN | Retried once; second failure exits with an `ELECTRON_MIRROR` pointer. |
| Electron release pulled from CDN | `@electron/get` throws after retry; bash propagates a clear error. |
| Exotic host arch | `fetch-electron-binary.js` throws with the supported-arch list. |
| Cross-arch build | Uses `process.arch` (mapped: `arm` → `armv7l`); CI runners build on their own arch, matching today's behavior. |
| Mirror env vars | `@electron/get` honors `ELECTRON_MIRROR` and `ELECTRON_CUSTOM_DIR`. |
| Stale `dist/` from prior build | Pre-existing `install_needed` check skips both npm install and the helper, same as before. |

## Test plan

- [ ] `./build.sh --build deb` on amd64 — fresh `work-dir` (no cached `dist/`)
- [ ] `./build.sh --build deb` on amd64 — second run reuses cached `dist/`
- [ ] `./build.sh --build appimage` on amd64
- [ ] `./build.sh --build rpm` on amd64
- [ ] CI green on this branch (covers arm64 + all three formats)
- [ ] Verify the produced binary launches and reports Electron 41.5.0

Refs #584
Follow-up to #586

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: designed the helper, traced downstream consumers to confirm the `dist/` layout contract, drafted the bash wiring, wrote the script, ran shellcheck and node --check, drafted commit and PR copy, applied self-review feedback (re-pinning `electron@41.5.0`, retry wrap, arch whitelist, BUILDING.md docs, ELECTRON_CACHE correction).
Human: chose the durable-fix-as-separate-PR strategy, signed off on the `@electron/get` + `extract-zip` approach over the `unzip(1)` alternative, caught the ABI-break risk from dropping the version pin during self-review.
