### PR TITLE
fix(launcher): exec Electron to fix Ctrl+C / signal forwarding

### DIFF
--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -265,12 +265,10 @@ build_electron_args 'nix'
 # Add app path
 electron_args+=("$app_path")
 
-# Execute Electron
+# Execute Electron (exec replaces the shell process so signals
+# like SIGINT, SIGTERM, and SIGHUP reach Electron directly)
 log_message "Executing: $electron_exec ''${electron_args[*]} $*"
-"$electron_exec" "''${electron_args[@]}" "$@" >> "$log_file" 2>&1
-exit_code=$?
-log_message "Electron exited with code: $exit_code"
-exit $exit_code
+exec "$electron_exec" "''${electron_args[@]}" "$@" >> "$log_file" 2>&1
 LAUNCHER
     # Substitute placeholders — electron_exec points to our custom
     # wrapper (which sets GTK/GIO env then execs our merged binary)

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -166,13 +166,10 @@ app_dir="/usr/lib/$package_name"
 log_message "Changing directory to \$app_dir"
 cd "\$app_dir" || { log_message "Failed to cd to \$app_dir"; exit 1; }
 
-# Execute Electron
+# Execute Electron (exec replaces the shell process so signals
+# like SIGINT, SIGTERM, and SIGHUP reach Electron directly)
 log_message "Executing: \$electron_exec \${electron_args[*]} \$*"
-"\$electron_exec" "\${electron_args[@]}" "\$@" >> "\$log_file" 2>&1
-exit_code=\$?
-log_message "Electron exited with code: \$exit_code"
-log_message '--- Claude Desktop Launcher End ---'
-exit \$exit_code
+exec "\$electron_exec" "\${electron_args[@]}" "\$@" >> "\$log_file" 2>&1
 EOF
 chmod +x "$install_dir/bin/claude-desktop" || exit 1
 echo 'Launcher script created'

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -149,13 +149,10 @@ app_dir="/usr/lib/$package_name"
 log_message "Changing directory to \$app_dir"
 cd "\$app_dir" || { log_message "Failed to cd to \$app_dir"; exit 1; }
 
-# Execute Electron
+# Execute Electron (exec replaces the shell process so signals
+# like SIGINT, SIGTERM, and SIGHUP reach Electron directly)
 log_message "Executing: \$electron_exec \${electron_args[*]} \$*"
-"\$electron_exec" "\${electron_args[@]}" "\$@" >> "\$log_file" 2>&1
-exit_code=\$?
-log_message "Electron exited with code: \$exit_code"
-log_message '--- Claude Desktop Launcher End ---'
-exit \$exit_code
+exec "\$electron_exec" "\${electron_args[@]}" "\$@" >> "\$log_file" 2>&1
 EOF
 chmod +x "$staging_dir/claude-desktop"
 


### PR DESCRIPTION
## Summary
- Add `exec` before Electron invocation in deb, RPM, and Nix launchers
- Removes unreachable exit-code logging after exec (low diagnostic value — these lines only logged *after* Electron exited, not during runtime)
- Fixes signal forwarding for SIGINT, SIGTERM, SIGHUP, SIGTSTP

Without `exec`, the launcher shell stays alive as a parent process. Electron handles SIGINT internally and never dies from it, so Ctrl+C in a terminal does nothing and the process tree keeps running. With `exec`, the shell is replaced by Electron, so signals go directly to the right process.

The AppImage launcher (`scripts/packaging/appimage.sh:118`) already uses `exec` correctly and is unchanged.

Fixes #424

## Test plan
- [x] Build deb package and verify Ctrl+C terminates the app
- [x] Verify `kill <pid>` of the launcher process terminates Electron
- [x] Verify AppImage behavior unchanged (already uses exec)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: implemented the fix based on issue analysis pipeline findings
Human: identified the quick win and directed implementation