### PR TITLE
fix: harden CI, build pipeline, and packaging scriptlets

### DIFF
--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -215,6 +215,7 @@ jobs:
         if: steps.classify.outputs.classification == 'bug' || steps.classify.outputs.classification == 'enhancement'
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          FIRST_PASS: ${{ steps.classify.outputs.classification }}
         run: |
           schema=$(cat .claude/scripts/schemas/classify-doublecheck-bug-vs-enhancement.json)
           title=$(jq -r '.title' /tmp/triage/issue.json)
@@ -249,7 +250,7 @@ jobs:
           printf '%s' "${structured}" \
             > /tmp/triage/classification-doublecheck.json
 
-          first_pass="${{ steps.classify.outputs.classification }}"
+          first_pass="${FIRST_PASS}"
           verdict=$(jq -r '.verdict' \
             /tmp/triage/classification-doublecheck.json)
 
@@ -271,10 +272,14 @@ jobs:
       # classifier entirely.
       - name: Decide route
         id: route
+        env:
+          SUSPICIOUS: ${{ steps.suspicious.outputs.suspicious }}
+          CLASSIFICATION: ${{ steps.classify.outputs.classification }}
+          DISAGREED: ${{ steps.doublecheck.outputs.disagreed }}
         run: |
-          suspicious="${{ steps.suspicious.outputs.suspicious }}"
-          classification="${{ steps.classify.outputs.classification }}"
-          disagreed="${{ steps.doublecheck.outputs.disagreed }}"
+          suspicious="${SUSPICIOUS}"
+          classification="${CLASSIFICATION}"
+          disagreed="${DISAGREED}"
 
           if [[ "${suspicious}" == "true" ]]; then
             echo "route=deferral" >> "$GITHUB_OUTPUT"
@@ -484,6 +489,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CLASSIFICATION_NAME: ${{ steps.classify.outputs.classification }}
+          HAS_REGRESSION: ${{ steps.regression.outputs.has_regression }}
         run: |
           schema=$(cat .claude/scripts/schemas/investigate.json)
           title=$(jq -r '.title' /tmp/triage/issue.json)
@@ -530,7 +536,7 @@ jobs:
             # the PR. The reporter named a culprit; the diff is a
             # primary input for Stage 4 because the defect site is
             # almost always inside the named PR's changed files.
-            if [[ "${{ steps.regression.outputs.has_regression }}" == "true" ]]; then
+            if [[ "${HAS_REGRESSION}" == "true" ]]; then
               echo "## Regression context (PR named by reporter)"
               echo ""
               reg_title=$(jq -r '.title' /tmp/triage/regression-of.json)
@@ -763,6 +769,7 @@ jobs:
               || steps.dup_fetch.outputs.dup_fetched == 'true')
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          HAS_REGRESSION: ${{ steps.regression.outputs.has_regression }}
           CLASSIFICATION_NAME: ${{ steps.classify.outputs.classification }}
         run: |
           schema=$(cat .claude/scripts/schemas/review.json)
@@ -867,7 +874,7 @@ jobs:
             # regression_of diff block — only when Stage 3b validated.
             # Lets the reviewer check whether a finding's citation
             # actually lands inside the named PR's changed files.
-            if [[ "${{ steps.regression.outputs.has_regression }}" == "true" ]]; then
+            if [[ "${HAS_REGRESSION}" == "true" ]]; then
               echo "## regression_of PR diff (reporter-named culprit)"
               echo ""
               reg_num=$(jq -r '.pr_number' /tmp/triage/regression-of.json)
@@ -1027,25 +1034,37 @@ jobs:
       # low-confidence cause).
       - name: Decide comment variant
         id: decide
+        env:
+          ROUTE: ${{ steps.route.outputs.route }}
+          DEFERRAL_REASON_ID: ${{ steps.route.outputs.deferral_reason_id }}
+          CLASSIFICATION: ${{ steps.classify.outputs.classification }}
+          FETCH_OK: ${{ steps.fetch.outputs.fetch_ok }}
+          INVEST_OK: ${{ steps.investigate.outputs.investigate_ok }}
+          DRIFT: ${{ steps.drift.outputs.drift_detected }}
+          REVIEW_OK: ${{ steps.review.outputs.review_ok }}
+          FINDINGS_PASSED: ${{ steps.validate.outputs.findings_passed }}
+          KEPT: ${{ steps.filter.outputs.review_findings_kept }}
+          AVG: ${{ steps.filter.outputs.review_avg_confidence }}
+          DUP_RATING: ${{ steps.filter.outputs.duplicate_of_rating }}
         run: |
-          route="${{ steps.route.outputs.route }}"
+          route="${ROUTE}"
 
           if [[ "${route}" == "deferral" ]]; then
             echo "variant=8b" >> "$GITHUB_OUTPUT"
-            echo "reason_id=${{ steps.route.outputs.deferral_reason_id }}" \
+            echo "reason_id=${DEFERRAL_REASON_ID}" \
               >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          classification="${{ steps.classify.outputs.classification }}"
