### PR TITLE
ci: add concurrency group to test-flags workflow

### DIFF
--- a/.github/workflows/test-flags.yml
+++ b/.github/workflows/test-flags.yml
@@ -4,6 +4,12 @@ on:
   workflow_call: # Make this workflow reusable
   workflow_dispatch: # Allows manual triggering for testing
 
+concurrency:
+  group: test-flags-${{ github.ref }}
+  # Matches ci.yml: queue rather than cancel, so a reusable invocation
+  # from an in-flight CI run isn't killed mid-flight on the next push.
+  cancel-in-progress: false
+
 jobs:
   test-flags:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a per-ref concurrency group to `.github/workflows/test-flags.yml`
- `cancel-in-progress: false` to match `ci.yml`'s release-safe posture, so a `workflow_call` invocation inside an in-flight CI run isn't killed when a subsequent push lands

## Why
`test-flags.yml` had no concurrency group, so direct `workflow_dispatch` invocations against the same ref would run in parallel. `tests.yml` already follows this pattern (`bats-${{ github.ref }}`); `test-flags.yml` was the only test workflow missing one.

The cancel posture (`false`) is deliberate: a reusable workflow's inner concurrency overrides the caller's. With `cancel-in-progress: true`, pushing to a branch while CI is running its `test-flags` step would cancel that step mid-flight, surfacing as a confusing CI failure. Queuing matches what `ci.yml` already does.

## Test plan
- [x] `actionlint .github/workflows/test-flags.yml` passes
- [x] All 9 `./build.sh --test-flags` cases run locally (9/9 pass)
- [ ] CI green on this PR
- [ ] Verify manual `gh workflow run "Test Build Script Flags (Reusable)"` shows the concurrency group in the run summary