### PR TITLE
fix(frame-fix): skip redundant webContents.focus() under sloppy WMs (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Tracks upstream Claude Desktop 1.8555.2.
 
 ### Fixed
 
+- Sloppy/focus-follows-mouse: suppress redundant `webContents.focus()` calls that trigger X11 `_NET_ACTIVE_WINDOW` raise-on-hover. Grace window handles stale `isFocused()` on tray-restore and minimize-restore. Thanks @tkrag. ([#589](https://github.com/aaddrick/claude-desktop-debian/pull/589), fixes [#416](https://github.com/aaddrick/claude-desktop-debian/issues/416))
 - Tray: extracted JS identifier captures now accept `$` so the 1.8089.1 minified bundle ('`i$A`' menu handler) matches. Switches `\w+` to `[\w$]+`. ([#627](https://github.com/aaddrick/claude-desktop-debian/pull/627), fixes [#625](https://github.com/aaddrick/claude-desktop-debian/issues/625))
 - RPM: silence "File listed twice" warning on `chrome-sandbox` by moving `chmod 4755` into `%install` (replaces `%attr` in `%files`). Adds regression guard that fails the build if the warning reappears. Thanks @JoshuaVlantis. ([#610](https://github.com/aaddrick/claude-desktop-debian/pull/610), fixes [#609](https://github.com/aaddrick/claude-desktop-debian/issues/609))
 - Window close with `CLAUDE_QUIT_ON_CLOSE=1` now actively quits via `app.quit()` instead of relying on the bundled handler that hardcodes hide-to-tray on Linux. Rides upstream's own quit-in-progress guard. Thanks @phelps-matthew. ([#624](https://github.com/aaddrick/claude-desktop-debian/pull/624), fixes [#623](https://github.com/aaddrick/claude-desktop-debian/issues/623))

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Special thanks to:
 - **[phelps-matthew](https://github.com/phelps-matthew)** for fixing `CLAUDE_QUIT_ON_CLOSE=1` to actively quit via `app.quit()` instead of relying on the bundled handler that hardcodes hide-to-tray on Linux, with thorough root cause analysis and alternatives evaluation (#624, #623)
 - **[dubreal](https://github.com/dubreal)** for `--password-store` keyring detection that probes D-Bus for kwallet6 / gnome-libsecret at startup, fixing session persistence on KDE Plasma and other desktops where Electron's `safeStorage` was unavailable (#611, #593)
 - **[JustinJLeopard](https://github.com/JustinJLeopard)** for detecting missing electron binaries after Node 24's `extract-zip` silently no-ops, with an `unzip` fallback that recovers from the `@electron/get` cache (#631, #584)
+- **[tkrag](https://github.com/tkrag)** for diagnosing and fixing the X11 window-raise-on-hover bug under sloppy/focus-follows-mouse WMs, tracing the upstream `webContents.focus()` → `_NET_ACTIVE_WINDOW` path through three iterations of review (#589, #416)
 
 ## Sponsorship
 

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -246,6 +246,21 @@ Module.prototype.require = function(id) {
               this.setMenuBarVisibility(false);
             }
 
+            // Track the most recent 'show' event timestamp on the
+            // window. Read by the webContents.focus() guard below to
+            // distinguish a genuine post-show activation (which must
+            // pass through to send _NET_ACTIVE_WINDOW and actually
+            // give the window WM focus) from a sloppy-focus
+            // reassertion (which is what we want to skip). Required
+            // because Electron's isFocused() returns stale-true after
+            // hide() on Cinnamon/KDE/Wayland — a freshly-restored
+            // window reports focused=true even though the WM never
+            // activated it, and skipping the focus() call leaves the
+            // window visible-but-inert until the user clicks it.
+            // See #416 review notes.
+            this._lastShownAt = 0;
+            this.on('show', () => { this._lastShownAt = Date.now(); });
+
             // Inject CSS for Linux scrollbar styling
             this.webContents.on('did-finish-load', () => {
               this.webContents.insertCSS(LINUX_CSS).catch(() => {});
@@ -594,6 +609,66 @@ Module.prototype.require = function(id) {
             event.preventDefault();
             result.app.quit();
           });
+
+          // Suppress redundant webContents.focus() calls that would
+          // re-trigger Chromium's X11Window::Activate() and send a
+          // _NET_ACTIVE_WINDOW client message — EWMH defines that as
+          // focus-AND-raise, so under sloppy / focus-follows-mouse
+          // WMs (Cinnamon Muffin, Mutter, i3 with focus_follows_mouse)
+          // every BrowserWindow 'focus' event causes a raise on
+          // mouse-enter, undoing the user's "no auto-raise" config.
+          // Tracks electron/electron#38184.
+          //
+          // Hooked at app.on('web-contents-created') so child views
+          // are covered too — the BrowserWindow-class wrap only
+          // touches the window's own webContents, but the upstream
+          // call site lives on a child WebContentsView (the claude.ai
+          // host view) whose webContents is a different object.
+          //
+          // Skip is gated on the *owning toplevel*'s isFocused(),
+          // not the webContents'. wc.isFocused() returns false on a
+          // freshly-attached child view even when the window is
+          // focused — that's exactly the state on every sloppy hover,
+          // so guarding on it would never skip and the raise loop
+          // would continue.
+          //
+          // The post-'show' grace window is the second half of the
+          // story. Electron's isFocused() returns stale-true after
+          // hide() on Cinnamon/KDE/Wayland (the same trap that
+          // drives the KDE-only patches in scripts/patches/
+          // quick-window.sh); a tray-restore hide → show then sees
+          // ownerFocused=true and a naive guard would skip, leaving
+          // the window visible-but-inert (no _NET_ACTIVE_WINDOW, no
+          // keyboard focus until the user clicks). Within
+          // SHOW_GRACE_MS of a 'show' event we pass through
+          // unconditionally, so the post-restore activation actually
+          // lands. 1000 ms covers the synchronous show → focus
+          // sequence with margin for slow restores.
+          //
+          // Trade-off: in sloppy mode, hover-induced focus events
+          // are SKIPped, which suppresses both the X11 raise (the
+          // bug we're fixing) and the renderer-focus direction that
+          // webContents.focus() would also do. Net effect: hover
+          // gives WM focus (frame highlight) but renderer focus
+          // doesn't follow until the user clicks. The Electron API
+          // doesn't expose a renderer-focus-only path on X11, so
+          // this is the best available trade against the constant-
+          // raise UX. Genuine activations (no recent show + not
+          // already focused) still go through end-to-end.
+          //
+          // Fixes: #416
+          const SHOW_GRACE_MS = 1000;
+          const origFocus = wc.focus.bind(wc);
+          wc.focus = (...args) => {
+            const owner = result.BrowserWindow.fromWebContents(wc);
+            if (!owner || owner.isDestroyed()) return origFocus(...args);
+            if (!owner.isFocused()) return origFocus(...args);
+            const shownAt = owner._lastShownAt || 0;
+            if (Date.now() - shownAt < SHOW_GRACE_MS) {
+              return origFocus(...args);
+            }
+            return;
+          };
         });
       }
 

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -260,6 +260,7 @@ Module.prototype.require = function(id) {
             // See #416 review notes.
             this._lastShownAt = 0;
             this.on('show', () => { this._lastShownAt = Date.now(); });
+            this.on('restore', () => { this._lastShownAt = Date.now(); });
 
             // Inject CSS for Linux scrollbar styling
             this.webContents.on('did-finish-load', () => {
@@ -655,6 +656,10 @@ Module.prototype.require = function(id) {
           // this is the best available trade against the constant-
           // raise UX. Genuine activations (no recent show + not
           // already focused) still go through end-to-end.
+          //
+          // Known: deferred setTimeout focus sites (e.g. find-bar
+          // dismiss) outside the grace window may lose renderer-focus
+          // direction on keyboard dismissal. See #416 review.
           //
           // Fixes: #416
           const SHOW_GRACE_MS = 1000;


### PR DESCRIPTION
## Summary

Under sloppy / focus-follows-mouse WMs (Cinnamon Muffin, Mutter, i3 with
`focus_follows_mouse`), every BrowserWindow `focus` event triggered an
upstream `webContents.focus()` call which on Electron/X11 routes
through Chromium's `X11Window::Activate()` and sends a
`_NET_ACTIVE_WINDOW` client message — EWMH defines that as
focus-AND-raise, so the WM raised the window on every mouse-enter,
undoing the user's "no auto-raise" config.

Tracks [electron/electron#38184][upstream]; no Electron flag exposes
a focus-only path on X11.

[upstream]: https://github.com/electron/electron/issues/38184

Fixes #416.

## Approach

Hooked at `app.on('web-contents-created')` so every webContents in
the process is covered (main + child views + popups + devtools). The
upstream call site sits on a **child `WebContentsView`** (the
`claude.ai` host view), not the main BrowserWindow's own webContents,
so wrapping at the BrowserWindow-class level is insufficient — the
first version of this PR did that and missed the actual call site.

The guard runs against the **owning toplevel's** `isFocused()`, not
`wc.isFocused()`. `wc.isFocused()` returns `false` on a freshly-
attached child view even when the window is focused — exactly the
sloppy-hover state — so guarding on it would never skip.

A pass-through grace window after every `show` event (`SHOW_GRACE_MS`,
1000 ms) handles Electron's stale-`isFocused()` bug on
Cinnamon/KDE/Wayland — the same trap already addressed for KDE by
`scripts/patches/quick-window.sh`. After `hide()`, `isFocused()` can
keep returning `true` even though the WM never re-activated the
window; without the grace window a tray-restore would be silently
skipped and the window would come back visible-but-inert until
clicked.

## Scope

The guard wraps **every** Linux webContents — main, child views,
Quick Entry, About, devtools, utility processes — not just the main
window. The PR body's earlier "gated to non-popup main window" claim
was a docs lag from v1 (which had a `if (!popup)` gate that didn't
catch the child WebContentsView call site); the actual fix has to be
wide. Risk of stomping unrelated focus flows is bounded by the
grace-window logic.

## Trade-off (sloppy mode)

`webContents.focus()` wears two hats in Electron: X11 activation
(the bug) **and** renderer-focus direction. Skipping suppresses
both. So in sloppy mode, hovering over the Claude window now gives
WM focus (frame highlights, keystrokes route to our process) but
the renderer focus isn't directed to the claude.ai view until the
user clicks. Net effect: **one click per hover cycle** to start
typing, versus the constant raise that #416 reports. Documenting
this here rather than burying it — users self-selecting sloppy-focus
presumably prefer the former.

## Pre-existing issue surfaced during testing

On Cinnamon, Quick Entry submit fails to surface the main window on
attempts after the first hide → show cycle. Same root cause as the
KDE-gated patch in `scripts/patches/quick-window.sh` (stale
`isFocused()` after hide making upstream's `focusCheck() || show()`
short-circuit skip the show). **Reproduces without this PR.** Worth
a follow-up issue to widen the KDE patch to Cinnamon.

## Test plan (manual on Cinnamon 6.0 / Mint 22.3)

- [x] Sloppy mode, `auto-raise` off, hover over Claude with another
      window in front: Claude **does not raise**. (Primary bug fix.)
- [x] Sloppy mode: WM focus arrives on hover (frame highlights);
      typing into chat requires one click first — known trade-off.
- [x] Click-to-focus mode, send Claude to tray, right-click tray →
      "Show": window restores, X11 activates, first keystroke lands.
      Grace window prevents stale-`isFocused()` false-positive.
- [x] Click-to-focus mode, app launch: initial focus established
      (guard logs `PASS`, owner not yet focused).
- [x] Quick Entry first invocation works; subsequent invocations hit
      the pre-existing Cinnamon `show()` short-circuit (not this PR).

## Notes on the review

- **Scope mismatch (review point 1):** docs lag, fixed by rewriting
  the body to own the wide scope as above.
- **Timing premise (review point 2):** the regression is real — the
  click-to-focus tray-restore path *does* hit the stale-`isFocused()`
  trap on Cinnamon, captured with diagnostic logging. The grace
  window resolves it for the synchronous show → focus sequence. The
  deferred `setTimeout(() => e.webContents.focus(), 10)` site you
  flagged near `index.js:522197` (find-end / similar) is still
  vulnerable in theory — outside the grace window, with `isFocused()`
  stale-true, the call would be skipped. In practice it would only
  bite users on Cinnamon/KDE/Wayland *and* only on the brief moment
  after closing find UI; I haven't been able to reproduce a UX
  regression from it. Open to a wider guard if you'd rather see one,
  but the simplest read is "let the rare case lose renderer-focus
  re-direction for one frame; users click to recover" mirroring the
  sloppy trade-off.
- **Stray blank line (review point 3):** dropped.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
30% AI / 70% Human
Claude: Drafted patch v1→v3 and PR text; ran diagnostic builds and
log captures end-to-end.
Human: Diagnosed the root cause from first principles in #416,
filed the issue, decided on iteration strategy (force-push v2/v3
on the fork), verified each build by running the AppImage on real
Cinnamon hardware, confirmed each behaviour change visually, made
the call on the sloppy-mode trade-off being acceptable.