-          fetch_ok="${{ steps.fetch.outputs.fetch_ok }}"
-          invest_ok="${{ steps.investigate.outputs.investigate_ok }}"
-          drift="${{ steps.drift.outputs.drift_detected }}"
-          review_ok="${{ steps.review.outputs.review_ok }}"
-          findings_passed="${{ steps.validate.outputs.findings_passed }}"
-          kept="${{ steps.filter.outputs.review_findings_kept }}"
-          avg="${{ steps.filter.outputs.review_avg_confidence }}"
-          dup_rating="${{ steps.filter.outputs.duplicate_of_rating }}"
+          classification="${CLASSIFICATION}"
+          fetch_ok="${FETCH_OK}"
+          invest_ok="${INVEST_OK}"
+          drift="${DRIFT}"
+          review_ok="${REVIEW_OK}"
+          findings_passed="${FINDINGS_PASSED}"
+          kept="${KEPT}"
+          avg="${AVG}"
+          dup_rating="${DUP_RATING}"
 
           # Shared gates that apply to every investigate route.
           if [[ "${fetch_ok}" != "true" ]]; then
@@ -1735,9 +1754,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REASON_ID: ${{ steps.decide.outputs.reason_id }}
+          CLASSIFICATION: ${{ steps.classify.outputs.classification }}
+          VARIANT: ${{ steps.decide.outputs.variant }}
         run: |
-          classification="${{ steps.classify.outputs.classification }}"
-          variant="${{ steps.decide.outputs.variant }}"
+          classification="${CLASSIFICATION}"
+          variant="${VARIANT}"
 
           if [[ "${variant}" == "8a" ]]; then
             triage_label="triage: investigated"

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -203,7 +203,7 @@ set -e
 
 # Update desktop database for MIME types
 echo "Updating desktop database..."
-update-desktop-database /usr/share/applications &> /dev/null || true
+update-desktop-database /usr/share/applications > /dev/null 2>&1 || true
 
 # Set correct permissions for chrome-sandbox if electron is installed globally
 # or locally packaged

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -233,11 +233,11 @@ chmod 4755 %{buildroot}/usr/lib/$package_name/node_modules/electron/dist/chrome-
 
 %post
 # Update desktop database for MIME types
-update-desktop-database /usr/share/applications &> /dev/null || true
+update-desktop-database /usr/share/applications > /dev/null 2>&1 || true
 
 %postun
 # Update desktop database after removal
-update-desktop-database /usr/share/applications &> /dev/null || true
+update-desktop-database /usr/share/applications > /dev/null 2>&1 || true
 
 %files
 %defattr(-, root, root, 0755)

--- a/scripts/patches/quick-window.sh
+++ b/scripts/patches/quick-window.sh
@@ -61,7 +61,7 @@ const focusedPropRe = /isWindowFocused:\s*\(\)\s*=>\s*!!(\w+)\(\)/;
 const focusedMatch = code.match(focusedPropRe);
 if (!focusedMatch) {
     console.log('  WARNING: Could not find isWindowFocused function');
-    process.exit(0);
+    process.exit(1);
 }
 const focusFn = focusedMatch[1];
 console.log('  Found focus check function: ' + focusFn);
@@ -79,7 +79,7 @@ const visMatch = nearbyCode.match(visFnRe);
 if (!visMatch) {
     console.log('  WARNING: Could not find visibility function near ' +
         focusFn);
-    process.exit(0);
+    process.exit(1);
 }
 const visFn = visMatch[1];
 console.log('  Found visibility check function: ' + visFn);


### PR DESCRIPTION
## Summary

- **CI injection hardening (#554):** Moved all `${{ steps.*.outputs.* }}` expressions out of `run:` shell blocks into `env:` blocks in `issue-triage-v2.yml`. This is the workflow with the widest attack surface (triggered by any user opening an issue, processes untrusted input, has `issues: write` + API key access). While current values are schema-constrained enums, the pattern itself is the vulnerability — eliminates it as precedent.

- **Build pipeline integrity (#429):** Changed `process.exit(0)` → `process.exit(1)` in `quick-window.sh` so that when patch anchors aren't found (e.g., after an upstream version bump), CI correctly fails instead of silently shipping broken patches with a green status.

- **Packaging scriptlet bashism:** Replaced `&> /dev/null` with `> /dev/null 2>&1` in deb `postinst` and RPM `%post`/`%postun` scriptlets. These run under `/bin/sh` (dash on Debian), where `&>` is undefined behavior — stderr leaks to the terminal during `apt install`.

## Test plan

- [ ] `actionlint` passes on issue-triage-v2.yml (verified locally)
- [ ] `shellcheck` clean on modified scripts (verified locally, pre-existing SC2148/SC2154 only)
- [ ] Trigger issue-triage-v2 on a test issue to confirm env var plumbing works
- [ ] Build a deb and confirm postinst runs cleanly under dash

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: researched injection sites, wrote all fixes, validated with actionlint/shellcheck
Human: directed priorities, approved approach