### PR TITLE
test: add headless launch + --doctor smoke tests for AppImage artifact

### DIFF
--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -44,7 +44,8 @@ jobs:
         if: matrix.format != 'rpm'
         run: |
           sudo apt-get update
-          sudo apt-get install -y file libfuse2 nodejs npm
+          sudo apt-get install -y file libfuse2 nodejs npm \
+            xvfb dbus-x11 procps
 
       - name: Run artifact tests
         run: |

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -97,8 +97,8 @@ resources_dir="$appdir/usr/lib/node_modules/electron/dist/resources"
 validate_app_contents "$resources_dir" "${component_id}.desktop"
 
 # --- Doctor smoke test ---
-# --doctor checks system state; some checks will fail in CI (no display,
-# etc.) but the script itself should not crash with signal or 127.
+# Some --doctor checks fail in CI (no display, etc.); we only care that
+# the script itself didn't crash via signal or exec failure (>=127).
 doctor_exit=0
 "$appimage_file" --doctor >/dev/null 2>&1 || doctor_exit=$?
 if [[ $doctor_exit -lt 127 ]]; then
@@ -108,32 +108,29 @@ else
 fi
 
 # --- Headless launch smoke test ---
-# Launch the AppImage under Xvfb and verify Electron stays alive briefly.
-# Catches startup-only regressions (e.g. asar/frame-fix-wrapper.js syntax
-# errors) that pure structure checks miss. AppRun execs electron with
-# stdout/stderr redirected to the launcher log, so on failure we tail
-# that log to surface the actual error.
+# Catches startup-only regressions (asar/frame-fix-wrapper syntax errors)
+# that pure structure checks miss.
 if command -v xvfb-run &>/dev/null \
 	&& command -v dbus-run-session &>/dev/null \
 	&& command -v setsid &>/dev/null; then
 
-	# Isolate launcher state so the test owns its own log file
+	# XDG_CACHE_HOME redirect so the test owns the launcher log.
 	cache_root=$(mktemp -d)
 	export XDG_CACHE_HOME="$cache_root"
 	launcher_log="$cache_root/claude-desktop-debian/launcher.log"
 
 	# setsid puts xvfb-run + Xvfb + dbus + AppRun + electron in a fresh
-	# process group, so a single kill -- -PGID tears the whole tree down
-	# (xvfb-run's EXIT trap alone leaves Xvfb behind on TERM).
-	# AppRun's exec redirects to launcher_log; capture xvfb-run's own
-	# stderr separately.
+	# process group; xvfb-run's EXIT trap alone leaves Xvfb behind on
+	# TERM, so we need kill -- -PGID below.
+	# AppRun redirects electron's stdout/stderr into launcher_log;
+	# xvfb_log captures xvfb-run's own stderr.
 	xvfb_log=$(mktemp)
 	setsid xvfb-run -a -s '-screen 0 1280x720x24' \
 		dbus-run-session -- "$appimage_file" \
 		>"$xvfb_log" 2>&1 &
 	launch_pid=$!
 
-	# Give Electron time to start. CI is slow; 10s is the floor.
+	# CI is slow; 10s is the floor for Electron startup.
 	sleep 10
 
 	if kill -0 "$launch_pid" 2>/dev/null; then
@@ -154,13 +151,12 @@ if command -v xvfb-run &>/dev/null \
 		fi
 	fi
 
-	# Tear down the whole process group (negative PID targets the PGID).
+	# Negative PID targets the process group.
 	kill -TERM -- "-$launch_pid" 2>/dev/null || true
 	sleep 1
 	kill -KILL -- "-$launch_pid" 2>/dev/null || true
 	wait "$launch_pid" 2>/dev/null || true
-	# Belt-and-braces sweep for any electron child still bound to this
-	# AppImage path (e.g. zygote that escaped the group).
+	# Sweep any electron child that escaped the group (e.g. zygote).
 	pkill -KILL -f "$appimage_file" 2>/dev/null || true
 
 	rm -rf "$cache_root" "$xvfb_log"

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -130,6 +130,14 @@ if command -v xvfb-run &>/dev/null \
 		>"$xvfb_log" 2>&1 &
 	launch_pid=$!
 
