### PR TITLE
fix(patches): add Linux org-plugins path to platform switch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -60,6 +60,8 @@ source "$script_dir/scripts/patches/quick-window.sh"
 source "$script_dir/scripts/patches/claude-code.sh"
 # shellcheck source=scripts/patches/cowork.sh
 source "$script_dir/scripts/patches/cowork.sh"
+# shellcheck source=scripts/patches/org-plugins.sh
+source "$script_dir/scripts/patches/org-plugins.sh"
 # shellcheck source=scripts/patches/wco-shim.sh
 source "$script_dir/scripts/patches/wco-shim.sh"
 # shellcheck source=scripts/staging/electron.sh

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -95,6 +95,9 @@ console.log('Updated package.json: main entry, desktopName, and node-pty depende
 	# Patch Cowork mode for Linux (TypeScript VM client + Unix socket)
 	patch_cowork_linux
 
+	# Add Linux org-plugins path for MDM-managed plugin marketplace
+	patch_org_plugins_path
+
 	# Inject WCO shim into the BrowserView preload so claude.ai's
 	# desktop topbar renders on Linux. The shim spoofs the bundle's
 	# isWindows() UA check (load-bearing) plus matchMedia and

--- a/scripts/patches/org-plugins.sh
+++ b/scripts/patches/org-plugins.sh
@@ -30,7 +30,7 @@ patch_org_plugins_path() {
 	local anchor='Application Support/Claude/org-plugins'
 	if ! grep -q "$anchor" "$index_js"; then
 		echo 'Warning: org-plugins path resolver not found' \
-			'in this version, skipping'
+			'in this version, skipping' >&2
 		return
 	fi
 
@@ -52,6 +52,6 @@ patch_org_plugins_path() {
 		echo 'Added Linux org-plugins path (/etc/claude/org-plugins)'
 	else
 		echo 'Warning: org-plugins switch pattern not matched,' \
-			'skipping'
+			'skipping' >&2
 	fi
 }

--- a/scripts/patches/org-plugins.sh
+++ b/scripts/patches/org-plugins.sh
@@ -1,0 +1,57 @@
+#===============================================================================
+# Linux org-plugins path: inject a case"linux" into the platform switch
+# that resolves the org-plugins source directory.
+#
+# Upstream only has cases for darwin and win32; the default returns null,
+# silently disabling the entire org-plugins marketplace feature on Linux.
+# This adds: case"linux":return"/etc/claude/org-plugins"
+#
+# /etc/claude/org-plugins is FHS-correct for MDM-managed configuration,
+# consistent with Claude Code's /etc/claude-code/ path.
+#
+# Sourced by: build.sh
+# Sourced globals: (none)
+# Modifies globals: (none)
+#===============================================================================
+
+patch_org_plugins_path() {
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Idempotency: skip if a Linux case already exists near the
+	# org-plugins path resolver (upstream may add one in the future).
+	if grep -q 'case"linux":return"/etc/claude/org-plugins"' \
+		"$index_js"; then
+		echo 'Linux org-plugins path already present'
+		return
+	fi
+
+	# Anchor: the darwin path string is unique in the entire bundle.
+	# Verify it exists before attempting the patch.
+	local anchor='Application Support/Claude/org-plugins'
+	if ! grep -q "$anchor" "$index_js"; then
+		echo 'Warning: org-plugins path resolver not found' \
+			'in this version, skipping'
+		return
+	fi
+
+	# Pattern (minified):
+	#   ..."org-plugins");default:return null}
+	#
+	# The compound anchor — "org-plugins") immediately before
+	# default:return null — is unique to this switch statement.
+	# Insert case"linux":return"/etc/claude/org-plugins"; between
+	# the end of the win32 case and the default case.
+	#
+	# \s* between tokens handles any future whitespace variation,
+	# though the target file is always minified in practice.
+	if grep -qP '"org-plugins"\)\s*;\s*default\s*:\s*return\s+null' \
+		"$index_js"; then
+		sed -i -E \
+			's/("org-plugins"\)\s*;\s*)(default\s*:\s*return\s+null)/\1case"linux":return"\/etc\/claude\/org-plugins";\2/' \
+			"$index_js"
+		echo 'Added Linux org-plugins path (/etc/claude/org-plugins)'
+	else
+		echo 'Warning: org-plugins switch pattern not matched,' \
+			'skipping'
+	fi
+}


### PR DESCRIPTION
## Summary
- Add Linux case to org-plugins path resolver (`scripts/patches/org-plugins.sh`)
- Returns `/etc/claude/org-plugins` for MDM-managed plugin configuration
- Upstream only has cases for darwin and win32; default returns null, silently disabling the org-plugins marketplace on Linux

Fixes #607

## Test plan
- [x] Build with patch and verify no patch warnings
- [x] Verify org-plugins feature is no longer silently disabled on Linux
- [x] Verify patch is idempotent (second build produces no changes)
- [x] Verify anchor validation skips gracefully on versions without org-plugins

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: implemented the fix based on issue analysis pipeline findings
Human: identified the quick win and directed implementation