### PR TITLE
fix(rpm): silence "File listed twice" warning on chrome-sandbox

### DIFF
--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -229,6 +229,11 @@ install -Dm 644 $staging_dir/claude-desktop.desktop %{buildroot}/usr/share/appli
 # Install launcher script
 install -Dm 755 $staging_dir/claude-desktop %{buildroot}/usr/bin/claude-desktop
 
+# Set the chrome-sandbox suid bit in the buildroot so the /usr/lib
+# directory walk in %files records 4755 in the payload (preserves #539
+# without the "File listed twice" warning #609 — see %files block).
+chmod 4755 %{buildroot}/usr/lib/$package_name/node_modules/electron/dist/chrome-sandbox
+
 %post
 # Update desktop database for MIME types
 update-desktop-database /usr/share/applications &> /dev/null || true
@@ -240,7 +245,6 @@ update-desktop-database /usr/share/applications &> /dev/null || true
 %files
 %defattr(-, root, root, 0755)
 %attr(755, root, root) /usr/bin/claude-desktop
-%attr(4755, root, root) /usr/lib/$package_name/node_modules/electron/dist/chrome-sandbox
 /usr/lib/$package_name
 /usr/share/applications/claude-desktop.desktop
 /usr/share/icons/hicolor/*/apps/claude-desktop.png
@@ -251,11 +255,25 @@ echo 'RPM spec file created'
 # --- Build RPM Package ---
 echo 'Building RPM package...'
 
-if ! rpmbuild --define "_topdir $rpmbuild_dir" \
+rpmbuild_log="$work_dir/rpmbuild.log"
+rpmbuild_status=0
+rpmbuild --define "_topdir $rpmbuild_dir" \
 	--define "_rpmdir $work_dir" \
 	--target "$rpm_arch" \
-	-bb "$rpmbuild_dir/SPECS/$package_name.spec"; then
+	-bb "$rpmbuild_dir/SPECS/$package_name.spec" 2>&1 |
+	tee "$rpmbuild_log"
+rpmbuild_status=${PIPESTATUS[0]}
+if (( rpmbuild_status != 0 )); then
 	echo 'Failed to build RPM package' >&2
+	exit 1
+fi
+
+# Guard against re-introducing #609: an overlap between %attr and the
+# parent dir glob emits this warning, and on modern rpmbuild it can
+# silently strip the file from the payload when %exclude is reached for.
+if grep -qF 'File listed twice' "$rpmbuild_log"; then
+	echo 'rpmbuild emitted "File listed twice" — %files has overlapping listings (see #609)' >&2
+	grep -F 'File listed twice' "$rpmbuild_log" >&2
 	exit 1
 fi
 

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -256,21 +256,19 @@ echo 'RPM spec file created'
 echo 'Building RPM package...'
 
 rpmbuild_log="$work_dir/rpmbuild.log"
-rpmbuild_status=0
 rpmbuild --define "_topdir $rpmbuild_dir" \
 	--define "_rpmdir $work_dir" \
 	--target "$rpm_arch" \
 	-bb "$rpmbuild_dir/SPECS/$package_name.spec" 2>&1 |
 	tee "$rpmbuild_log"
-rpmbuild_status=${PIPESTATUS[0]}
-if (( rpmbuild_status != 0 )); then
+if (( ${PIPESTATUS[0]} != 0 )); then
 	echo 'Failed to build RPM package' >&2
 	exit 1
 fi
 
-# Guard against re-introducing #609: an overlap between %attr and the
-# parent dir glob emits this warning, and on modern rpmbuild it can
-# silently strip the file from the payload when %exclude is reached for.
+# Guard against re-introducing #609. The "File listed twice" warning
+# means %files has overlapping listings, and on modern rpmbuild any
+# %exclude workaround silently strips the file from the payload.
 if grep -qF 'File listed twice' "$rpmbuild_log"; then
 	echo 'rpmbuild emitted "File listed twice" — %files has overlapping listings (see #609)' >&2
 	grep -F 'File listed twice' "$rpmbuild_log" >&2

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -261,7 +261,7 @@ rpmbuild --define "_topdir $rpmbuild_dir" \
 	--target "$rpm_arch" \
 	-bb "$rpmbuild_dir/SPECS/$package_name.spec" 2>&1 |
 	tee "$rpmbuild_log"
-if (( ${PIPESTATUS[0]} != 0 )); then
+if (( PIPESTATUS[0] != 0 )); then
 	echo 'Failed to build RPM package' >&2
 	exit 1
 fi


### PR DESCRIPTION
## Summary

Closes #609. Drops the explicit `%attr(4755, ...)` line on chrome-sandbox from `%files` and instead bakes the suid bit into the buildroot in `%install`, so the directory walk under `/usr/lib/$package_name` picks up the correct mode without `%files` claiming chrome-sandbox twice.

The warning was introduced in #595 — the fix for #539 — which added `%attr(4755, ...)` to bake suid into the rpm payload. Combined with the existing bare-dir listing, that produced:

```
warning: File listed twice: /usr/lib/claude-desktop/node_modules/electron/dist/chrome-sandbox
```

on every `rpmbuild` invocation.

## Why this shape

I tested four `%files` restructurings against a minimal spec on `fedora:42` and `rockylinux:9` to find a shape that silences the warning **and** keeps chrome-sandbox in the payload with suid:

| Shape | Warning? | In package? | Suid? |
|---|---|---|---|
| `%attr` + bare dir (current) | yes | yes | yes |
| `%attr` + `%exclude` + bare dir (bot draft on #609) | none | **no** | n/a |
| bare dir + `%exclude` + `%attr` (Slack/Spotify ordering) | none | **no** | n/a |
| `%attr` + bare dir + `%exclude` | yes | **no** | n/a |
| chmod 4755 in `%install`, drop `%attr` (this PR) | **none** | **yes** | **yes** |

On modern `rpmbuild`, `%exclude` is absolute — once a path is excluded, no later `%attr` line resurrects it. The chmod-in-`%install` shape is the only one I found that preserves the #539 fix and silences the warning.

## Regression guard

Captures `rpmbuild` output and fails the build if `File listed twice` appears, so any future overlap between `%files` and `%attr` surfaces at build time instead of becoming background noise. Complements `assert_setuid` in `tests/test-artifact-rpm.sh`, which catches the opposite regression (suid bit lost).

## Verification (Docker)

Ran `./build.sh --build rpm` inside `fedora:42` mirroring CI:

- `rpmbuild` log: no `File listed twice` warning, no other new warnings
- `rpm -qlvp claude-desktop-1.7196.0-1.x86_64.rpm | grep chrome-sandbox`:
  ```
  -rwsr-xr-x  1 root root 15248 May 14 11:49 /usr/lib/claude-desktop/.../chrome-sandbox
  ```
- `rpm -ivh --nodeps`; `ls -la` shows `-rwsr-xr-x root root` on disk

## Test plan

- [ ] CI builds rpm successfully on amd64 and arm64
- [ ] `tests/test-artifact-rpm.sh` `assert_setuid` still passes
- [ ] CI rpmbuild log no longer contains `File listed twice`

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
20% AI / 80% Human
Claude: empirical %exclude semantics testing on fedora:42 and rockylinux:9, draft patch, Docker build verification, regression-guard wiring
Human: directed the investigation, validated the shape selection, reviewed and trimmed comments