+	# Safety net: covers Ctrl-C, CI timeout, or any earlier `exit` so we
+	# never leak Xvfb/electron between launch and the explicit kill below.
+	trap '
+		kill -KILL -- "-$launch_pid" 2>/dev/null
+		pkill -KILL -f "$appimage_file" 2>/dev/null
+		rm -rf "$cache_root" "$xvfb_log"
+	' EXIT INT TERM
+
 	# CI is slow; 10s is the floor for Electron startup.
 	sleep 10
 
@@ -162,7 +170,10 @@ if command -v xvfb-run &>/dev/null \
 	rm -rf "$cache_root" "$xvfb_log"
 	unset XDG_CACHE_HOME
 else
-	fail "xvfb-run/dbus-run-session/setsid missing; skipping launch test"
+	# Match the codebase convention (test-artifact-common.sh
+	# validate_app_contents): tool absence is a skip, not a failure.
+	# Loud failure on missing tools belongs at the workflow layer.
+	pass "Skipping launch smoke test (xvfb-run/dbus-run-session/setsid missing)"
 fi
 
 # --- Cleanup ---

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -96,6 +96,79 @@ assert_contains "$appdir/AppRun" 'build_electron_args' \
 resources_dir="$appdir/usr/lib/node_modules/electron/dist/resources"
 validate_app_contents "$resources_dir" "${component_id}.desktop"
 
+# --- Doctor smoke test ---
+# --doctor checks system state; some checks will fail in CI (no display,
+# etc.) but the script itself should not crash with signal or 127.
+doctor_exit=0
+"$appimage_file" --doctor >/dev/null 2>&1 || doctor_exit=$?
+if [[ $doctor_exit -lt 127 ]]; then
+	pass "--doctor runs without crashing (exit: $doctor_exit)"
+else
+	fail "--doctor crashed (exit: $doctor_exit)"
+fi
+
+# --- Headless launch smoke test ---
+# Launch the AppImage under Xvfb and verify Electron stays alive briefly.
+# Catches startup-only regressions (e.g. asar/frame-fix-wrapper.js syntax
+# errors) that pure structure checks miss. AppRun execs electron with
+# stdout/stderr redirected to the launcher log, so on failure we tail
+# that log to surface the actual error.
+if command -v xvfb-run &>/dev/null \
+	&& command -v dbus-run-session &>/dev/null \
+	&& command -v setsid &>/dev/null; then
+
+	# Isolate launcher state so the test owns its own log file
+	cache_root=$(mktemp -d)
+	export XDG_CACHE_HOME="$cache_root"
+	launcher_log="$cache_root/claude-desktop-debian/launcher.log"
+
+	# setsid puts xvfb-run + Xvfb + dbus + AppRun + electron in a fresh
+	# process group, so a single kill -- -PGID tears the whole tree down
+	# (xvfb-run's EXIT trap alone leaves Xvfb behind on TERM).
+	# AppRun's exec redirects to launcher_log; capture xvfb-run's own
+	# stderr separately.
+	xvfb_log=$(mktemp)
+	setsid xvfb-run -a -s '-screen 0 1280x720x24' \
+		dbus-run-session -- "$appimage_file" \
+		>"$xvfb_log" 2>&1 &
+	launch_pid=$!
+
+	# Give Electron time to start. CI is slow; 10s is the floor.
+	sleep 10
+
+	if kill -0 "$launch_pid" 2>/dev/null; then
+		pass "AppImage stays alive under Xvfb for 10s"
+	else
+		wait "$launch_pid" 2>/dev/null
+		exit_code=$?
+		fail "AppImage exited within 10s (exit: $exit_code)"
+		if [[ -f $launcher_log ]]; then
+			echo '--- launcher.log (last 40 lines) ---' >&2
+			tail -40 "$launcher_log" >&2
+			echo '------------------------------------' >&2
+		fi
+		if [[ -s $xvfb_log ]]; then
+			echo '--- xvfb-run stderr (last 20 lines) ---' >&2
+			tail -20 "$xvfb_log" >&2
+			echo '---------------------------------------' >&2
+		fi
+	fi
+
+	# Tear down the whole process group (negative PID targets the PGID).
+	kill -TERM -- "-$launch_pid" 2>/dev/null || true
+	sleep 1
+	kill -KILL -- "-$launch_pid" 2>/dev/null || true
+	wait "$launch_pid" 2>/dev/null || true
+	# Belt-and-braces sweep for any electron child still bound to this
+	# AppImage path (e.g. zygote that escaped the group).
+	pkill -KILL -f "$appimage_file" 2>/dev/null || true
+
+	rm -rf "$cache_root" "$xvfb_log"
+	unset XDG_CACHE_HOME
+else
+	fail "xvfb-run/dbus-run-session/setsid missing; skipping launch test"
+fi
+
 # --- Cleanup ---
 rm -rf "$extract_dir"
 

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -110,6 +110,11 @@ fi
 # --- Headless launch smoke test ---
 # Catches startup-only regressions (asar/frame-fix-wrapper syntax errors)
 # that pure structure checks miss.
