### PR TITLE
docs: follow-ups from #585 review (#608)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -131,6 +131,45 @@ windows or rich compose-key sequences. Only reach for it if your
 real input method (IBus/Fcitx) is broken; if you depend on CJK or
 compose, prefer fixing the IBus/Fcitx integration instead.
 
+### Repeated Electron Crashes / GPU Process FATAL ([#583](https://github.com/aaddrick/claude-desktop-debian/issues/583))
+
+If Claude Desktop crashes repeatedly on launch or shortly after,
+the most common cause on Linux is the Chromium GPU process hitting
+a FATAL exhaustion path. `claude-desktop --doctor` surfaces this
+when `systemd-coredump` shows 3+ Electron crashes in the last 7
+days, pointing at this issue.
+
+Two ways to disable hardware acceleration as a workaround:
+
+1. **In-app:** Settings → toggle hardware acceleration off →
+   restart Claude Desktop. Persists in the upstream config.
+2. **Env var (headless / persists across reinstalls):** set
+   `CLAUDE_DISABLE_GPU=1` in the environment before launching.
+
+```bash
+# One-off:
+CLAUDE_DISABLE_GPU=1 claude-desktop
+
+# Persistent (shell profile):
+echo 'export CLAUDE_DISABLE_GPU=1' >> ~/.profile
+```
+
+When `CLAUDE_DISABLE_GPU=1` is set, the launcher passes
+`--disable-gpu --disable-software-rasterizer` to Electron (see
+`scripts/launcher-common.sh`). This is the same pair of flags
+applied automatically inside XRDP sessions, where software
+rendering is required regardless. Either signal is sufficient —
+the launcher won't stack duplicate flags.
+
+**When to prefer which:** the in-app toggle is friendlier if you
+can reach Settings without the app crashing. Reach for
+`CLAUDE_DISABLE_GPU=1` when the app crashes before you can open
+Settings, when running in environments with no GPU available
+(XRDP, headless CI smoke tests, some VMs), or when you want the
+behavior to persist across reinstalls and config resets.
+
+Tracking issue: [#583](https://github.com/aaddrick/claude-desktop-debian/issues/583).
+
 ### AppImage Sandbox Warning
 
 AppImages run with `--no-sandbox` due to electron's chrome-sandbox requiring root privileges for unprivileged namespace creation. This is a known limitation of AppImage format with Electron applications.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -460,6 +460,12 @@ _doctor_check_recent_crashes() {
 	[[ -n $listing ]] || return 0
 
 	# Drop the header line; count remaining entries.
+	# Assumes `coredumpctl list electron`'s COMM=electron filter
+	# excludes `-- Reboot --` separator rows from the listing (true
+	# on systemd as of writing). The path-matched branch below uses
+	# index($0, p) so it's unaffected even if that ever changes;
+	# revisit this total-count branch if a future systemd version
+	# starts leaking reboot markers into per-COMM listings.
 	total_count=$(awk 'NR>1 && NF>0' <<< "$listing" | wc -l)
 	((total_count == 0)) && return 0
 
@@ -481,6 +487,9 @@ _doctor_check_recent_crashes() {
 		footnote=' (some entries may be from other Electron apps)'
 	fi
 
+	# Threshold tuned against the #583 repro (~10 crashes over 7 days
+	# on the affected laptop); a noisy session typically clears 3 in a
+	# week, so 3 is the floor for "worth surfacing the workaround".
 	if ((count >= 3)); then
 		_warn "Recent Electron crashes: $count in last 7 days$footnote"
 		_info \


### PR DESCRIPTION
## Summary

Picks up the three non-blocking items @aaddrick captured from my #585
review into [#608](https://github.com/aaddrick/claude-desktop-debian/issues/608):

- **`docs/TROUBLESHOOTING.md`** — new "Repeated Electron Crashes / GPU
  Process FATAL" section. Documents `CLAUDE_DISABLE_GPU=1`: when to
  reach for the env var vs the in-app Settings toggle, the
  `--disable-gpu --disable-software-rasterizer` translation in
  `scripts/launcher-common.sh`, the XRDP overlap, and the #583
  tracking link the `--doctor` warning points at.
- **`scripts/doctor.sh` (`_doctor_check_recent_crashes`)** — one-line
  comment above the `count >= 3` threshold explaining the tuning
  basis (#583 repro, ~10 crashes over 7 days on the affected laptop,
  3 chosen as the "worth surfacing the workaround" floor). Picked
  option (1) from the issue — no env override surface, can revisit
  if anyone reports the nag is noisy.
- **`scripts/doctor.sh` (awk total-count branch)** — comment noting
  the count relies on `coredumpctl list electron`'s `COMM=electron`
  filter to exclude `-- Reboot --` separator rows. The path-matched
  branch uses `index($0, p)` so it's already safe; the comment
  flags the assumption so future-us revisits if systemd ever leaks
  reboot markers through per-COMM listings.

Fixes #608.