### PR TITLE
Fix #584: detect missing electron binary + add unzip fallback for Node 24 silent extract-zip failure

### DIFF
--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -250,23 +250,59 @@ setup_electron_asar() {
 		echo 'Electron and Asar installation command finished.'
 
 		# electron@42+ no longer ships a postinstall script that fetches
-		# the prebuilt binary into dist/. If npm didn't populate it, fetch
-		# the matching binary explicitly via @electron/get. See #584.
-		# Retry once on transient CDN failures (503, network drops).
-		if [[ ! -d $electron_dist_path ]]; then
-			echo 'Electron postinstall did not populate dist/; fetching binary explicitly...'
+		# the prebuilt binary into dist/. If npm didn't populate it,
+		# fetch the matching binary explicitly via @electron/get. See
+		# #584. Retry once on transient CDN failures (503, network drops).
+		#
+		# Check for the binary itself (not just the dist/ directory),
+		# because under Node 24 the extract-zip step in both the npm
+		# postinstall (electron <42 path) and @electron/get can silently
+		# no-op — leaving an empty dist/locales/ behind, which would pass
+		# a bare `-d` check while no electron binary actually landed.
+		if [[ ! -f $electron_dist_path/electron ]]; then
+			echo 'Electron dist/electron missing; fetching binary explicitly...'
 			local fetch_attempts=0
 			while ! node "$project_root/scripts/setup/fetch-electron-binary.js"; do
 				fetch_attempts=$((fetch_attempts + 1))
 				if (( fetch_attempts >= 2 )); then
 					echo 'Failed to fetch Electron binary via @electron/get after 2 attempts.' >&2
 					echo 'For air-gapped or mirrored builds set ELECTRON_MIRROR or ELECTRON_CUSTOM_DIR; see docs/BUILDING.md.' >&2
-					cd "$project_root" || exit 1
-					exit 1
+					break
 				fi
 				echo "Retrying Electron binary fetch (attempt $((fetch_attempts + 1))/2)..."
 				sleep 2
 			done
+
+			# Final fallback: even when @electron/get reports success,
+			# extract-zip can leave dist/ empty under Node 24 (the
+			# unzip stream resolves without writing files). If we still
+			# have no binary, the cache zip was downloaded successfully
+			# — unpack it with system `unzip`.
+			if [[ ! -f $electron_dist_path/electron ]]; then
+				echo 'extract-zip path produced no binary; unpacking @electron/get cache with system unzip...'
+				local electron_cache_dir="${electron_config_cache:-$HOME/.cache/electron}"
+				local cached_zip
+				cached_zip=$(find "$electron_cache_dir" -name "electron-v${electron_version}-linux-${target_architecture:-x64}.zip" 2>/dev/null | head -1)
+				if [[ -z $cached_zip ]]; then
+					echo "No cached zip matching electron-v${electron_version}-linux-*.zip under $electron_cache_dir" >&2
+					cd "$project_root" || exit 1
+					exit 1
+				fi
+				if ! command -v unzip >/dev/null 2>&1; then
+					echo "unzip not installed; cannot apply final fallback. Install unzip and retry, or upgrade extract-zip upstream." >&2
+					cd "$project_root" || exit 1
+					exit 1
+				fi
+				mkdir -p "$electron_dist_path"
+				if ! unzip -oq "$cached_zip" -d "$electron_dist_path"; then
+					echo 'unzip fallback failed.' >&2
+					cd "$project_root" || exit 1
+					exit 1
+				fi
+				printf 'v%s\n' "$electron_version" > "$electron_dist_path/version"
+				printf 'electron\n' > "$work_dir/node_modules/electron/path.txt"
+				echo "unzip fallback populated $electron_dist_path ($(du -sh "$electron_dist_path" | awk '{print $1}'))"
+			fi
 		fi
 	else
 		echo 'Local Electron distribution and Asar binary already present.'

--- a/scripts/setup/dependencies.sh
+++ b/scripts/setup/dependencies.sh
@@ -261,6 +261,7 @@ setup_electron_asar() {
 		# a bare `-d` check while no electron binary actually landed.
 		if [[ ! -f $electron_dist_path/electron ]]; then
 			echo 'Electron dist/electron missing; fetching binary explicitly...'
+			local fetch_ok=false
 			local fetch_attempts=0
 			while ! node "$project_root/scripts/setup/fetch-electron-binary.js"; do
 				fetch_attempts=$((fetch_attempts + 1))
@@ -272,6 +273,9 @@ setup_electron_asar() {
 				echo "Retrying Electron binary fetch (attempt $((fetch_attempts + 1))/2)..."
 				sleep 2
 			done
+			if (( fetch_attempts < 2 )); then
+				fetch_ok=true
+			fi
 
 			# Final fallback: even when @electron/get reports success,
 			# extract-zip can leave dist/ empty under Node 24 (the
@@ -279,10 +283,21 @@ setup_electron_asar() {
 			# have no binary, the cache zip was downloaded successfully
 			# — unpack it with system `unzip`.
 			if [[ ! -f $electron_dist_path/electron ]]; then
+				if [[ $fetch_ok == false ]]; then
+					echo 'Electron download failed; no cached zip to fall back on.' >&2
+					cd "$project_root" || exit 1
+					exit 1
+				fi
 				echo 'extract-zip path produced no binary; unpacking @electron/get cache with system unzip...'
-				local electron_cache_dir="${electron_config_cache:-$HOME/.cache/electron}"
+				local electron_cache_dir="$HOME/.cache/electron"
+				local electron_arch
+				case $architecture in
+					amd64) electron_arch='x64' ;;
+					arm64) electron_arch='arm64' ;;
+					*)     electron_arch='x64' ;;
+				esac
 				local cached_zip
-				cached_zip=$(find "$electron_cache_dir" -name "electron-v${electron_version}-linux-${target_architecture:-x64}.zip" 2>/dev/null | head -1)
+				cached_zip=$(find "$electron_cache_dir" -name "electron-v${electron_version}-linux-${electron_arch}.zip" 2>/dev/null | head -1)
 				if [[ -z $cached_zip ]]; then
 					echo "No cached zip matching electron-v${electron_version}-linux-*.zip under $electron_cache_dir" >&2
 					cd "$project_root" || exit 1
@@ -308,8 +323,8 @@ setup_electron_asar() {
 		echo 'Local Electron distribution and Asar binary already present.'
 	fi
 
-	if [[ -d $electron_dist_path ]]; then
-		echo "Found Electron distribution directory at $electron_dist_path."
+	if [[ -f $electron_dist_path/electron ]]; then
+		echo "Found Electron binary at $electron_dist_path."
 		chosen_electron_module_path="$(realpath "$work_dir/node_modules/electron")"
 		echo "Setting Electron module path for copying to $chosen_electron_module_path."
 	else


### PR DESCRIPTION
## Summary

Builds fail on Ubuntu 26.04 (sid/forky) + Node v24 with a confusing late-stage warning:

```
Warning: Staged Electron binary not found at expected path: …/electron-app/node_modules/electron/dist/electron
Warning: Electron resources directory not found at …/electron-app/node_modules/electron/dist/resources
Copying Claude locale JSON files to Electron resources directory...
cp: target '…/electron-app/node_modules/electron/dist/resources/': No such file or directory
```

Root cause: under Node 24, `extract-zip` (used by both the legacy electron postinstall and `@electron/get` via `fetch-electron-binary.js`) can silently no-op. The zip download succeeds (visible in `~/.cache/electron/<sha256>/electron-v…-linux-x64.zip`), but `extract` resolves without writing files — leaving only an empty `dist/locales/` subdirectory that npm created earlier.

The existing fallback chain doesn't catch this because `[[ ! -d $electron_dist_path ]]` passes (the empty `dist/` dir exists), so `fetch-electron-binary.js` never fires — and even when it does fire, it hits the same broken extract-zip.

## Changes (`scripts/setup/dependencies.sh`)

1. **Check for the binary, not just the dir.** `[[ ! -f $electron_dist_path/electron ]]` replaces `[[ ! -d $electron_dist_path ]]` so the `@electron/get` fallback triggers when extract-zip silently produced an empty dist.

2. **Final `unzip` fallback** after both `fetch-electron-binary.js` attempts. If we still have no binary, the zip is sitting in `~/.cache/electron/` ready to be unpacked — system `unzip` sidesteps the broken Node module entirely. Writes the `dist/version` + `path.txt` marker files so subsequent `install.js` calls see the install as complete.

3. Graceful errors when the cache zip or system `unzip` is missing (with actionable guidance).

## Reproduction

- Ubuntu 26.04 LTS amd64
- Node v24.16.0 (via NVM)
- `./build.sh` (default --clean yes)
- Without the patch: reliably fails as quoted above.
- With the patch: builds `claude-desktop_1.8555.0_amd64.deb` cleanly; installed and verified.

## Test plan

- [ ] Build on Ubuntu 26.04 + Node 24.16 → produces working `.deb`
- [ ] Build on Ubuntu 24.04 + Node 20 (LTS) → unchanged behavior (regression check)
- [ ] Manually delete `~/.cache/electron/` and rebuild → `@electron/get` re-downloads, unzip fallback unpacks
- [ ] System without `unzip` installed → fails gracefully with clear message rather than the cryptic stage_electron warning

## Notes

- The `unzip` dependency would be new for this fallback path. If preferred, the maintainer could add `unzip` to `scripts/setup/dependencies.sh`'s install list when the patch fires, or document it as a soft prereq. Most Debian/Ubuntu installs include it via `unzip` or `bsdmainutils` already.
- Doesn't affect the happy path on Node 20 where extract-zip works correctly — the new checks only fire when the binary is genuinely missing.
- Related to but distinct from #584 (which is about the postinstall removal in electron@42+); this is the same shaped failure mode in the existing @electron/get fallback under a different Node.

Fixes #584 for the Node 24 case.