### PR TITLE
fix(node-pty): clean upstream Windows binaries before staging Linux build

### DIFF
--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -832,6 +832,15 @@ install_node_pty() {
 
 	if [[ -n $pty_src_dir && -d $pty_src_dir ]]; then
 		echo 'Copying node-pty JavaScript files into app.asar.contents...'
+		# Wipe the upstream-extracted node-pty before staging the Linux
+		# build. The Windows installer's app.asar ships node-pty with
+		# Windows binaries (winpty.dll, winpty-agent.exe, Windows
+		# build/Release/*.node files). `cp -r $pty_src_dir/build` only
+		# overwrites same-named files; orphan Windows binaries persist
+		# inside the asar, surface as PE32+ when users inspect with
+		# `asar list`, and pollute /tmp via Electron's lazy-extract on
+		# any spurious require() (#401).
+		rm -rf "$app_staging_dir/app.asar.contents/node_modules/node-pty"
 		mkdir -p "$app_staging_dir/app.asar.contents/node_modules/node-pty" || exit 1
 		# --no-preserve=mode so read-only bits from the Nix store
 		# (--node-pty-dir) don't propagate into the staging tree.


### PR DESCRIPTION
## Summary

Closes #401. `rm -rf` the upstream-extracted `node_modules/node-pty/` in `app.asar.contents/` before staging the locally-compiled Linux build's `lib/`, `package.json`, and `build/`.

## Why

The Windows installer's `app.asar` ships node-pty with Windows binaries — `winpty.dll`, `winpty-agent.exe`, and Windows-format `build/Release/*.node` files (`pty.node`, `conpty.node`, `conpty_console_list.node`). After upstream extraction these sit in `app.asar.contents/node_modules/node-pty/`. The existing `cp -r $pty_src_dir/build` only overwrites same-named files, so:

- Orphan Windows binaries (`winpty.dll`, `*.exe`, `conpty*.node`) persist inside the asar.
- Worse, when `npm install node-pty` silently fails (e.g., missing C build tools — the rpm CI image briefly hit this during my testing) `pty.node` itself stays as a Windows DLL. `unixTerminal.js`'s `require('../build/Release/pty.node')` then resolves through the asar to a PE32+ DLL that `dlopen()` rejects, breaking the integrated terminal with the symptoms in #401.

After this change, `app.asar` only contains Linux node-pty: lib (cross-platform JS), package.json, and a Linux-ELF `pty.node` (which `--unpack '**/*.node'` redirects to `app.asar.unpacked/`).

## Verification (Docker)

Built **both** `.deb` (in `ubuntu:24.04`) and `.rpm` (in `fedora:42` with `gcc gcc-c++ make`) and inspected the shipped artifacts:

```
$ asar list app.asar | grep node-pty/build
/node_modules/node-pty/build/binding.Makefile
/node_modules/node-pty/build/config.gypi
/node_modules/node-pty/build/Makefile
/node_modules/node-pty/build/pty.target.mk
/node_modules/node-pty/build/Release
/node_modules/node-pty/build/Release/pty.node

$ file .../app.asar.unpacked/node_modules/node-pty/build/Release/pty.node
... ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked
```

No `.dll`, `.exe`, or Windows `.node` files remain inside the asar on either format.

## Note on remaining cosmetic leftovers

`app.asar.unpacked/node_modules/node-pty/build/Release/` still contains the upstream Windows installer's `winpty.dll`, `winpty-agent.exe`, and Windows `conpty*.node` files because they came in via `cp -a` of the Windows `app.asar.unpacked/`. Linux runtime never `require()`s them (they're outside `unixTerminal.js`'s code path), so they're harmless dead weight rather than a bug. A follow-up could clean those in `finalize_app_asar` (`scripts/staging/electron.sh`) before staging Linux binaries — out of scope here.

## Latent issue surfaced during testing

When `npm install node-pty` silently fails in `install_node_pty()` (because the build env lacks gcc/make), `pty_src_dir` is left empty and the entire copy block — including this `rm -rf` — is skipped. The result is a build that uses upstream Windows binaries unchanged. The fix in this PR makes that failure mode no worse than today (the bug was pre-existing) but doesn't resolve it. Worth a separate issue/PR to either fail the build loudly when node-pty install fails, or to enforce build-tool dependencies in `check_dependencies()`.

## Test plan

- [ ] CI builds both .deb and .rpm successfully
- [ ] `asar list` on shipped `app.asar` shows no Windows artifacts
- [ ] `file` on shipped `pty.node` reports ELF
- [ ] Smoke test: open the integrated terminal in Claude Desktop on a Linux install — should spawn a shell instead of "Failed to load terminal backend"