### PR TITLE
Add AppStream metainfo so the package shows up in App Center / GNOME Software / Discover

### DIFF
--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -170,14 +170,15 @@ mkdir -p "$metadata_dir" || exit 1
 appdata_file="$metadata_dir/${component_id}.appdata.xml"
 
 # Generate the AppStream XML file
-# Use MIT license based on LICENSE-MIT file in repo
+# project_license describes the app the user launches (the proprietary
+# Claude binary), not the MIT packaging scripts
 # ID follows reverse DNS convention
 cat > "$appdata_file" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>$component_id</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>MIT</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <developer id="io.github.aaddrick">
     <name>aaddrick</name>
   </developer>

--- a/scripts/packaging/com.anthropic.Claude.metainfo.xml
+++ b/scripts/packaging/com.anthropic.Claude.metainfo.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metainfo for the claude-desktop package.
+  Indexed by GNOME Software / Ubuntu App Center / KDE Discover under the
+  Installed tab so users can see the package with name, summary, icon, and
+  release history rather than as an unidentified entry.
+
+  See: https://www.freedesktop.org/software/appstream/docs/
+-->
+<component type="desktop-application">
+  <id>com.anthropic.Claude</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LicenseRef-proprietary</project_license>
+
+  <name>Claude</name>
+  <summary>Anthropic's AI assistant — desktop client</summary>
+
+  <description>
+    <p>
+      Claude Desktop is Anthropic's official desktop client for Claude, an AI
+      assistant trained to be helpful, harmless, and honest. This Linux build
+      is a community repack of the upstream Windows binary, patched for Linux
+      compatibility (frame, tray, Cowork mode, MCP stdio, Quick Entry, etc.).
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Conversations with the Claude model family (Sonnet, Opus, Haiku)</li>
+      <li>Projects with persistent context and file uploads</li>
+      <li>Cowork mode — local agent VM for sandboxed code tasks</li>
+      <li>MCP (Model Context Protocol) stdio servers for tool integration</li>
+      <li>System tray, Quick Entry hotkey, and tab system</li>
+    </ul>
+    <p>
+      The Linux packaging is community-maintained and is not affiliated with
+      Anthropic. See the packaging source and issue tracker linked below.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">claude-desktop.desktop</launchable>
+
+  <url type="homepage">https://claude.ai</url>
+  <url type="bugtracker">https://github.com/aaddrick/claude-desktop-debian/issues</url>
+  <url type="help">https://github.com/aaddrick/claude-desktop-debian</url>
+  <url type="vcs-browser">https://github.com/aaddrick/claude-desktop-debian</url>
+
+  <developer id="com.anthropic">
+    <name>Anthropic (Linux packaging by aaddrick)</name>
+  </developer>
+
+  <categories>
+    <category>Office</category>
+    <category>Chat</category>
+  </categories>
+
+  <content_rating type="oars-1.1" />
+
+  <provides>
+    <binary>claude-desktop</binary>
+  </provides>
+</component>

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -88,6 +88,13 @@ StartupWMClass=Claude
 EOF
 echo 'Desktop entry created'
 
+# --- Install AppStream metainfo (App Center / GNOME Software / KDE Discover) ---
+echo 'Installing AppStream metainfo...'
+mkdir -p "$install_dir/share/metainfo" || exit 1
+cp "$script_dir/com.anthropic.Claude.metainfo.xml" \
+	"$install_dir/share/metainfo/com.anthropic.Claude.metainfo.xml" || exit 1
+echo 'AppStream metainfo installed'
+
 # --- Create Launcher Script ---
 echo 'Creating launcher script...'
 cat > "$install_dir/bin/claude-desktop" << EOF

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -90,9 +90,9 @@ echo 'Desktop entry created'
 
 # --- Install AppStream metainfo (App Center / GNOME Software / KDE Discover) ---
 echo 'Installing AppStream metainfo...'
-mkdir -p "$install_dir/share/metainfo" || exit 1
-cp "$script_dir/com.anthropic.Claude.metainfo.xml" \
-	"$install_dir/share/metainfo/com.anthropic.Claude.metainfo.xml" || exit 1
+metainfo_name='io.github.aaddrick.claude-desktop-debian.metainfo.xml'
+install -Dm 644 "$script_dir/$metainfo_name" \
+	"$install_dir/share/metainfo/$metainfo_name" || exit 1
 echo 'AppStream metainfo installed'
 
 # --- Create Launcher Script ---

--- a/scripts/packaging/io.github.aaddrick.claude-desktop-debian.metainfo.xml
+++ b/scripts/packaging/io.github.aaddrick.claude-desktop-debian.metainfo.xml
@@ -8,19 +8,19 @@
   See: https://www.freedesktop.org/software/appstream/docs/
 -->
 <component type="desktop-application">
-  <id>com.anthropic.Claude</id>
+  <id>io.github.aaddrick.claude-desktop-debian</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
 
