### PR TITLE
feat(frame-fix): add F11 fullscreen toggle

### DIFF
--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -551,6 +551,27 @@ Module.prototype.require = function(id) {
       const originalSetAppMenu = OriginalMenu.setApplicationMenu.bind(OriginalMenu);
       patchedSetApplicationMenu = function(menu) {
         console.log('[Frame Fix] Intercepting setApplicationMenu');
+
+        // Append a hidden View submenu with F11 fullscreen toggle.
+        // Upstream has fullscreenable:true and persists isFullScreen
+        // across sessions; macOS provides the green traffic-light
+        // button; Linux has no equivalent OS-level trigger, so we
+        // register an accelerator here. visible:false keeps it out
+        // of the menu bar — it only registers the keybinding.
+        // Fixes: #580
+        if (process.platform === 'linux' && menu) {
+          const { MenuItem, Menu: MenuClass } = electronModule;
+          menu.append(new MenuItem({
+            label: 'View',
+            visible: false,
+            submenu: MenuClass.buildFromTemplate([{
+              label: 'Toggle Full Screen',
+              role: 'togglefullscreen',
+              accelerator: 'F11',
+            }]),
+          }));
+        }
+
         originalSetAppMenu(menu);
         if (process.platform === 'linux' && MENU_BAR_MODE === 'hidden') {
           for (const win of PatchedBrowserWindow.getAllWindows()) {


### PR DESCRIPTION
## Summary
- Add F11 fullscreen toggle via hidden menu accelerator in `frame-fix-wrapper.js`
- Linux parity patch: upstream has `fullscreenable: true` + state persistence, macOS provides the green button, Linux needs an explicit keybinding
- Uses `role: 'togglefullscreen'` with `visible: false` so there is no visual menu change — only the accelerator is registered

Fixes #580

## Test plan
- [x] Press F11 to enter fullscreen
- [x] Press F11 again to exit fullscreen
- [ ] Verify fullscreen state persists across restart (upstream handles this)
- [x] Verify no menu visual changes (item is hidden)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
90% AI / 10% Human
Claude: implemented the fix based on issue analysis pipeline findings
Human: identified the quick win and directed implementation