### PR TITLE
fix(launcher): add --class=Claude for WM_CLASS consistency

### DIFF
--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -181,6 +181,13 @@ build_electron_args() {
 		electron_args+=('--disable-features=CustomTitlebar')
 	fi
 
+	# Explicitly set the X11 WM_CLASS to match StartupWMClass=Claude in
+	# the .desktop file. Without this, Electron can pick an unpredictable
+	# class name (e.g. "electron", "AdwaitaHandy"), which breaks taskbar
+	# grouping and can crash GNOME extensions that filter by WM_CLASS.
+	# Ref: #635
+	electron_args+=('--class=Claude')
+
 	# Chromium's safeStorage API and cookie encryption both require a
 	# system keyring selected by --password-store. Without an explicit
 	# value, Electron may silently report encryption unavailable even

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -182,10 +182,10 @@ build_electron_args() {
 	fi
 
 	# Explicitly set the X11 WM_CLASS to match StartupWMClass=Claude in
-	# the .desktop file. Without this, Electron can pick an unpredictable
-	# class name (e.g. "electron", "AdwaitaHandy"), which breaks taskbar
-	# grouping and can crash GNOME extensions that filter by WM_CLASS.
-	# Ref: #635
+	# the .desktop file. Without this, Electron may derive an
+	# unpredictable class name, which breaks taskbar grouping and can
+	# trigger crashes in third-party GNOME extensions that filter by
+	# WM_CLASS. Ref: #635
 	electron_args+=('--class=Claude')
 
 	# Chromium's safeStorage API and cookie encryption both require a


### PR DESCRIPTION
## Summary
- Add `--class=Claude` to Electron launcher args in `build_electron_args()`
- Ensures X11 WM_CLASS matches `StartupWMClass=Claude` in the .desktop file
- Prevents GNOME extension crashes from unexpected WM_CLASS values (e.g. `AdwaitaHandy`)

Ref #635

## Test plan
- [x] Launch app and verify `xprop WM_CLASS` shows `Claude`
- [x] Verify taskbar grouping still works correctly
- [ ] Verify no regression on KDE/GNOME/XFCE

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: implemented the fix based on issue analysis pipeline findings
Human: identified the quick win and directed implementation