### PR TITLE
fix(tray): support $-containing identifiers in 1.8089.1 minified bundle (#625)

### DIFF
--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -11,9 +11,9 @@ patch_tray_menu_handler() {
 	echo 'Patching tray menu handler...'
 	local index_js='app.asar.contents/.vite/build/index.js'
 
-	local tray_func tray_var first_const
+	local tray_func tray_func_re tray_var first_const
 	tray_func=$(grep -oP \
-		'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' "$index_js")
+		'on\("menuBarEnabled",\(\)=>\{\K[\w$]+(?=\(\)\})' "$index_js")
 	if [[ -z $tray_func ]]; then
 		echo 'Failed to extract tray menu function name' >&2
 		cd "$project_root" || exit 1
@@ -21,8 +21,12 @@ patch_tray_menu_handler() {
 	fi
 	echo "  Found tray function: $tray_func"
 
+	# Escape `$` for PCRE / sed -E patterns where it would otherwise act
+	# as an end-of-line anchor. Minifier emits identifiers like `i$A`.
+	tray_func_re="${tray_func//\$/\\$}"
+
 	tray_var=$(grep -oP \
-		"\}\);let \K\w+(?==null;(?:async )?function ${tray_func})" \
+		"\}\);let \K\w+(?==null;(?:async )?function ${tray_func_re})" \
 		"$index_js")
 	if [[ -z $tray_var ]]; then
 		echo 'Failed to extract tray variable name' >&2
@@ -31,11 +35,17 @@ patch_tray_menu_handler() {
 	fi
 	echo "  Found tray variable: $tray_var"
 
-	sed -i "s/function ${tray_func}(){/async function ${tray_func}(){/g" \
-		"$index_js"
+	# Idempotent: upstream may already ship the function as `async`
+	# (1.8089.1 does). Re-applying the sed would produce
+	# `async async function`, which then breaks downstream patches that
+	# match `(?:async )?function NAME`.
+	if ! grep -q "async function ${tray_func}(){" "$index_js"; then
+		sed -i "s/function ${tray_func}(){/async function ${tray_func}(){/g" \
+			"$index_js"
+	fi
 
 	first_const=$(grep -oP \
-		"async function ${tray_func}\(\)\{.*?const \K\w+(?==)" \
+		"async function ${tray_func_re}\(\)\{.*?const \K\w+(?==)" \
 		"$index_js" | head -1)
 	if [[ -z $first_const ]]; then
 		echo 'Failed to extract first const in function' >&2
@@ -69,7 +79,7 @@ patch_tray_menu_handler() {
 			"s/(${electron_var_re}\.nativeTheme\.on\(\s*\"updated\"\s*,\s*\(\)\s*=>\s*\{)/let _trayStartTime=Date.now();\1/g" \
 			"$index_js"
 		sed -i -E \
-			"s/\((\w+\([^)]*\))\s*,\s*${tray_func}\(\)\s*,/(\1,Date.now()-_trayStartTime>3e3\&\&${tray_func}(),/g" \
+			"s/\((\w+\([^)]*\))\s*,\s*${tray_func_re}\(\)\s*,/(\1,Date.now()-_trayStartTime>3e3\&\&${tray_func}(),/g" \
 			"$index_js"
 		echo '  Added startup delay check (3 second window)'
 	fi
@@ -98,17 +108,19 @@ patch_tray_inplace_update() {
 
 	# Re-extract the tray variable name — `patch_tray_menu_handler`
 	# declares it `local` so it's not visible here. Same grep pattern.
-	local tray_func local_tray_var tray_var_re
+	local tray_func tray_func_re local_tray_var tray_var_re
 	local menu_func path_var enabled_var enabled_count
 	tray_func=$(grep -oP \
-		'on\("menuBarEnabled",\(\)=>\{\K\w+(?=\(\)\})' "$index_js")
+		'on\("menuBarEnabled",\(\)=>\{\K[\w$]+(?=\(\)\})' "$index_js")
 	if [[ -z $tray_func ]]; then
 		echo '  Could not find tray function — skipping'
 		echo '##############################################################'
 		return
 	fi
+	# Escape `$` for PCRE patterns; matches the `tray_var_re` trick below.
+	tray_func_re="${tray_func//\$/\\$}"
 	local_tray_var=$(grep -oP \
-		"\}\);let \K\w+(?==null;(?:async )?function ${tray_func})" \
+		"\}\);let \K\w+(?==null;(?:async )?function ${tray_func_re})" \
 		"$index_js")
 	if [[ -z $local_tray_var ]]; then
 		echo '  Could not extract tray variable name — skipping'


### PR DESCRIPTION
## Summary

Three small fixes in `scripts/patches/tray.sh` that together unblock the 1.8089.1 build (#625) and restore the duplicate-icon fast-path from #515 on the new bundle.

## Root cause

The 1.8089.1 minified bundle emits the tray menu handler as `i$A` — an identifier containing `$`. `patch_tray_menu_handler` uses PCRE `\w+` to capture it; `\w` is `[A-Za-z0-9_]` and does **not** match `$`. `tray_func` comes back empty, the guard fires, and the entire `build.sh` aborts with `exit 1` — taking every downstream patch with it.

Once `tray_func=i$A` is captured correctly, a **second** latent bug surfaces: the unescaped `$` is interpolated raw into PCRE and `sed -E` patterns where it acts as an end-of-line anchor (`function i$A` reads as "function i", end of line, "A"), so `tray_var` extraction also returns empty.

And a **third** issue, surfaced only after the first two are fixed: Anthropic now ships the menu handler as `async function i$A()` upstream in 1.8089.1. `patch_tray_menu_handler`'s `s/function NAME/async function NAME/` then produces `async async function`, which breaks `patch_tray_inplace_update`'s `(?:async )?function NAME` anchor and silently loses the #515 duplicate-icon fix on this version.

## Fix

1. **Allow `$` in extracted JS identifiers** (`tray.sh:16,104`). `\w+` → `[\w$]+`, mirroring the `\$?\w+` pattern `_common.sh` already uses for `electron_var`.

2. **Escape `$` when interpolating `tray_func` into PCRE / `sed -E` patterns** (`tray.sh:25,38,72,111`). Mirror the existing `tray_var_re="\${local_tray_var//\\$/\\\\$}"` trick at line 120. BRE seds (lines 34, 49, 57) are safe with raw `$` because BRE treats `$` as an anchor only at end-of-pattern.

3. **Make the `s/function/async function/` sed idempotent** (`tray.sh:38`). Guard with `grep -q 'async function NAME'` so it no-ops when upstream already ships the function as async.

The change is a strict superset of old behavior: `[\w$]+` matches everything `\w+` did, `tray_func_re` is identical to `tray_func` when no `$` is present, and the new guard only suppresses a redundant rewrite. Older bundles continue to patch the same way.

## Test plan

Verified end-to-end against a freshly-downloaded 1.8089.1 bundle (`Claude-b98a06c70e376344e3b6938d6980242e8cc20547.exe`, sha matches upstream's `scripts/setup/detect-host.sh`):

```
patch_tray_menu_handler:
  Found tray function: i$A
  Found tray variable: Ju
  Found first const variable: e
  Added mutex guard to i$A()
  Added DBus cleanup delay after Ju.destroy()
  Added startup delay check (3 second window)
patch_tray_icon_selection:
  Patched tray icon selection for Linux theme support
patch_tray_inplace_update:
  Found tray variable: Ju
  Found menu function: QGe
  Found icon-path var: t
  Found menuBarEnabled var: e
  [OK] Fast-path injected before destroy-recreate
patch_menu_bar_default:
  Patched menuBarEnabled to default to true
```

- `node --check` on the patched bundle: parses cleanly (no syntax errors introduced)
- Post-patch grep confirms every marker: `_trayStartTime` (×1), `i$A._running` (×1), `setTimeout(r,250)` (×1), `Ju.setImage(cA.nativeImage.createFromPath(t))` (×1, the #515 fast-path), `e!==false` (×1), `TrayIconTemplate-Dark.png` (×1)
- Double-async check: `grep -c 'async async function'` → 0

`shellcheck -x scripts/patches/tray.sh` reports no new findings vs. main (the four pre-existing SC2148/SC2154 warnings about sourced globals are unchanged).

Fixes #625.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)