### PR TITLE
fix(rpm): set chrome-sandbox suid via %attr instead of %post chmod

### DIFF
--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -233,14 +233,6 @@ install -Dm 755 $staging_dir/claude-desktop %{buildroot}/usr/bin/claude-desktop
 # Update desktop database for MIME types
 update-desktop-database /usr/share/applications &> /dev/null || true
 
-# Set correct permissions for chrome-sandbox
-SANDBOX_PATH="/usr/lib/$package_name/node_modules/electron/dist/chrome-sandbox"
-if [ -f "\$SANDBOX_PATH" ]; then
-    echo "Setting chrome-sandbox permissions..."
-    chown root:root "\$SANDBOX_PATH" || echo "Warning: Failed to chown chrome-sandbox"
-    chmod 4755 "\$SANDBOX_PATH" || echo "Warning: Failed to chmod chrome-sandbox"
-fi
-
 %postun
 # Update desktop database after removal
 update-desktop-database /usr/share/applications &> /dev/null || true
@@ -248,6 +240,7 @@ update-desktop-database /usr/share/applications &> /dev/null || true
 %files
 %defattr(-, root, root, 0755)
 %attr(755, root, root) /usr/bin/claude-desktop
+%attr(4755, root, root) /usr/lib/$package_name/node_modules/electron/dist/chrome-sandbox
 /usr/lib/$package_name
 /usr/share/applications/claude-desktop.desktop
 /usr/share/icons/hicolor/*/apps/claude-desktop.png

--- a/tests/test-artifact-common.sh
+++ b/tests/test-artifact-common.sh
@@ -38,6 +38,14 @@ assert_executable() {
 	fi
 }
 
+assert_setuid() {
+	if [[ -u $1 ]]; then
+		pass "Setuid bit set: $1"
+	else
+		fail "Setuid bit not set: $1"
+	fi
+}
+
 assert_contains() {
 	local file="$1" pattern="$2" desc="${3:-}"
 	if grep -q "$pattern" "$file" 2>/dev/null; then

--- a/tests/test-artifact-rpm.sh
+++ b/tests/test-artifact-rpm.sh
@@ -41,9 +41,13 @@ electron_path='/usr/lib/claude-desktop/node_modules/electron/dist/electron'
 assert_file_exists "$electron_path"
 assert_executable "$electron_path"
 
-# chrome-sandbox
-assert_file_exists \
-	'/usr/lib/claude-desktop/node_modules/electron/dist/chrome-sandbox'
+# chrome-sandbox: setuid bit must be set by the rpm spec's %files
+# %attr(4755, ...) entry, not by a %post chmod (#539). The check
+# guards against regressing the spec to the old %post chmod pattern,
+# which leaves chrome-sandbox unsuid'd if the scriptlet is skipped.
+chrome_sandbox='/usr/lib/claude-desktop/node_modules/electron/dist/chrome-sandbox'
+assert_file_exists "$chrome_sandbox"
+assert_setuid "$chrome_sandbox"
 
 # --- Desktop entry validation ---
 desktop_file='/usr/share/applications/claude-desktop.desktop'

--- a/tests/test-artifact-rpm.sh
+++ b/tests/test-artifact-rpm.sh
@@ -43,8 +43,9 @@ assert_executable "$electron_path"
 
 # chrome-sandbox: setuid bit must be set by the rpm spec's %files
 # %attr(4755, ...) entry, not by a %post chmod (#539). The check
-# guards against regressing the spec to the old %post chmod pattern,
-# which leaves chrome-sandbox unsuid'd if the scriptlet is skipped.
+# guards against any regression that strips the suid bit — including
+# (but not limited to) reverting to a %post chmod, which silently
+# no-ops if the scriptlet is skipped (--noscripts, layered images).
 chrome_sandbox='/usr/lib/claude-desktop/node_modules/electron/dist/chrome-sandbox'
 assert_file_exists "$chrome_sandbox"
 assert_setuid "$chrome_sandbox"


### PR DESCRIPTION
## Summary

Closes #539. Move the chrome-sandbox suid bit out of the `%post` scriptlet and into the rpm spec's `%files` section via `%attr(4755, root, root)`.

The previous pattern only ran on fresh installs and silently regressed when the scriptlet was skipped (`--noscripts`, layered image builds, etc.), shipping a non-suid chrome-sandbox that breaks Electron sandboxing on every launch.

Also adds an `assert_setuid` helper to `tests/test-artifact-common.sh` and wires it up in `tests/test-artifact-rpm.sh` so a future spec regression to the old `%post` pattern fails CI rather than landing silently.

## Verification (Docker)

1. Built `.rpm` in `fedora:42` container with full build tooling.
2. Inspected rpm metadata: `rpm -qlv -p ./claude-desktop-*.rpm` shows `-rwsr-xr-x` on chrome-sandbox.
3. Confirmed `%post` no longer chmods: `rpm -q --scripts -p` shows only the `update-desktop-database` line.
4. Installed via `dnf install` in a fresh `fedora:42` container; `ls -la` and bash `[ -u <path> ]` confirm the suid bit.

## Note

`rpmbuild` emits `warning: File listed twice: /usr/lib/.../chrome-sandbox` because the file is covered by both the `/usr/lib/$package_name` directory listing and the explicit `%attr` line. This is benign — rpm uses the more specific `%attr` for the file's permissions, which is the intended behavior. The alternative (enumerating the entire `/usr/lib/$package_name` tree file-by-file in `%files`) trades the warning for a much larger and more brittle spec.

## Test plan

- [ ] CI builds rpm successfully
- [ ] `tests/test-artifact-rpm.sh` passes including the new `assert_setuid` check
- [ ] Smoke test: install via `dnf install ./claude-desktop-*.rpm` and confirm `ls -la /usr/lib/claude-desktop/.../chrome-sandbox` shows `-rwsr-xr-x`