### PR TITLE
fix(node-pty): fail loudly on npm install failure; require gcc/make/python3

### DIFF
--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -807,12 +807,27 @@ install_node_pty() {
 		echo '{"name":"node-pty-build","version":"1.0.0","private":true}' > package.json
 
 		echo 'Installing node-pty (this compiles native module)...'
-		if npm install node-pty 2>&1; then
-			echo 'node-pty installed successfully'
-			pty_src_dir="$node_pty_build_dir/node_modules/node-pty"
-		else
-			echo 'Failed to install node-pty - terminal features may not work'
+		# Fail loudly on npm install failure rather than warn-and-continue.
+		# The previous behavior silently dropped pty_src_dir, skipped the
+		# entire copy block, and shipped the upstream Windows node-pty
+		# binaries (the #401 failure mode). check_dependencies should now
+		# install gcc/g++/make/python3 before we get here, so this branch
+		# is the last line of defense for build-tool gaps that auto-install
+		# couldn't fix (unknown distro, broken package mirror, etc.).
+		if ! npm install node-pty 2>&1; then
+			echo "Error: 'npm install node-pty' failed." >&2
+			echo 'node-pty has a native module compiled via node-gyp;' >&2
+			echo 'this usually means the build environment lacks a C/C++' >&2
+			echo 'compiler, make, or python3.' >&2
+			echo '' >&2
+			echo 'Install build tools and re-run:' >&2
+			echo '  Debian/Ubuntu: sudo apt install build-essential python3' >&2
+			echo '  Fedora/RHEL:   sudo dnf install gcc gcc-c++ make python3' >&2
+			cd "$project_root" || exit 1
+			exit 1
 		fi
+		echo 'node-pty installed successfully'
+		pty_src_dir="$node_pty_build_dir/node_modules/node-pty"
 	fi
 
 	if [[ -n $pty_src_dir && -d $pty_src_dir ]]; then

--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -48,19 +48,24 @@ check_dependencies() {
 		[make]='make' [python3]='python3'
 	)
 
-	local cmd
+	local cmd pkg
 	for cmd in $all_deps; do
 		if ! check_command "$cmd"; then
 			case "$distro_family" in
-				debian)
-					deps_to_install="$deps_to_install ${debian_pkgs[$cmd]}"
-					;;
-				rpm)
-					deps_to_install="$deps_to_install ${rpm_pkgs[$cmd]}"
-					;;
+				debian) pkg="${debian_pkgs[$cmd]}" ;;
+				rpm)    pkg="${rpm_pkgs[$cmd]}" ;;
 				*)
 					echo "Warning: Cannot auto-install '$cmd' on unknown distro. Please install manually." >&2
+					continue
 					;;
+			esac
+			# Several commands map to the same package (gcc/g++/make
+			# -> build-essential, wrestool/icotool -> icoutils). Skip
+			# if the package is already queued so the log line stays
+			# readable.
+			case " $deps_to_install " in
+				*" $pkg "*) ;;
+				*) deps_to_install="$deps_to_install $pkg" ;;
 			esac
 		fi
 	done

--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -22,16 +22,30 @@ check_dependencies() {
 		rpm) all_deps="$all_deps rpmbuild" ;;
 	esac
 
+	# node-pty has a native C++ module compiled via node-gyp during
+	# `npm install`. Without gcc/g++/make/python3 the install silently
+	# emits a warning, leaves pty_src_dir empty, and the build ends up
+	# shipping the upstream Windows binaries (the #401 failure mode).
+	# Skip when --node-pty-dir is set (Nix and explicit overrides bring
+	# their own pre-built node-pty).
+	if [[ -z ${node_pty_dir:-} ]]; then
+		all_deps="$all_deps gcc g++ make python3"
+	fi
+
 	# Command-to-package mappings per distro family
 	declare -A debian_pkgs=(
 		[p7zip]='p7zip-full' [wget]='wget' [wrestool]='icoutils'
 		[icotool]='icoutils' [convert]='imagemagick'
 		[dpkg-deb]='dpkg-dev' [rpmbuild]='rpm'
+		[gcc]='build-essential' [g++]='build-essential'
+		[make]='build-essential' [python3]='python3'
 	)
 	declare -A rpm_pkgs=(
 		[p7zip]='p7zip p7zip-plugins' [wget]='wget' [wrestool]='icoutils'
 		[icotool]='icoutils' [convert]='ImageMagick'
 		[dpkg-deb]='dpkg' [rpmbuild]='rpm-build'
+		[gcc]='gcc' [g++]='gcc-c++'
+		[make]='make' [python3]='python3'
 	)
 
 	local cmd