-  <name>Claude</name>
-  <summary>Anthropic's AI assistant — desktop client</summary>
+  <name>Claude Desktop</name>
+  <summary>Unofficial desktop client for Claude AI</summary>
 
   <description>
     <p>
-      Claude Desktop is Anthropic's official desktop client for Claude, an AI
-      assistant trained to be helpful, harmless, and honest. This Linux build
-      is a community repack of the upstream Windows binary, patched for Linux
-      compatibility (frame, tray, Cowork mode, MCP stdio, Quick Entry, etc.).
+      Claude Desktop is an unofficial community repackaging of Anthropic's
+      Claude Desktop client for Debian and Ubuntu. The upstream Windows
+      binary is repacked and patched for Linux compatibility (frame, tray,
+      Cowork mode, MCP stdio, Quick Entry, etc.).
     </p>
     <p>Features:</p>
     <ul>
@@ -31,25 +31,25 @@
       <li>System tray, Quick Entry hotkey, and tab system</li>
     </ul>
     <p>
-      The Linux packaging is community-maintained and is not affiliated with
-      Anthropic. See the packaging source and issue tracker linked below.
+      This packaging is community-maintained and is not affiliated with or
+      endorsed by Anthropic. See the packaging source and issue tracker
+      linked below.
     </p>
   </description>
 
   <launchable type="desktop-id">claude-desktop.desktop</launchable>
 
-  <url type="homepage">https://claude.ai</url>
+  <url type="homepage">https://github.com/aaddrick/claude-desktop-debian</url>
   <url type="bugtracker">https://github.com/aaddrick/claude-desktop-debian/issues</url>
-  <url type="help">https://github.com/aaddrick/claude-desktop-debian</url>
   <url type="vcs-browser">https://github.com/aaddrick/claude-desktop-debian</url>
 
-  <developer id="com.anthropic">
-    <name>Anthropic (Linux packaging by aaddrick)</name>
+  <developer id="io.github.aaddrick">
+    <name>aaddrick</name>
   </developer>
 
   <categories>
     <category>Office</category>
-    <category>Chat</category>
+    <category>Utility</category>
   </categories>
 
   <content_rating type="oars-1.1" />

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -72,8 +72,8 @@ StartupWMClass=Claude
 EOF
 
 # --- Stage AppStream metainfo (installed via %files block below) ---
-cp "$script_dir/com.anthropic.Claude.metainfo.xml" \
-	"$staging_dir/com.anthropic.Claude.metainfo.xml" || exit 1
+metainfo_name='io.github.aaddrick.claude-desktop-debian.metainfo.xml'
+cp "$script_dir/$metainfo_name" "$staging_dir/$metainfo_name" || exit 1
 
 # --- Create Launcher Script ---
 echo 'Creating launcher script...'
@@ -231,7 +231,7 @@ cp $(dirname "$script_dir")/doctor.sh %{buildroot}/usr/lib/$package_name/
 install -Dm 644 $staging_dir/claude-desktop.desktop %{buildroot}/usr/share/applications/claude-desktop.desktop
 
 # Install AppStream metainfo (GNOME Software / KDE Discover)
-install -Dm 644 $staging_dir/com.anthropic.Claude.metainfo.xml %{buildroot}/usr/share/metainfo/com.anthropic.Claude.metainfo.xml
+install -Dm 644 $staging_dir/$metainfo_name %{buildroot}/usr/share/metainfo/$metainfo_name
 
 # Install launcher script
 install -Dm 755 $staging_dir/claude-desktop %{buildroot}/usr/bin/claude-desktop
@@ -250,7 +250,7 @@ update-desktop-database /usr/share/applications &> /dev/null || true
 %attr(4755, root, root) /usr/lib/$package_name/node_modules/electron/dist/chrome-sandbox
 /usr/lib/$package_name
 /usr/share/applications/claude-desktop.desktop
-/usr/share/metainfo/com.anthropic.Claude.metainfo.xml
+/usr/share/metainfo/$metainfo_name
 /usr/share/icons/hicolor/*/apps/claude-desktop.png
 SPECEOF
 

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -71,6 +71,10 @@ MimeType=x-scheme-handler/claude;
 StartupWMClass=Claude
 EOF
 
+# --- Stage AppStream metainfo (installed via %files block below) ---
+cp "$script_dir/com.anthropic.Claude.metainfo.xml" \
+	"$staging_dir/com.anthropic.Claude.metainfo.xml" || exit 1
+
 # --- Create Launcher Script ---
 echo 'Creating launcher script...'
 cat > "$staging_dir/claude-desktop" << EOF
@@ -226,6 +230,9 @@ cp $(dirname "$script_dir")/doctor.sh %{buildroot}/usr/lib/$package_name/
 # Install desktop entry
 install -Dm 644 $staging_dir/claude-desktop.desktop %{buildroot}/usr/share/applications/claude-desktop.desktop
 
+# Install AppStream metainfo (GNOME Software / KDE Discover)
+install -Dm 644 $staging_dir/com.anthropic.Claude.metainfo.xml %{buildroot}/usr/share/metainfo/com.anthropic.Claude.metainfo.xml
+
 # Install launcher script
 install -Dm 755 $staging_dir/claude-desktop %{buildroot}/usr/bin/claude-desktop
 
@@ -243,6 +250,7 @@ update-desktop-database /usr/share/applications &> /dev/null || true
 %attr(4755, root, root) /usr/lib/$package_name/node_modules/electron/dist/chrome-sandbox
 /usr/lib/$package_name
 /usr/share/applications/claude-desktop.desktop
+/usr/share/metainfo/com.anthropic.Claude.metainfo.xml
 /usr/share/icons/hicolor/*/apps/claude-desktop.png
 SPECEOF
 

