### PR TITLE
fix(patches): preserve mcpServers across config writes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -64,6 +64,8 @@ source "$script_dir/scripts/patches/cowork.sh"
 source "$script_dir/scripts/patches/org-plugins.sh"
 # shellcheck source=scripts/patches/wco-shim.sh
 source "$script_dir/scripts/patches/wco-shim.sh"
+# shellcheck source=scripts/patches/config.sh
+source "$script_dir/scripts/patches/config.sh"
 # shellcheck source=scripts/staging/electron.sh
 source "$script_dir/scripts/staging/electron.sh"
 # shellcheck source=scripts/staging/icons.sh

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -110,6 +110,13 @@ console.log('Updated package.json: main entry, desktopName, and node-pty depende
 	# docs/learnings/linux-topbar-shim.md.
 	patch_wco_shim
 
+	# Preserve externally-added mcpServers across config writes (#400)
+	patch_config_write_merge
+
+	# Reject .asar paths in addTrustedFolder to reduce spurious config
+	# writes that amplify the stale-cache overwrite bug (#400)
+	patch_asar_trusted_folder_guard
+
 	# Copy cowork VM service daemon for Linux Cowork mode
 	echo 'Installing cowork VM service daemon...'
 	cp "$source_dir/scripts/cowork-vm-service.js" \

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -1,0 +1,142 @@
+#===============================================================================
+# Config-related patches: preserve externally-added mcpServers across config
+# writes, and guard addTrustedFolder against .asar paths.
+#
+# Sourced by: build.sh
+# Sourced globals: project_root
+# Modifies globals: (none)
+#===============================================================================
+
+patch_config_write_merge() {
+	echo 'Patching config writer to preserve mcpServers from disk...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Idempotency guard
+	if grep -q '_cdd_dc' "$index_js"; then
+		echo '  mcpServers merge already present (idempotent)'
+		echo '##############################################################'
+		return
+	fi
+
+	# Extract variable names from the unique anchor:
+	#   await WRITE_FN(PATH_VAR, CONFIG_VAR), LOGGER.info("Config file written")
+	local write_fn path_var config_var
+
+	write_fn=$(grep -oP \
+		'await \K[$\w]+(?=\([$\w]+,\s*[$\w]+\)\s*,\s*[$\w]+\.info\("Config file written"\))' \
+		"$index_js")
+	if [[ -z $write_fn ]]; then
+		echo '  Could not extract write function name — skipping' >&2
+		echo '##############################################################'
+		return
+	fi
+
+	local write_fn_re="${write_fn//\$/\\$}"
+
+	path_var=$(grep -oP \
+		"await ${write_fn_re}\\(\\K[\$\\w]+(?=,\\s*[\$\\w]+\\)\\s*,\\s*[\$\\w]+\\.info\\(\"Config file written\"\\))" \
+		"$index_js")
+	if [[ -z $path_var ]]; then
+		echo '  Could not extract path variable — skipping' >&2
+		echo '##############################################################'
+		return
+	fi
+
+	local path_var_re="${path_var//\$/\\$}"
+
+	config_var=$(grep -oP \
+		"await ${write_fn_re}\\(${path_var_re},\\s*\\K[\$\\w]+(?=\\)\\s*,\\s*[\$\\w]+\\.info\\(\"Config file written\"\\))" \
+		"$index_js")
+	if [[ -z $config_var ]]; then
+		echo '  Could not extract config variable — skipping' >&2
+		echo '##############################################################'
+		return
+	fi
+
+	echo "  Write fn: $write_fn, path: $path_var, config: $config_var"
+
+	if ! WRITE_FN="$write_fn" PATH_VAR="$path_var" CFG_VAR="$config_var" \
+		node -e "
+const fs = require('fs');
+const p = 'app.asar.contents/.vite/build/index.js';
+const W = process.env.WRITE_FN;
+const P = process.env.PATH_VAR;
+const C = process.env.CFG_VAR;
+let code = fs.readFileSync(p, 'utf8');
+
+const reEsc = (s) => s.replace(/[.*+?\${}()|[\\]\\\\]/g, '\\\\\$&');
+const anchor = new RegExp(
+  'await\\\\s+' + reEsc(W) + '\\\\(' + reEsc(P) + ',\\\\s*' + reEsc(C) +
+  '\\\\)\\\\s*,\\\\s*\\\\w+\\\\.info\\\\(\"Config file written\"\\\\)'
+);
+if (!anchor.test(code)) {
+  console.error('  [FAIL] Config-write anchor not found');
+  process.exit(1);
+}
+
+const merge =
+  'try{var _cdd_dc=JSON.parse(require(\"fs\").readFileSync(' + P +
+  ',\"utf8\"));if(_cdd_dc.mcpServers){' + C +
+  '.mcpServers=Object.assign({},_cdd_dc.mcpServers,' + C +
+  '.mcpServers||{})}}catch(_cdd_ex){}';
+
+code = code.replace(anchor, (m) => merge + ';' + m);
+fs.writeFileSync(p, code);
+console.log('  [OK] mcpServers merge injected before config write');
+"; then
+		echo 'Failed to inject config write merge' >&2
+		cd "$project_root" || exit 1
+		exit 1
+	fi
+
+	echo '##############################################################'
+}
+
+patch_asar_trusted_folder_guard() {
+	echo 'Patching addTrustedFolder to reject .asar paths...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Idempotency guard
+	if grep -qF 'endsWith(".asar"))return' "$index_js"; then
+		echo '  .asar guard already present (idempotent)'
+		echo '##############################################################'
+		return
+	fi
+
+	local folder_param
+	folder_param=$(grep -oP \
+		'LocalAgentModeSessions\.addTrustedFolder: \$\{\K[$\w]+(?=\})' \
+		"$index_js")
+	if [[ -z $folder_param ]]; then
+		echo '  Could not extract folder parameter — skipping' >&2
+		echo '##############################################################'
+		return
+	fi
+	echo "  Found folder parameter: $folder_param"
+
+	if ! FOLDER_PARAM="$folder_param" node -e "
+const fs = require('fs');
+const p = 'app.asar.contents/.vite/build/index.js';
+const F = process.env.FOLDER_PARAM;
+let code = fs.readFileSync(p, 'utf8');
+
+const anchor = 'LocalAgentModeSessions.addTrustedFolder: \${' + F + '}\`);';
+const idx = code.indexOf(anchor);
+if (idx === -1) {
+  console.error('  [FAIL] addTrustedFolder anchor not found');
+  process.exit(1);
+}
+
+const insertPoint = idx + anchor.length;
+const guard = 'if(' + F + '.endsWith(\".asar\"))return;';
+code = code.slice(0, insertPoint) + guard + code.slice(insertPoint);
+fs.writeFileSync(p, code);
+console.log('  [OK] .asar guard injected in addTrustedFolder');
+"; then
+		echo 'Failed to inject .asar trusted folder guard' >&2
+		cd "$project_root" || exit 1
+		exit 1
+	fi
+
+	echo '##############################################################'
+}

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -20,7 +20,7 @@ patch_config_write_merge() {
 
 	# Extract variable names from the unique anchor:
 	#   await WRITE_FN(PATH_VAR, CONFIG_VAR), LOGGER.info("Config file written")
-	local write_fn path_var config_var
+	local write_fn path_var config_var write_fn_re path_var_re
 
 	write_fn=$(grep -oP \
 		'await \K[$\w]+(?=\([$\w]+,\s*[$\w]+\)\s*,\s*[$\w]+\.info\("Config file written"\))' \
@@ -31,7 +31,7 @@ patch_config_write_merge() {
 		return
 	fi
 
-	local write_fn_re="${write_fn//\$/\\$}"
+	write_fn_re="${write_fn//\$/\\$}"
 
 	path_var=$(grep -oP \
 		"await ${write_fn_re}\\(\\K[\$\\w]+(?=,\\s*[\$\\w]+\\)\\s*,\\s*[\$\\w]+\\.info\\(\"Config file written\"\\))" \
@@ -42,7 +42,7 @@ patch_config_write_merge() {
 		return
 	fi
 
-	local path_var_re="${path_var//\$/\\$}"
+	path_var_re="${path_var//\$/\\$}"
 
 	config_var=$(grep -oP \
 		"await ${write_fn_re}\\(${path_var_re},\\s*\\K[\$\\w]+(?=\\)\\s*,\\s*[\$\\w]+\\.info\\(\"Config file written\"\\))" \


### PR DESCRIPTION
## Summary

- Adds `scripts/patches/config.sh` with two patches that prevent upstream's stale-cache config writer from dropping externally-added `mcpServers` on every preference change
- **`patch_config_write_merge`** — injects a disk-merge step in `nj()` (central config writer) that re-reads `mcpServers` from the file before each write; disk servers form the base, in-memory servers override matching entries
- **`patch_asar_trusted_folder_guard`** — rejects `.asar` paths in `addTrustedFolder`, preventing Electron's ASAR VFS shim from misidentifying archives as folders and triggering spurious config writes

Fixes #400

## Root Cause

The memoized config reader `xs()` caches parsed config on first read. Every write path reads from this stale cache, mutates one key, then calls `nj(e)` which does `JSON.stringify(e)` and writes the full file — never re-reading from disk. If `mcpServers` were added externally (or the cache was populated before they existed), subsequent preference writes silently drop them.

Five write paths funnel through `nj()`: global shortcut, mcpServers sync, hardware acceleration, generic preferences, and trusted folder additions. The `addTrustedFolder` path accepting `.asar` paths amplifies write frequency via `$n()` → `jN()` → `nj()`.

## Test plan

- [x] AppImage builds successfully with both patches applied
- [x] `node --check` passes on the patched `index.js` (syntactically valid)
- [x] Both patches confirmed in the packed asar via grep markers (`_cdd_dc`, `endsWith(".asar")`)
- [x] Idempotency verified — re-running the build doesn't double-apply
- [x] Grep patterns use `[$\w]+` per `docs/learnings/patching-minified-js.md`
- [ ] Manual test: add an mcpServer to `~/.config/Claude/claude_desktop_config.json`, toggle a preference, verify the server survives

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: root cause analysis, patch design, implementation, build verification
Human: direction, review, build testing