### PR DESCRIPTION
## Summary

Refs #401. Closes the silent-failure path surfaced during PR #597's testing — when `npm install node-pty` fails (most often because the build env lacks gcc/g++/make/python3 for node-gyp), the build silently leaves `pty_src_dir` empty, skips the entire copy block (including PR #597's `rm -rf`), and ships the upstream Windows node-pty binaries unchanged. That's exactly the #401 failure mode this catches in two layers.

## Changes

1. **`scripts/patches/cowork.sh`** — `install_node_pty()`: when `npm install node-pty` exits non-zero, abort the build with an explicit error message naming the likely cause (missing toolchain) and the per-distro fix command:

   ```
   Error: 'npm install node-pty' failed.
   node-pty has a native module compiled via node-gyp;
   this usually means the build environment lacks a C/C++
   compiler, make, or python3.

   Install build tools and re-run:
     Debian/Ubuntu: sudo apt install build-essential python3
     Fedora/RHEL:   sudo dnf install gcc gcc-c++ make python3
   ```

2. **`scripts/setup/dependencies.sh`** — `check_dependencies()`: add `gcc`, `g++`, `make`, `python3` to the dep check (mapped to `build-essential` on Debian, `gcc`/`gcc-c++`/`make`/`python3` on Fedora) so the build env is auto-provisioned before `install_node_pty` runs. Skipped when `--node-pty-dir` is set (Nix and explicit overrides bring their own pre-built node-pty).

Together: the dep check makes the failure rare; the abort makes the rare failure obvious instead of silent.

## Verification (Docker)

**Test 1 — fail-loudly behavior (isolated):** forced `npm` to a fake binary that prints "fake compile failure" and exits 1, called `install_node_pty` with `node_pty_dir` unset, captured exit code and stderr.

```
exit_code=1 (expect: 1)
captured stderr contains "'npm install node-pty' failed."
captured stderr contains "build-essential"  (Debian hint)
captured stderr contains "gcc gcc-c++ make"  (Fedora hint)
copy block did NOT run (no node-pty in app.asar.contents)
PASS: install_node_pty exits 1 loudly when npm install fails
```

**Test 2 — full deb build, minimal Ubuntu:** ran `./build.sh --build deb --clean no` in an `ubuntu:24.04` container that started with **no** pre-installed compilers (only `ca-certificates`, `wget`, `sudo`, `nodejs`, `npm`). The new `check_dependencies` detected the gap and ran `apt install ... build-essential` automatically. `npm install node-pty` subsequently compiled cleanly. The shipped `pty.node` is `ELF 64-bit LSB shared object, x86-64`.

## Relation to PR #597

Independent and complementary. #597 cleans the upstream Windows binaries from the staging tree; this PR makes sure that cleaning code path actually runs (by failing the build instead of skipping the copy block when npm install fails) and reduces the chance of failure (by auto-installing build tools). Either order of merge is fine — this PR doesn't depend on #597 landing first, and vice versa.

## Test plan

- [ ] CI deb/rpm/AppImage builds succeed (the new dep check should be a no-op since CI images already have build tools)
- [ ] On a minimal user environment (Debian/Fedora minimal) without compilers, `./build.sh` should auto-install `build-essential` (or Fedora equivalent) without manual intervention
- [ ] If `npm install node-pty` ever fails for some other reason, the build should now exit with a clear error rather than silently shipping a broken artifact