### PR TITLE
fix: actively quit on close when CLAUDE_QUIT_ON_CLOSE=1 (#623)

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -339,6 +339,32 @@ Module.prototype.require = function(id) {
                     this.hide();
                   }
                 });
+              } else {
+                // CLAUDE_QUIT_ON_CLOSE=1: the bundled main-process code
+                // (`.vite/build/index.js`) installs its own main-window
+                // close listener that hardcodes `preventDefault()` +
+                // `hide()` on every non-Windows platform, with no
+                // setting or env var to disable it. The wrapper's
+                // opt-out above only removes *this* file's hide handler;
+                // the bundled one still runs, so without this branch
+                // closing the window still leaves the app alive in the
+                // tray (in-app schedulers / single-instance lock /
+                // deleted-inode electron after dpkg upgrade-in-place).
+                //
+                // Approach: register a close listener that runs *first*
+                // and calls app.quit(). app.quit() emits 'before-quit'
+                // synchronously, which sets the bundled code's
+                // "quitting in progress" flag. The bundled close
+                // listener then runs second, sees that flag, and
+                // short-circuits via its own `if (lC()) return;` guard
+                // — so it never calls preventDefault, and the window
+                // closes normally during the quit flow. We ride the
+                // upstream's own quit-safety contract instead of trying
+                // to remove or splice their listener; robust to any
+                // refactor that preserves the quit-in-progress short-
+                // circuit (which they need for Ctrl+Q / tray Quit /
+                // SIGTERM anyway). Fixes: #623
+                this.on('close', () => { result.app.quit(); });
               }
 
               // Directly set child view bounds to match content size.


### PR DESCRIPTION
## Summary

When `CLAUDE_QUIT_ON_CLOSE=1` is set, install an *active* close listener that calls `app.quit()` instead of merely declining to install the wrapper's hide-on-close handler. This counters the bundled main-process close listener in `.vite/build/index.js` that hardcodes `preventDefault + hide` on non-Windows platforms — a handler Anthropic added upstream after #448 shipped, which the wrapper's existing opt-out doesn't reach.

Fixes #623. Refs #448.

## Why this approach

The bundled listener guards itself with `if (lC()) return;` where `lC()` ORs together flags armed by the bundled before-quit / will-quit handlers. `app.quit()` fires `before-quit` *synchronously*, which sets `ltA=true` inside that handler before returning.

So if we register our close listener first (right after `super()` in the patched `BrowserWindow`), the sequence on X-click is:

1. Electron emits `close`.
2. Our listener runs → `app.quit()` → before-quit fires → `ltA=true` → `lC()` truthy.
3. Bundled close listener runs second → `if (lC()) return;` → short-circuits, no `preventDefault`, no `hide()`.
4. `close` completes without preventDefault, the window closes in the quit flow, async cleanup proceeds, app exits.

No string-matching against the minified bundle. No `removeListener` splicing. The contract we rely on (`lC()` guard) is upstream's own quit-safety mechanism; they need it for Ctrl+Q / tray Quit / SIGTERM regardless, so it's not going away.

Alternatives considered:

| Approach | Robust to upstream re-minification | Visual flash | Touches their listener |
|---|---|---|---|
| Splice `_events.close` | No (`.toString()` heuristic) | None | Yes (fragile) |
| Additive `app.quit()` without ordering | Yes | Brief hide-then-quit | No |
| **Prepended listener riding `lC()`** | **Yes** | **None** | **No** |
| Patch `BrowserWindow.prototype.on` | No (same heuristic) | None | Yes (fragile) |

## Test plan

- [x] Manually verified on Ubuntu 25.10 (GNOME, Wayland/XWayland), 1.7196.1 base, clean `~/.config/Claude`. Before this patch: clicking X with `CLAUDE_QUIT_ON_CLOSE=1` set leaves the process alive (`pgrep -af /usr/lib/claude-desktop/` still shows the main process; relaunch from icon logs `Not main instance, returning early`). After: clicking X exits the main process; relaunch is a fresh start.
- [x] `[Frame Fix] Close-to-tray: off` still logged in launcher.log (env-var path unchanged for that message).
- [x] Without the env var (default tray behaviour): `CLOSE_TO_TRAY` path unchanged, X still hides — verified.
- [ ] CI lint / `./build.sh --build appimage` — I have not run a full local appimage build for this change because it's an in-place edit to `frame-fix-wrapper.js` (not a `scripts/patches/*.sh` patch) and the existing CI should exercise the wrapper. Happy to run a local build if you'd like.

## Scope

One file (`scripts/frame-fix-wrapper.js`), +26 / -0. Behaviour is gated entirely on the existing `CLAUDE_QUIT_ON_CLOSE=1` env var — default behaviour (close-to-tray) is unchanged.

A follow-up doc tweak to the README's `CLAUDE_QUIT_ON_CLOSE` description seems warranted once this lands (today the README implies it fully restores Electron-default close=quit); happy to do that as a separate PR if you'd prefer not to bundle.