+#
+# Scope: main-process startup failures only. GPU/renderer-process
+# crashes (e.g. #583-class) leave the main process alive and pass
+# this check — Xvfb has no GPU, so Electron falls back to SwiftShader
+# and the GPU-crash path isn't exercised here.
 if command -v xvfb-run &>/dev/null \
 	&& command -v dbus-run-session &>/dev/null \
 	&& command -v setsid &>/dev/null; then


### PR DESCRIPTION
## Problem

The AppImage artifact test (`tests/test-artifact-appimage.sh`) only validates package **structure** — extraction, AppDir layout, asar contents, desktop entry. It never actually executes the binary, so runtime-only regressions silently pass CI:

- `frame-fix-wrapper.js` syntax errors
- asar patches that produce invalid JS
- `frame-fix-entry.js` / `package.json` `main` field mismatches
- Electron startup crashes

The `.deb` test already runs `--doctor` as a lightweight smoke check (`tests/test-artifact-deb.sh:102-111`) — but the AppImage path had no equivalent.

## Changes

**`tests/test-artifact-appimage.sh`** — adds two new checks:

1. **`--doctor` parity test** (mirrors the deb smoke test). `--doctor` short-circuits before Electron starts (`scripts/packaging/appimage.sh:79-84`), so no display is required. Exit code `< 127` confirms the launcher dispatch + `doctor.sh` sourcing didn't crash.

2. **Headless launch test under Xvfb**. Runs the AppImage via `setsid xvfb-run dbus-run-session -- ...`, sleeps 10s, verifies the process is still alive, then tears down the whole process group. On failure, tails `launcher.log` and `xvfb-run` stderr to surface the actual error.

`setsid` is load-bearing — `xvfb-run`'s EXIT trap leaves Xvfb behind when the wrapper is killed by signal; running everything in a fresh process group lets `kill -- -PGID` reap the whole tree (xvfb-run, Xvfb, dbus, AppRun, electron, zygote children). `XDG_CACHE_HOME` is redirected to a temp dir so the test owns its own `launcher.log` without polluting the runner's cache.

**`.github/workflows/test-artifacts.yml`** — adds `xvfb`, `dbus-x11`, and `procps` to the Ubuntu apt install line (`procps` for `pkill` in the teardown sweep).

## Verification

- `shellcheck -x tests/test-artifact-appimage.sh` — clean
- `actionlint .github/workflows/test-artifacts.yml` — clean
- Local run against `claude-desktop-1.5354.0-amd64.AppImage`: **34/34 pass**, including both new tests
- `pgrep` after teardown: **zero orphan processes** (Xvfb, electron, etc. all reaped)

## Test plan

- [ ] CI `Test Build Artifacts` job for `appimage` matrix entry passes on this PR
- [ ] No orphan processes / hung jobs in the runner
- [ ] Failure path is exercised at least once in CI history before merging anything that breaks Electron startup (the test will surface `launcher.log` tail on crash)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
80% AI / 20% Human
Claude: codebase audit, gap identification, test design (process-group teardown, log capture), implementation, local verification
Human: scope decision (full xvfb launch vs --doctor parity), review, direction