### PR TITLE
fix(launcher): inject --password-store before app path, probe keyring at startup

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #===============================================================================
 # Doctor Diagnostics
 #
@@ -555,6 +556,28 @@ _doctor_check_recent_crashes() {
 	fi
 }
 
+# Report the active Chromium password-store backend.
+#
+# Calls _detect_password_store() (defined in launcher-common.sh, which
+# sources this file) to surface what keyring Electron will use for
+# safeStorage / cookie encryption. 'basic' is valid but means tokens
+# rely on filesystem permissions alone, so we note it for visibility.
+# Never fails — basic is an intentional fallback, not an error.
+_doctor_check_password_store() {
+	local store
+	store=$(_detect_password_store)
+	_pass "Password store: $store"
+	if [[ $store == 'basic' ]]; then
+		_info \
+			'  → using fixed-key fallback;' \
+			'tokens are protected by filesystem permissions only'
+	fi
+	if [[ -n ${CLAUDE_PASSWORD_STORE:-} ]]; then
+		_info \
+			"  → overridden by CLAUDE_PASSWORD_STORE=${CLAUDE_PASSWORD_STORE}"
+	fi
+}
+
 # Run all diagnostic checks and print results
 # Arguments: $1 = electron path (optional, for package-specific checks)
 run_doctor() {
@@ -726,6 +749,9 @@ run_doctor() {
 	else
 		_pass 'SingletonLock: no lock file (OK)'
 	fi
+
+	# -- Password store --
+	_doctor_check_password_store
 
 	# -- MCP config --
 	local mcp_config="$config_dir/claude_desktop_config.json"

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -128,7 +128,7 @@ _detect_password_store() {
 	fi
 
 	# kwallet6: KDE Plasma 6 keyring
-	if dbus-send --session --print-reply \
+	if dbus-send --session --print-reply --reply-timeout=1000 \
 		--dest=org.kde.kwalletd6 \
 		/modules/kwalletd6 \
 		org.kde.KWallet.isEnabled 2>/dev/null \
@@ -139,10 +139,10 @@ _detect_password_store() {
 	fi
 
 	# gnome-libsecret: GNOME Keyring, KWallet 5 compat bridge, etc.
-	if dbus-send --session \
+	if dbus-send --session --print-reply --reply-timeout=1000 \
 		--dest=org.freedesktop.secrets \
 		/org/freedesktop/secrets \
-		org.freedesktop.DBus.Peer.Ping 2>/dev/null
+		org.freedesktop.DBus.Peer.Ping >/dev/null 2>&1
 	then
 		echo 'gnome-libsecret'
 		return

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -42,6 +42,7 @@ log_session_env() {
 		QT_IM_MODULE \
 		CLAUDE_USE_WAYLAND \
 		CLAUDE_TITLEBAR_STYLE \
+		CLAUDE_PASSWORD_STORE \
 		CLAUDE_GTK_IM_MODULE \
 		CLAUDE_DISABLE_GPU
 	do
@@ -101,6 +102,56 @@ _resolve_titlebar_style() {
 	esac
 }
 
+# Determine the best available Chromium password-store backend.
+#
+# Electron's safeStorage API and Chromium's cookie encryption both rely
+# on the OS credential store selected by --password-store. Without a
+# working store safeStorage.isEncryptionAvailable() returns false, OAuth
+# tokens are silently discarded on exit, and users must re-authenticate
+# on every launch (Cookies file stays 0 bytes). Fixes: #593
+#
+# Detection order (first match wins):
+#   CLAUDE_PASSWORD_STORE env var  — explicit user override
+#   kwallet6                        — KDE Plasma 6 keyring
+#   gnome-libsecret                 — GNOME Keyring / libsecret bridge
+#   basic                           — fixed internal key (always works)
+#
+# With 'basic' the stored data is encrypted with a fixed key. Tokens
+# remain protected by Linux filesystem permissions on ~/.config/Claude/.
+#
+# Assumes a D-Bus session bus is available; this is true for any
+# graphical login session.
+_detect_password_store() {
+	if [[ -n ${CLAUDE_PASSWORD_STORE:-} ]]; then
+		echo "$CLAUDE_PASSWORD_STORE"
+		return
+	fi
+
+	# kwallet6: KDE Plasma 6 keyring
+	if dbus-send --session --print-reply \
+		--dest=org.kde.kwalletd6 \
+		/modules/kwalletd6 \
+		org.kde.KWallet.isEnabled 2>/dev/null \
+		| grep -q 'boolean true'
+	then
+		echo 'kwallet6'
+		return
+	fi
+
+	# gnome-libsecret: GNOME Keyring, KWallet 5 compat bridge, etc.
+	if dbus-send --session \
+		--dest=org.freedesktop.secrets \
+		/org/freedesktop/secrets \
+		org.freedesktop.DBus.Peer.Ping 2>/dev/null
+	then
+		echo 'gnome-libsecret'
+		return
+	fi
+
+	# No keyring accessible — fall back to fixed-key provider.
+	echo 'basic'
+}
+
 # Build Electron arguments array based on display backend
 # Requires: is_wayland, use_x11_on_wayland to be set
 #           (call detect_display_backend first)
@@ -129,6 +180,19 @@ build_electron_args() {
 	else
 		electron_args+=('--disable-features=CustomTitlebar')
 	fi
+
+	# Chromium's safeStorage API and cookie encryption both require a
+	# system keyring selected by --password-store. Without an explicit
+	# value, Electron may silently report encryption unavailable even
+	# when a keyring daemon is running, discarding OAuth tokens on exit
+	# and forcing re-authentication on every launch. We probe for the
+	# best available store at startup and pass it before the app path
+	# so Chromium treats it as a Chromium flag (args after the app
+	# path go to the renderer, not Chromium). Fixes: #593
+	local pw_store
+	pw_store=$(_detect_password_store)
+	electron_args+=("--password-store=${pw_store}")
+	log_message "Password store: ${pw_store}"
 
 	# Remote XRDP sessions lack GPU acceleration and render a blank
 	# window when GPU compositing is enabled. Detect via XRDP_SESSION

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -22,6 +22,7 @@ setup() {
 	unset CLAUDE_USE_WAYLAND
 	unset GTK_IM_MODULE
 	unset CLAUDE_GTK_IM_MODULE
+	unset CLAUDE_PASSWORD_STORE
 
 	# shellcheck source=scripts/doctor.sh
 	source "$SCRIPT_DIR/../scripts/doctor.sh"
@@ -33,6 +34,11 @@ setup() {
 	# to stub it unless they're exercising the package-check branch.
 	# Override in-test for rc=0 (installed) or rc=1 (missing).
 	_pkg_installed() { return 2; }
+
+	# Default stub for _detect_password_store (defined in
+	# launcher-common.sh, not sourced here). Tests that exercise
+	# _doctor_check_password_store override this in-test if needed.
+	_detect_password_store() { echo 'basic'; }
 }
 
 teardown() {
@@ -423,4 +429,17 @@ SHIM
 	[[ $output == *'NAME_MAX=143'* ]]
 	[[ $output != *'eCryptfs'* ]]
 	[[ $output != *'LUKS'* ]]
+}
+
+# =============================================================================
+# _doctor_check_password_store
+# =============================================================================
+
+@test "_doctor_check_password_store: output contains 'Password store:' with a valid backend" {
+	# setup() already stubs _detect_password_store to return 'basic'.
+	run _doctor_check_password_store
+	[[ $status -eq 0 ]]
+	[[ $output == *'[PASS]'* ]]
+	[[ $output == *'Password store:'* ]]
+	[[ $output == *'basic'* ]]
 }

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -74,6 +74,7 @@ setup() {
 	unset QT_IM_MODULE
 	unset CLAUDE_GTK_IM_MODULE
 	unset CLAUDE_PASSWORD_STORE
+	CLAUDE_PASSWORD_STORE='basic'
 
 	# shellcheck source=scripts/launcher-common.sh
 	source "$SCRIPT_DIR/../scripts/launcher-common.sh"
@@ -165,6 +166,7 @@ teardown() {
 	# All vars unset by setup() except this one, which exercises the
 	# empty-string branch (must be indistinguishable from unset).
 	GTK_IM_MODULE=''
+	unset CLAUDE_PASSWORD_STORE
 	log_session_env
 
 	run cat "$log_file"
@@ -742,6 +744,7 @@ s.close()
 }
 
 @test "_detect_password_store: falls back to kwallet6 when kwallet6 dbus-send call succeeds" {
+	unset CLAUDE_PASSWORD_STORE
 	_stub_dbus_send kwallet6
 	run _detect_password_store
 	[[ $status -eq 0 ]]
@@ -749,6 +752,7 @@ s.close()
 }
 
 @test "_detect_password_store: falls back to gnome-libsecret when kwallet6 fails but secrets ping succeeds" {
+	unset CLAUDE_PASSWORD_STORE
 	_stub_dbus_send secrets-ok
 	run _detect_password_store
 	[[ $status -eq 0 ]]
@@ -756,6 +760,7 @@ s.close()
 }
 
 @test "_detect_password_store: falls back to basic when both dbus-send calls fail" {
+	unset CLAUDE_PASSWORD_STORE
 	_stub_dbus_send fail
 	run _detect_password_store
 	[[ $status -eq 0 ]]

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -18,6 +18,35 @@ has_electron_arg() {
 	return 1
 }
 
+# Install a dbus-send stub at the front of PATH.
+#   kwallet6   — echoes 'boolean true', exits 0 (kwallet6 detectable)
+#   secrets-ok — fails for kwalletd6 dest, succeeds for all other dests
+#   fail       — always exits 1 with no output (no keyring accessible)
+_stub_dbus_send() {
+	mkdir -p "$TEST_TMP/bin"
+	case "${1:-fail}" in
+		kwallet6)
+			cat > "$TEST_TMP/bin/dbus-send" <<'STUB'
+#!/usr/bin/env bash
+echo 'boolean true'
+STUB
+			;;
+		secrets-ok)
+			cat > "$TEST_TMP/bin/dbus-send" <<'STUB'
+#!/usr/bin/env bash
+[[ "$*" == *kwalletd6* ]] && exit 1
+exit 0
+STUB
+			;;
+		*)
+			printf '#!/usr/bin/env bash\nexit 1\n' \
+				> "$TEST_TMP/bin/dbus-send"
+			;;
+	esac
+	chmod +x "$TEST_TMP/bin/dbus-send"
+	export PATH="$TEST_TMP/bin:$PATH"
+}
+
 setup() {
 	TEST_TMP=$(mktemp -d)
 	export TEST_TMP
@@ -44,6 +73,7 @@ setup() {
 	unset XMODIFIERS
 	unset QT_IM_MODULE
 	unset CLAUDE_GTK_IM_MODULE
+	unset CLAUDE_PASSWORD_STORE
 
 	# shellcheck source=scripts/launcher-common.sh
 	source "$SCRIPT_DIR/../scripts/launcher-common.sh"
@@ -106,6 +136,7 @@ teardown() {
 	QT_IM_MODULE='ibus'
 	CLAUDE_USE_WAYLAND='1'
 	CLAUDE_TITLEBAR_STYLE='hybrid'
+	CLAUDE_PASSWORD_STORE='basic'
 	CLAUDE_GTK_IM_MODULE='xim'
 	CLAUDE_DISABLE_GPU='1'
 	log_session_env
@@ -123,9 +154,10 @@ teardown() {
 	[[ "${lines[7]}"  == '  QT_IM_MODULE=ibus' ]]
 	[[ "${lines[8]}"  == '  CLAUDE_USE_WAYLAND=1' ]]
 	[[ "${lines[9]}"  == '  CLAUDE_TITLEBAR_STYLE=hybrid' ]]
-	[[ "${lines[10]}" == '  CLAUDE_GTK_IM_MODULE=xim' ]]
-	[[ "${lines[11]}" == '  CLAUDE_DISABLE_GPU=1' ]]
-	[[ "${lines[12]}" == '}' ]]
+	[[ "${lines[10]}" == '  CLAUDE_PASSWORD_STORE=basic' ]]
+	[[ "${lines[11]}" == '  CLAUDE_GTK_IM_MODULE=xim' ]]
+	[[ "${lines[12]}" == '  CLAUDE_DISABLE_GPU=1' ]]
+	[[ "${lines[13]}" == '}' ]]
 }
 
 @test "log_session_env: unset/empty values render as 'KEY=' (no value)" {
@@ -147,8 +179,9 @@ teardown() {
 	[[ "${lines[7]}"  == '  QT_IM_MODULE=' ]]
 	[[ "${lines[8]}"  == '  CLAUDE_USE_WAYLAND=' ]]
 	[[ "${lines[9]}"  == '  CLAUDE_TITLEBAR_STYLE=' ]]
-	[[ "${lines[10]}" == '  CLAUDE_GTK_IM_MODULE=' ]]
-	[[ "${lines[11]}" == '  CLAUDE_DISABLE_GPU=' ]]
+	[[ "${lines[10]}" == '  CLAUDE_PASSWORD_STORE=' ]]
+	[[ "${lines[11]}" == '  CLAUDE_GTK_IM_MODULE=' ]]
+	[[ "${lines[12]}" == '  CLAUDE_DISABLE_GPU=' ]]
 }
 
 # =============================================================================
@@ -693,4 +726,38 @@ s.close()
 	local result
 	result=$(_electron_version "$TEST_TMP/electron/electron") || true
 	[[ -z $result ]]
+}
+
+# =============================================================================
+# _detect_password_store
+# =============================================================================
+
+@test "_detect_password_store: CLAUDE_PASSWORD_STORE env var wins without calling dbus-send" {
+	CLAUDE_PASSWORD_STORE='mystore'
+	# Stub dbus-send to fail — the early-return path must not reach it.
+	_stub_dbus_send fail
+	run _detect_password_store
+	[[ $status -eq 0 ]]
+	[[ $output == 'mystore' ]]
+}
+
+@test "_detect_password_store: falls back to kwallet6 when kwallet6 dbus-send call succeeds" {
+	_stub_dbus_send kwallet6
+	run _detect_password_store
+	[[ $status -eq 0 ]]
+	[[ $output == 'kwallet6' ]]
+}
+
+@test "_detect_password_store: falls back to gnome-libsecret when kwallet6 fails but secrets ping succeeds" {
+	_stub_dbus_send secrets-ok
+	run _detect_password_store
+	[[ $status -eq 0 ]]
+	[[ $output == 'gnome-libsecret' ]]
+}
+
+@test "_detect_password_store: falls back to basic when both dbus-send calls fail" {
+	_stub_dbus_send fail
+	run _detect_password_store
+	[[ $status -eq 0 ]]
+	[[ $output == 'basic' ]]
 }


### PR DESCRIPTION
## Problem

On KDE Plasma and other desktops with a running keyring daemon,
`safeStorage.isEncryptionAvailable()` was returning false, causing OAuth
tokens to be silently discarded on exit. The Cookies file stayed at 0 bytes
and users had to re-authenticate on every launch.

Root cause: `--password-store` was being injected *after* `app.asar` in the
Electron exec call. Electron passes post-app-path arguments to the renderer,
not to Chromium — so the flag was silently ignored and Chromium fell back to
an unusable store.

Fixes #593 (password-store half — rendering investigation tracked separately)

## Changes

**`scripts/launcher-common.sh`**
- Add `_detect_password_store()`: probes D-Bus at startup and returns the
  best available backend (kwallet6 → gnome-libsecret → basic fallback)
- Respect `CLAUDE_PASSWORD_STORE` env var for explicit user override
- Inject `--password-store=VALUE` before `app.asar` in `build_electron_args()`
  so Chromium treats it as a browser flag
- Add `CLAUDE_PASSWORD_STORE` to `log_session_env` for diagnostic reports (#548)

**`scripts/doctor.sh`**
- Add `_doctor_check_password_store()`: surfaces the resolved backend in
  `--doctor` output between SingletonLock and MCP config checks
- Notes when `CLAUDE_PASSWORD_STORE` override is active
- Notes when falling back to `basic` (fixed-key, filesystem-permission-protected)

**`tests/launcher-common.bats` / `tests/doctor.bats`**
- 4 cases for `_detect_password_store` fallback chain
- 1 case for `_doctor_check_password_store` output
- Updated `log_session_env` tests for new key position

## Testing

All existing bats tests pass. New tests added and passing:

- `_detect_password_store`: CLAUDE_PASSWORD_STORE wins without calling dbus-send
- `_detect_password_store`: falls back to kwallet6 when kwallet6 probe succeeds
- `_detect_password_store`: falls back to gnome-libsecret when kwallet6 fails
- `_detect_password_store`: falls back to basic when both dbus-send calls fail
- `_doctor_check_password_store`: output contains backend name

Verified on Fedora 44 KDE Plasma — kwallet6 detected correctly, session
persists across restarts.