### PR TITLE
fix: add powerSaveBlocker logging shim and CLAUDE_KEEP_AWAKE=0 escape hatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Tracks upstream Claude Desktop 1.8555.2.
 
 ### Added
 
+- `CLAUDE_KEEP_AWAKE=0` env var to suppress `powerSaveBlocker` sleep inhibitor that upstream holds indefinitely on Linux (no lifecycle management). Adds diagnostic logging for all `powerSaveBlocker` calls and `--doctor` visibility. ([#605](https://github.com/aaddrick/claude-desktop-debian/issues/605))
 - `--doctor` flags filesystems with `NAME_MAX < 200` (eCryptfs, certain encrypted overlays) and surfaces the LUKS-symlink workaround for cowork. Thanks @RayCharlizard, @lizthegrey for the repro. ([#614](https://github.com/aaddrick/claude-desktop-debian/pull/614), fixes [#590](https://github.com/aaddrick/claude-desktop-debian/issues/590))
 - Top-level governance docs: this `CHANGELOG.md`, [`RELEASING.md`](RELEASING.md) (pre-release checklist + tag-driven CI flow), [`SECURITY.md`](SECURITY.md) (private GHSA reporting + in/out-of-scope), [`docs/index.md`](docs/index.md) (navigation hub), and [`docs/styleguides/docs_styleguide.md`](docs/styleguides/docs_styleguide.md) (page anatomy, naming, antipatterns). [`CLAUDE.md`](CLAUDE.md) gains explicit § Required reading, § Anti-patterns, and § Docs sections; [`AGENTS.md`](AGENTS.md) becomes a byte-identical mirror of the new body (was a 13-line stub) so non-Claude tools get the same instructions.
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) "Before you start" triage section: where to go for a bug, a fix-in-hand, a new-feature ask, or a security report.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -677,6 +677,14 @@ run_doctor() {
 		_info 'Titlebar style: hybrid (default, native frame + in-app topbar)'
 	fi
 
+	# -- Keep awake override --
+	local keep_awake="${CLAUDE_KEEP_AWAKE:-}"
+	if [[ $keep_awake == '0' ]]; then
+		_pass 'Keep awake: suppressed (CLAUDE_KEEP_AWAKE=0)'
+	elif [[ -n $keep_awake ]]; then
+		_info "Keep awake: CLAUDE_KEEP_AWAKE=$keep_awake (default behavior)"
+	fi
+
 	# -- Electron binary --
 	# Version is read from the file next to the binary rather than
 	# launching Electron, which can hang (see #371).

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -81,6 +81,15 @@ const CLOSE_TO_TRAY = process.platform === 'linux'
   && process.env.CLAUDE_QUIT_ON_CLOSE !== '1';
 console.log(`[Frame Fix] Close-to-tray: ${CLOSE_TO_TRAY ? 'on' : 'off'}`);
 
+// Power save blocker behavior, controlled by CLAUDE_KEEP_AWAKE env var:
+//   unset / '1' - pass through with diagnostic logging
+//   '0'         - suppress powerSaveBlocker.start() calls entirely
+// Upstream's keepAwakeEnabled has no lifecycle management on Linux (the
+// darwin-only wake scheduler never runs), so the inhibitor fires at init
+// and never releases — preventing suspend and screensaver. See #605.
+const KEEP_AWAKE = process.env.CLAUDE_KEEP_AWAKE !== '0';
+console.log(`[Frame Fix] Keep awake: ${KEEP_AWAKE ? 'on (default)' : 'suppressed (CLAUDE_KEEP_AWAKE=0)'}`);
+
 // Detect if a window intends to be frameless (popup/Quick Entry/About).
 // Window kinds — see build-reference/app-extracted/.vite/build/index.js:
 //   Quick Entry:    titleBarStyle:"hidden",      frame:false  (caught early)
@@ -927,6 +936,38 @@ X-GNOME-Autostart-enabled=true
             get(menuTarget, menuProp) {
               if (menuProp === 'setApplicationMenu') return patchedSetApplicationMenu;
               return Reflect.get(menuTarget, menuProp);
+            }
+          });
+        }
+        if (prop === 'powerSaveBlocker' && process.platform === 'linux') {
+          const origPSB = target.powerSaveBlocker;
+          return new Proxy(origPSB, {
+            get(psTarget, psProp) {
+              if (psProp === 'start') {
+                return function(type) {
+                  if (!KEEP_AWAKE) {
+                    console.log(`[Power] powerSaveBlocker.start('${type}') suppressed (CLAUDE_KEEP_AWAKE=0)`);
+                    return -1;
+                  }
+                  const id = psTarget.start(type);
+                  console.log(`[Power] powerSaveBlocker.start('${type}') -> id=${id}`);
+                  return id;
+                };
+              }
+              if (psProp === 'stop') {
+                return function(id) {
+                  if (id < 0) return;
+                  console.log(`[Power] powerSaveBlocker.stop(${id})`);
+                  return psTarget.stop(id);
+                };
+              }
+              if (psProp === 'isStarted') {
+                return function(id) {
+                  if (id < 0) return false;
+                  return psTarget.isStarted(id);
+                };
+              }
+              return Reflect.get(psTarget, psProp);
             }
           });
         }

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -940,8 +940,9 @@ X-GNOME-Autostart-enabled=true
           });
         }
         if (prop === 'powerSaveBlocker' && process.platform === 'linux') {
-          const origPSB = target.powerSaveBlocker;
-          return new Proxy(origPSB, {
+          // Wrap powerSaveBlocker with logging and optional suppression
+          const originalPSB = target.powerSaveBlocker;
+          return new Proxy(originalPSB, {
             get(psTarget, psProp) {
               if (psProp === 'start') {
                 return function(type) {


### PR DESCRIPTION
## Summary

- Intercepts `powerSaveBlocker` via Proxy in `frame-fix-wrapper.js` — all `start()`/`stop()`/`isStarted()` calls are logged to `launcher.log` for diagnostic observability
- `CLAUDE_KEEP_AWAKE=0` env var suppresses `powerSaveBlocker.start()` entirely (returns a fake negative ID handled gracefully by `stop`/`isStarted`), giving users an immediate workaround for the indefinite sleep inhibitor
- `--doctor` reports the override when set

Upstream's `keepAwakeEnabled` has no lifecycle management on Linux — the darwin-only wake scheduler never runs, so `powerSaveBlocker.start("prevent-app-suspension")` fires at init and never releases, preventing suspend and screensaver activation.

Fixes #605

## Test plan

- [ ] Build and launch with no env var set — confirm `[Power] powerSaveBlocker.start(...)` appears in `launcher.log`
- [ ] Launch with `CLAUDE_KEEP_AWAKE=0` — confirm `suppressed` message in log and `systemd-inhibit --list` shows no Claude inhibitor
- [ ] Run `claude-desktop --doctor` with and without `CLAUDE_KEEP_AWAKE=0` — confirm output reflects the setting
- [ ] Verify `stop()` and `isStarted()` handle both real and fake (negative) IDs without errors

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: implementation, changelog, doctor integration
Human: issue triage, cluster analysis, review and approval