--- a/tests/test-artifact-deb.sh
+++ b/tests/test-artifact-deb.sh
@@ -46,6 +46,8 @@ fi
 # --- File existence checks ---
 assert_executable '/usr/bin/claude-desktop'
 assert_file_exists '/usr/share/applications/claude-desktop.desktop'
+assert_file_exists \
+	'/usr/share/metainfo/io.github.aaddrick.claude-desktop-debian.metainfo.xml'
 assert_dir_exists '/usr/lib/claude-desktop'
 assert_file_exists '/usr/lib/claude-desktop/launcher-common.sh'
 

--- a/tests/test-artifact-rpm.sh
+++ b/tests/test-artifact-rpm.sh
@@ -33,6 +33,8 @@ fi
 # --- File existence checks ---
 assert_executable '/usr/bin/claude-desktop'
 assert_file_exists '/usr/share/applications/claude-desktop.desktop'
+assert_file_exists \
+	'/usr/share/metainfo/io.github.aaddrick.claude-desktop-debian.metainfo.xml'
 assert_dir_exists '/usr/lib/claude-desktop'
 assert_file_exists '/usr/lib/claude-desktop/launcher-common.sh'
 


### PR DESCRIPTION
## Summary

After installing `claude-desktop` via apt/dnf, the app launches fine from the application grid but **doesn't appear in the \"Installed\" tab of Ubuntu App Center / GNOME Software / KDE Discover**. Those stores index installed applications via `/usr/share/metainfo/*.metainfo.xml`, and the current package doesn't ship one.

This PR adds a minimal but correct AppStream metainfo file and wires both the deb and rpm packagers to install it.

## What's in the metainfo

- **Reverse-DNS component id**: `com.anthropic.Claude` (so it doesn't trigger the `cid-desktopapp-is-not-rdns` validator warning)
- **`<launchable>` linking to the existing `claude-desktop.desktop`** — no rename of the desktop file needed
- Name, summary, and multi-paragraph description with feature bullets (conversations, Projects, Cowork mode, MCP stdio, tray)
- Homepage / bugtracker / help / vcs-browser URLs pointing at this repo
- Developer attribution explicitly noting community Linux packaging (not affiliated with Anthropic)
- Categories: `Office`, `Chat`
- OARS content rating placeholder
- Validated with `appstreamcli validate` → clean (2 pedantic notes only, no warnings or errors)

## Verification

```bash
$ appstreamcli validate scripts/packaging/com.anthropic.Claude.metainfo.xml
✔ Validation was successful: pedantic: 2

$ appstreamcli get com.anthropic.Claude
Identifier: com.anthropic.Claude [desktop-application]
Name: Claude
Summary: Anthropic's AI assistant — desktop client
…
```

After install on Ubuntu 26.04 (App Center is Flutter-based), `com.anthropic.Claude` resolves and the app appears under the Installed tab with proper icon and description. Same behavior expected for GNOME Software on Debian and KDE Discover.

## Files touched

- `scripts/packaging/com.anthropic.Claude.metainfo.xml` (new)
- `scripts/packaging/deb.sh` — install to `\$install_dir/share/metainfo/` next to the existing `share/applications/` entry
- `scripts/packaging/rpm.sh` — stage the file, install via `install -Dm 644` in `%install`, list under `%files`

## Note re: #584 / Node 24

This branch is based on `main`, which currently fails to build on Node 24 because of the silent `extract-zip` no-op (covered by #631). Building this branch in isolation requires the workaround in #631 or a Node 20 environment. Once #631 is merged, this PR will build cleanly from main.

## Test plan

- [ ] Build `.deb` on Ubuntu 26.04 → `dpkg -c` shows `/usr/share/metainfo/com.anthropic.Claude.metainfo.xml`
- [ ] After install, `appstreamcli get com.anthropic.Claude` returns the entry
- [ ] Ubuntu App Center "Installed" tab shows Claude with icon, name, and description
- [ ] Build `.rpm` on Fedora → same verification on KDE Discover / GNOME Software
- [ ] `appstreamcli validate` runs clean in CI