### PR TITLE
fix(linux): no-op autoUpdater on Linux to defend against feed activation

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -120,12 +120,21 @@ const LINUX_CSS = `
 // autoUpdater no-op: every property access returns a chainable function
 // so `.on(...).once(...).setFeedURL(...).checkForUpdates()` is harmless.
 // `getFeedURL` returns '' so any code that inspects the URL gets a
-// well-typed empty string rather than undefined. Defined once and reused
-// across all require('electron') calls. Linux-only; macOS/Windows still
-// see the real autoUpdater. See #567.
+// well-typed empty string rather than undefined. `then`/`catch`/`finally`
+// and `Symbol.toPrimitive`/`Symbol.iterator` resolve to `undefined` so the
+// Proxy is not mistaken for a thenable (which would call chainNoop as
+// `then(resolve, reject)` and never resolve — silent await hang) or
+// asked to coerce to a primitive. Writes land on the target but are
+// shadowed by the get-trap. Defined once and reused across all
+// require('electron') calls. Linux-only; macOS/Windows still see the
+// real autoUpdater. See #567.
 const autoUpdaterNoop = new Proxy({}, {
   get(_target, prop) {
     if (prop === 'getFeedURL') return () => '';
+    if (prop === 'then' || prop === 'catch' || prop === 'finally'
+      || prop === Symbol.toPrimitive || prop === Symbol.iterator) {
+      return undefined;
+    }
     return function chainNoop() { return autoUpdaterNoop; };
   },
 });

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -117,6 +117,19 @@ const LINUX_CSS = `
   }
 `;
 
+// autoUpdater no-op: every property access returns a chainable function
+// so `.on(...).once(...).setFeedURL(...).checkForUpdates()` is harmless.
+// `getFeedURL` returns '' so any code that inspects the URL gets a
+// well-typed empty string rather than undefined. Defined once and reused
+// across all require('electron') calls. Linux-only; macOS/Windows still
+// see the real autoUpdater. See #567.
+const autoUpdaterNoop = new Proxy({}, {
+  get(_target, prop) {
+    if (prop === 'getFeedURL') return () => '';
+    return function chainNoop() { return autoUpdaterNoop; };
+  },
+});
+
 // Build the patched BrowserWindow class and Menu interceptor once,
 // on first require('electron'), then reuse via Proxy on every access.
 let PatchedBrowserWindow = null;
@@ -740,6 +753,23 @@ X-GNOME-Autostart-enabled=true
               return Reflect.get(menuTarget, menuProp);
             }
           });
+        }
+        if (prop === 'autoUpdater' && process.platform === 'linux') {
+          // Force autoUpdater into a no-op on Linux. Upstream's bundled
+          // app code sets a feed URL of api.anthropic.com/api/desktop/linux/...
+          // when app.isPackaged is true (we set ELECTRON_FORCE_IS_PACKAGED=true
+          // unconditionally). Today this is a happy accident: Electron's Linux
+          // autoUpdater is unimplemented and logs "AutoUpdater is not supported
+          // on Linux", so the calls no-op. If a future Electron implements it,
+          // every install would start hitting that feed and would either 404
+          // or — worse — receive content the install wasn't prepared for.
+          // .deb/.rpm/AppImage updates flow through the OS package manager
+          // (or AppImageUpdate); the Anthropic feed has no Linux artifacts.
+          // We replace the entire autoUpdater object with a Proxy that
+          // no-ops every method and returns chainable stubs for EventEmitter
+          // calls so listener registration in the bundled code is harmless.
+          // See #567.
+          return autoUpdaterNoop;
         }
         return Reflect.get(target, prop, receiver);
       }


### PR DESCRIPTION
## Summary

Closes #567. Wraps `require('electron').autoUpdater` on Linux with a Proxy that no-ops every method and returns chainable stubs for EventEmitter calls, installed via the existing `Module.prototype.require` interceptor in `frame-fix-wrapper.js`.

## Why

The bundled app's `lii()` gate sets a feed URL of `api.anthropic.com/api/desktop/linux/...` when `app.isPackaged` is true (which we set unconditionally via `ELECTRON_FORCE_IS_PACKAGED=true`), and registers update-check listeners. Today this is a happy accident: Electron's Linux `autoUpdater` is unimplemented and the calls log `"AutoUpdater is not supported on Linux"` and no-op.

If a future Electron implements Linux `autoUpdater`, every install in the wild would start hitting that feed and either 404 or — worse — receive content the install wasn't prepared for. `.deb`/`.rpm`/AppImage updates flow through the OS package manager (or AppImageUpdate); the Anthropic feed has no Linux artifacts.

This is the defensive option from the issue (Option 1) — the alternative (Option 2: gating `ELECTRON_FORCE_IS_PACKAGED` on package format) has nicer semantics but a thinner safety margin if `lii()` later checks something other than `app.isPackaged`.

## Verification (Docker)

1. Built `.deb` in `ubuntu:24.04` container.
2. Extracted shipped `frame-fix-wrapper.js` from `app.asar`; confirmed both the `autoUpdaterNoop` Proxy definition and the `prop === 'autoUpdater' && process.platform === 'linux'` intercept are present.
3. **Runtime test:** loaded the SHIPPED wrapper from the built `.deb` with a mock electron module whose `autoUpdater` records every method call. Replayed every bundled-app pattern observed in `index.js`:
   - `gA.autoUpdater.setFeedURL('https://api.anthropic.com/...')`
   - `gA.autoUpdater.on('error', ...)` / `on('update-available', ...)`
   - `gA.autoUpdater.checkForUpdates()`
   - `gA.autoUpdater.quitAndInstall()`
   - `gA.autoUpdater.getFeedURL()` (returns `''`)
   - Truthy check `A.autoUpdater && n(...)` (still passes — Proxy is truthy)
   - Chained `.on().on()` (returns the Proxy for chaining)

   **Zero real autoUpdater calls were recorded.** The Proxy intercepts every access path the bundled app uses.

## Test plan

- [ ] CI builds deb/rpm/AppImage successfully
- [ ] Smoke test: launch installed deb, confirm no `api.anthropic.com/api/desktop/linux` requests in `~/.cache/claude-desktop-debian/launcher.log` (or via tcpdump/strace)
- [ ] App still starts cleanly and update-related code paths don't throw