### PR TITLE
feat(doctor): flag eCryptfs short NAME_MAX + workaround doc (#590)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ Special thanks to:
   - `autoUpdater` no-op Proxy on Linux that defends against future feed activation, with a thenable allowlist masking `then`/`catch`/`finally`/`Symbol.toPrimitive`/`Symbol.iterator` to `undefined` (#567)
   - Failing loudly on `npm install node-pty` failures instead of silently shipping the upstream Windows binaries, plus auto-installing `gcc`/`g++`/`make`/`python3` on minimal build environments (#401)
 - **[Hayao0819](https://github.com/Hayao0819)** for diagnosing the upstream `titleBarStyle:""` → `titleBarStyle:"hiddenInset"` migration that broke the About window render on GNOME/X11 and contributing the `isPopupWindow()` match extension (#481, #489)
+- **[michelsfun](https://github.com/michelsfun)** for reporting the cowork `ENAMETOOLONG` failure on eCryptfs-encrypted home directories with detailed `--doctor` output that pinpointed the short-NAME_MAX filesystem as the cause (#590)
+- **[proffalken](https://github.com/proffalken)** for the LUKS-volume + `pam_mount` workaround documented in `TROUBLESHOOTING.md`, restoring cowork support on legacy eCryptfs-encrypted home directories (#590)
 
 ## Sponsorship
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -290,14 +290,22 @@ ln -s /mnt/claude-secure/Claude-config ~/.config/Claude
 ln -s /mnt/claude-secure/claude-cache ~/.cache/claude-desktop-debian
 ln -s /mnt/claude-secure/claude-home ~/.claude
 
-# 3. Verify the filename limit
+# 3. Verify the filename limit and the symlinks
 getconf NAME_MAX /mnt/claude-secure   # should print 255
+mountpoint /mnt/claude-secure         # confirms the volume is mounted
+readlink ~/.claude                    # /mnt/claude-secure/claude-home
+readlink ~/.config/Claude             # /mnt/claude-secure/Claude-config
 ```
 
+**If you've set `CLAUDE_CONFIG_DIR`** (or otherwise reconfigured
+Claude Code to use a directory other than `~/.claude/`), the
+`~/.claude` symlink above doesn't apply — adapt the path to wherever
+your Claude Code config actually lives. The constraint is the same:
+the directory tree where Claude Code creates per-session project
+dirs must sit on a filesystem with `NAME_MAX` ≥ ~200.
+
 **Auto-mount at login** with `pam_mount` so the volume unlocks
-transparently each session without a manual `cryptsetup open`. If
-your login password matches the LUKS passphrase, the unlock is
-silent:
+without a manual `cryptsetup open`:
 
 ```bash
 sudo apt install libpam-mount
@@ -318,8 +326,19 @@ Add a `<volume>` entry to `/etc/security/pam_mount.conf.xml`
 
 **Notes:**
 - Tested on Linux Mint with LightDM as the display manager.
-- The LUKS passphrase must match your login password for the
-  transparent unlock to work.
+- **LUKS passphrase tradeoff:** for `pam_mount` to unlock silently
+  at login the LUKS passphrase must match your login password. That
+  means one compromise unlocks both your session and the encrypted
+  volume — equivalent to the threat surface eCryptfs already had,
+  but worth a deliberate choice. Use a distinct LUKS passphrase if
+  you'd rather be prompted on each unlock.
+- **Confidentiality posture vs eCryptfs.** The LUKS image lives at
+  `/opt/claude-secure.img`, outside `$HOME` and outside whatever
+  encryption envelope eCryptfs gives you. If `pam_mount` ever fails
+  silently — wrong passphrase, mount race at login, profile error —
+  Claude won't start (the symlink targets won't exist), so writes
+  fail loudly rather than landing on plaintext disk. Verify with
+  `mountpoint /mnt/claude-secure` after login if you're unsure.
 - 2 GB is a conservative starting size; the Claude config
   directory can exceed 500 MB once cowork session history
   accumulates. Resize if needed.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -228,6 +228,97 @@ TMPDIR=~/.config/Claude/tmp claude-desktop
 
 Or add `TMPDIR=%h/.config/Claude/tmp` to the `Exec=` line in your `.desktop` file.
 
+### Cowork: ENAMETOOLONG on encrypted home (eCryptfs)
+
+Cowork sessions can fail with an opaque `ENAMETOOLONG` error when
+`$HOME` is on a filesystem with a short filename limit. The common
+case is **eCryptfs** — the legacy "encrypted home" option on older
+Ubuntu and Linux Mint installs, which caps individual filenames at
+143 chars because of filename-encryption overhead. Standard
+filesystems (ext4, btrfs, xfs, zfs) cap at 255 chars and are fine.
+
+**Why it happens:** Claude Code creates one directory per session
+under `~/.claude/projects/`, named after the sanitized host CWD. For
+cowork sessions the host CWD is the deeply nested outputs dir under
+`~/.config/Claude/local-agent-mode-sessions/<accountId>/<orgId>/local_<uuid>/outputs`,
+which sanitizes to ~180 chars — fits ext4 but exceeds the eCryptfs
+143-char ceiling.
+
+**Diagnosis:** `claude-desktop --doctor` detects this automatically
+and emits a `[WARN] Filename limit: NAME_MAX=143…` line, plus an
+eCryptfs-specific hint when the filesystem type matches. You can
+also check by hand:
+
+```bash
+df -T $HOME              # look for type "ecryptfs"
+getconf NAME_MAX $HOME   # eCryptfs reports 143; ext4 reports 255
+```
+
+**Workaround:** move Claude's data onto a separate LUKS-encrypted
+ext4 volume (NAME_MAX = 255) and symlink the original paths back.
+This keeps the data encrypted at rest while sidestepping the
+eCryptfs filename-length cap.
+
+```bash
+# 1. Create a 2 GB LUKS container
+sudo dd if=/dev/urandom of=/opt/claude-secure.img bs=1M count=2048 \
+    status=progress
+sudo cryptsetup luksFormat /opt/claude-secure.img
+sudo cryptsetup open /opt/claude-secure.img claude-secure
+sudo mkfs.ext4 /dev/mapper/claude-secure
+
+# 2. Mount and move Claude's data in
+sudo mkdir -p /mnt/claude-secure
+sudo mount /dev/mapper/claude-secure /mnt/claude-secure
+sudo chown "$USER:$USER" /mnt/claude-secure
+
+mv ~/.config/Claude /mnt/claude-secure/Claude-config
+mv ~/.cache/claude-desktop-debian /mnt/claude-secure/claude-cache
+
+ln -s /mnt/claude-secure/Claude-config ~/.config/Claude
+ln -s /mnt/claude-secure/claude-cache ~/.cache/claude-desktop-debian
+
+# 3. Verify the filename limit
+getconf NAME_MAX /mnt/claude-secure   # should print 255
+```
+
+**Auto-mount at login** with `pam_mount` so the volume unlocks
+transparently each session without a manual `cryptsetup open`. If
+your login password matches the LUKS passphrase, the unlock is
+silent:
+
+```bash
+sudo apt install libpam-mount
+```
+
+Add a `<volume>` entry to `/etc/security/pam_mount.conf.xml`
+(replace `YOUR_USERNAME` with your login name):
+
+```xml
+<volume user="YOUR_USERNAME" fstype="crypt"
+        path="/opt/claude-secure.img"
+        mountpoint="/mnt/claude-secure"
+        options="" />
+```
+
+`libpam-mount` registers itself with `/etc/pam.d/common-auth` and
+`/etc/pam.d/common-session` automatically on install.
+
+**Notes:**
+- Tested on Linux Mint with LightDM as the display manager.
+- The LUKS passphrase must match your login password for the
+  transparent unlock to work.
+- 2 GB is a conservative starting size; the Claude config
+  directory can exceed 500 MB once cowork session history
+  accumulates. Resize if needed.
+- This is a system-wide change that affects login flow — review
+  the pam_mount config against your threat model before applying.
+
+Credit: reported with detailed `--doctor` output by
+[@michelsfun](https://github.com/michelsfun); LUKS-volume workaround
+contributed by [@proffalken](https://github.com/proffalken) in
+[#590](https://github.com/aaddrick/claude-desktop-debian/issues/590).
+
 ### Authentication Errors (401)
 
 If you encounter recurring "API Error: 401" messages after periods of inactivity, the cached OAuth token may need to be cleared. This is an upstream application issue reported in [#156](https://github.com/aaddrick/claude-desktop-debian/issues/156).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -256,6 +256,10 @@ getconf NAME_MAX $HOME   # eCryptfs reports 143; ext4 reports 255
 
 **Workaround:** move Claude's data onto a separate LUKS-encrypted
 ext4 volume (NAME_MAX = 255) and symlink the original paths back.
+`~/.claude/` is the critical one — that's where Claude Code creates
+the long-named per-session dirs that overflow the limit — and
+`~/.config/Claude/` plus `~/.cache/claude-desktop-debian/` are
+relocated alongside it so all Claude state lives on the same volume.
 This keeps the data encrypted at rest while sidestepping the
 eCryptfs filename-length cap.
 
@@ -274,9 +278,17 @@ sudo chown "$USER:$USER" /mnt/claude-secure
 
 mv ~/.config/Claude /mnt/claude-secure/Claude-config
 mv ~/.cache/claude-desktop-debian /mnt/claude-secure/claude-cache
+# ~/.claude may not exist yet on a fresh install — create the target
+# either way so the symlink below resolves.
+if [ -e ~/.claude ]; then
+    mv ~/.claude /mnt/claude-secure/claude-home
+else
+    mkdir -p /mnt/claude-secure/claude-home
+fi
 
 ln -s /mnt/claude-secure/Claude-config ~/.config/Claude
 ln -s /mnt/claude-secure/claude-cache ~/.cache/claude-desktop-debian
+ln -s /mnt/claude-secure/claude-home ~/.claude
 
 # 3. Verify the filename limit
 getconf NAME_MAX /mnt/claude-secure   # should print 255

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -436,6 +436,54 @@ JSEOF
 	fi
 }
 
+# Diagnose short-filename-limit filesystems that break cowork session
+# initialization. Claude Code creates a per-session directory under
+# ~/.claude/projects/ whose name is the sanitized host CWD — for cowork
+# sessions that flattens to ~180 chars (the host CWD is the deeply
+# nested outputs dir under ~/.config/Claude/local-agent-mode-sessions/
+# <accountId>/<orgId>/local_<uuid>/outputs). On filesystems with a
+# short NAME_MAX — eCryptfs caps at 143 due to filename-encryption
+# overhead — that mkdir fails with ENAMETOOLONG and the session never
+# starts. Standard fs (ext4/btrfs/xfs/zfs) cap at 255 and are fine. See
+# #590.
+_doctor_check_filename_limit() {
+	# Walk up from ~/.claude/projects to the first dir that exists so
+	# getconf has something to query on a fresh install where the tree
+	# hasn't been created yet. $HOME is the floor — stop there rather
+	# than crossing into /.
+	local probe_dir="$HOME/.claude/projects"
+	while [[ ! -d $probe_dir ]]; do
+		probe_dir=$(dirname "$probe_dir")
+		[[ $probe_dir == "$HOME" || $probe_dir == / ]] && break
+	done
+	[[ -d $probe_dir ]] || return 0
+
+	local name_max
+	name_max=$(getconf NAME_MAX "$probe_dir" 2>/dev/null) || return 0
+	[[ $name_max =~ ^[0-9]+$ ]] || return 0
+
+	((name_max >= 200)) && return 0
+
+	_warn "Filename limit: NAME_MAX=$name_max on $probe_dir (< 200)"
+	_info \
+		'Cowork sessions create project-dir names up to ~180 chars' \
+		'under ~/.claude/projects/; short limits cause ENAMETOOLONG'
+	_info 'when Claude Code initializes a session inside cowork (#590).'
+
+	local fs_type
+	fs_type=$(df --output=fstype "$probe_dir" 2>/dev/null \
+		| awk 'NR==2 {print $1}')
+	if [[ $fs_type == 'ecryptfs' ]]; then
+		_info \
+			'Detected eCryptfs (legacy Ubuntu/Mint encrypted home,' \
+			'NAME_MAX=143 due to filename-encryption overhead).'
+		_info \
+			'Workaround: move ~/.claude and ~/.config/Claude onto a' \
+			'separate LUKS-encrypted ext4 volume (NAME_MAX=255) and'
+		_info 'symlink them back. See #590 for a worked example.'
+	fi
+}
+
 # Surface a warning when systemd-coredump shows N+ recent Electron
 # crashes. The most common cause on Linux is the GPU process FATAL
 # exhaustion tracked in #583 — workaround for affected users is the
@@ -946,6 +994,10 @@ print(len(servers))
 
 	# Custom bwrap mount configuration
 	_doctor_check_bwrap_mounts
+
+	# Short NAME_MAX on the host's ~/.claude tree (eCryptfs etc.)
+	# blocks cowork session init with ENAMETOOLONG — see #590.
+	_doctor_check_filename_limit
 
 	# -- Orphaned cowork daemon --
 	# Uses the same live-UI detection as cleanup_orphaned_cowork_daemon

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -478,9 +478,11 @@ _doctor_check_filename_limit() {
 			'Detected eCryptfs (legacy Ubuntu/Mint encrypted home,' \
 			'NAME_MAX=143 due to filename-encryption overhead).'
 		_info \
-			'Workaround: move ~/.claude and ~/.config/Claude onto a' \
-			'separate LUKS-encrypted ext4 volume (NAME_MAX=255) and'
-		_info 'symlink them back. See #590 for a worked example.'
+			'Workaround: move ~/.config/Claude onto a separate' \
+			'LUKS-encrypted ext4 volume (NAME_MAX=255) and symlink it'
+		_info \
+			'back. See docs/TROUBLESHOOTING.md "Cowork: ENAMETOOLONG' \
+			'on encrypted home (eCryptfs)" for the worked steps.'
 	fi
 }
 

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -320,3 +320,88 @@ Wed 2026-05-06 08:00:21 EDT 130375 1000 1000 SIGTRAP present /usr/lib/claude-des
 	[[ $output == *'Recent Electron crashes: 1'* ]]
 	[[ $output == *'may be from other Electron apps'* ]]
 }
+
+# =============================================================================
+# _doctor_check_filename_limit: NAME_MAX probe + eCryptfs hint (#590)
+# =============================================================================
+
+# Install a getconf shim that emits $1 on stdout. Empty $1 → shim exits 1
+# so callers can test the "getconf failed" path.
+_install_getconf_shim() {
+	mkdir -p "$TEST_TMP/bin"
+	local value="$1"
+	if [[ -z $value ]]; then
+		cat > "$TEST_TMP/bin/getconf" <<'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+	else
+		cat > "$TEST_TMP/bin/getconf" <<SHIM
+#!/usr/bin/env bash
+echo ${value}
+SHIM
+	fi
+	chmod +x "$TEST_TMP/bin/getconf"
+	export PATH="$TEST_TMP/bin:$PATH"
+}
+
+# Install a df shim that emits a single-column fstype listing matching
+# the `df --output=fstype` shape the helper relies on.
+_install_df_shim() {
+	mkdir -p "$TEST_TMP/bin"
+	local fstype="$1"
+	cat > "$TEST_TMP/bin/df" <<SHIM
+#!/usr/bin/env bash
+cat <<'OUT'
+Type
+${fstype}
+OUT
+SHIM
+	chmod +x "$TEST_TMP/bin/df"
+	export PATH="$TEST_TMP/bin:$PATH"
+}
+
+@test "_doctor_check_filename_limit: silent when NAME_MAX >= 200" {
+	_install_getconf_shim '255'
+	run _doctor_check_filename_limit
+	[[ $status -eq 0 ]]
+	[[ -z $output ]]
+}
+
+@test "_doctor_check_filename_limit: warns when NAME_MAX < 200" {
+	_install_getconf_shim '143'
+	_install_df_shim 'ext4'
+	run _doctor_check_filename_limit
+	[[ $status -eq 0 ]]
+	[[ $output == *'[WARN]'* ]]
+	[[ $output == *'NAME_MAX=143'* ]]
+	[[ $output == *'#590'* ]]
+	# Non-ecryptfs fs: no LUKS hint
+	[[ $output != *'eCryptfs'* ]]
+	[[ $output != *'LUKS'* ]]
+}
+
+@test "_doctor_check_filename_limit: eCryptfs adds LUKS workaround hint" {
+	_install_getconf_shim '143'
+	_install_df_shim 'ecryptfs'
+	run _doctor_check_filename_limit
+	[[ $status -eq 0 ]]
+	[[ $output == *'[WARN]'* ]]
+	[[ $output == *'NAME_MAX=143'* ]]
+	[[ $output == *'eCryptfs'* ]]
+	[[ $output == *'LUKS'* ]]
+}
+
+@test "_doctor_check_filename_limit: silent on non-numeric getconf output" {
+	_install_getconf_shim 'undefined'
+	run _doctor_check_filename_limit
+	[[ $status -eq 0 ]]
+	[[ -z $output ]]
+}
+
+@test "_doctor_check_filename_limit: silent when getconf fails" {
+	_install_getconf_shim ''
+	run _doctor_check_filename_limit
+	[[ $status -eq 0 ]]
+	[[ -z $output ]]
+}

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -346,17 +346,25 @@ SHIM
 }
 
 # Install a df shim that emits a single-column fstype listing matching
-# the `df --output=fstype` shape the helper relies on.
+# the `df --output=fstype` shape the helper relies on. Empty $1 → shim
+# exits 1 so callers can test the "df failed" path.
 _install_df_shim() {
 	mkdir -p "$TEST_TMP/bin"
 	local fstype="$1"
-	cat > "$TEST_TMP/bin/df" <<SHIM
+	if [[ -z $fstype ]]; then
+		cat > "$TEST_TMP/bin/df" <<'SHIM'
+#!/usr/bin/env bash
+exit 1
+SHIM
+	else
+		cat > "$TEST_TMP/bin/df" <<SHIM
 #!/usr/bin/env bash
 cat <<'OUT'
 Type
 ${fstype}
 OUT
 SHIM
+	fi
 	chmod +x "$TEST_TMP/bin/df"
 	export PATH="$TEST_TMP/bin:$PATH"
 }
@@ -404,4 +412,15 @@ SHIM
 	run _doctor_check_filename_limit
 	[[ $status -eq 0 ]]
 	[[ -z $output ]]
+}
+
+@test "_doctor_check_filename_limit: df failure suppresses eCryptfs hint, keeps warn" {
+	_install_getconf_shim '143'
+	_install_df_shim ''
+	run _doctor_check_filename_limit
+	[[ $status -eq 0 ]]
+	[[ $output == *'[WARN]'* ]]
+	[[ $output == *'NAME_MAX=143'* ]]
+	[[ $output != *'eCryptfs'* ]]
+	[[ $output != *'LUKS'* ]]
 }


### PR DESCRIPTION
## Summary

- Add `_doctor_check_filename_limit` to `scripts/doctor.sh` — probes `NAME_MAX` on the first existing ancestor of `~/.claude/projects/`, warns when `< 200`, and adds an eCryptfs-specific LUKS workaround hint when `df --output=fstype` reports the filesystem type. Wired into the Cowork Mode section of `run_doctor` so users hit the warning before their first session attempt rather than chasing an opaque `ENAMETOOLONG`.
- Add `Cowork: ENAMETOOLONG on encrypted home (eCryptfs)` section to `docs/TROUBLESHOOTING.md` walking through @proffalken's LUKS-volume + `pam_mount` workaround. The doctor's eCryptfs hint references this section by name.
- Credit @michelsfun (detailed `--doctor` bug report that pinpointed the short-`NAME_MAX` filesystem) and @proffalken (LUKS workaround) in README Acknowledgments.

Closes #590.

## Test plan

- [x] `shellcheck -x` clean (CI-style invocation against all linted shell scripts)
- [x] `bats tests/doctor.bats` — 28 tests pass (23 existing + 5 new covering: silent at `NAME_MAX >= 200`, warn at `< 200`, eCryptfs hint adds LUKS workaround, non-numeric `getconf` output silent, failing `getconf` silent)
- [x] Smoke-tested against real ext4 home (255, silent) and simulated eCryptfs via PATH shims (143 → warn + LUKS hint fires correctly)
- [x] CI shellcheck on push
- [ ] @michelsfun or @proffalken confirms the documented LUKS workaround unblocks cowork on a real eCryptfs setup

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <claude-opus-4-7> <noreply@anthropic.com>
75% AI / 25% Human
Claude: drafted `_doctor_check_filename_limit` with eCryptfs detection, wrote 5 bats tests with `getconf`/`df` PATH shims, drafted the TROUBLESHOOTING.md section adapting @proffalken's workaround, drafted commit messages and this PR body
Human: directed scope (doctor check + doc + acks), did the initial issue triage that confirmed the eCryptfs hypothesis from michelsfun's `df -T` output, reviewed the approach and approved push