### PR TITLE
test(appimage): readiness-marker poll + unified cleanup trap

### DIFF
--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -143,15 +143,39 @@ if command -v xvfb-run &>/dev/null \
 		rm -rf "$cache_root" "$xvfb_log"
 	' EXIT INT TERM
 
-	# CI is slow; 10s is the floor for Electron startup.
-	sleep 10
+	# Wait up to 30s for the frame-fix readiness marker, or early
+	# process death. The marker is the last log line emitted by
+	# scripts/frame-fix-wrapper.js after all patches are installed,
+	# so reaching it means main-process startup finished without
+	# crashing. Replaces a flat 10s sleep that was both slow on
+	# healthy startups and a flake risk on noisy runners.
+	readiness_marker='[Frame Fix] Patches built successfully'
+	readiness_timeout=30
+	deadline=$((SECONDS + readiness_timeout))
+	saw_marker=0
+	while ((SECONDS < deadline)); do
+		if [[ -f $launcher_log ]] \
+			&& grep -qF "$readiness_marker" \
+				"$launcher_log"; then
+			saw_marker=1
+			break
+		fi
+		if ! kill -0 "$launch_pid" 2>/dev/null; then
+			break
+		fi
+		sleep 0.5
+	done
 
-	if kill -0 "$launch_pid" 2>/dev/null; then
-		pass "AppImage stays alive under Xvfb for 10s"
+	if ((saw_marker == 1)); then
+		pass "AppImage reached ready state under Xvfb"
 	else
-		wait "$launch_pid" 2>/dev/null
-		exit_code=$?
-		fail "AppImage exited within 10s (exit: $exit_code)"
+		if kill -0 "$launch_pid" 2>/dev/null; then
+			fail "AppImage did not reach ready state within ${readiness_timeout}s"
+		else
+			wait "$launch_pid" 2>/dev/null
+			exit_code=$?
+			fail "AppImage exited before reaching ready state (exit: $exit_code)"
+		fi
 		if [[ -f $launcher_log ]]; then
 			echo '--- launcher.log (last 40 lines) ---' >&2
 			tail -40 "$launcher_log" >&2

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -8,11 +8,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$script_dir/test-artifact-common.sh"
 
 # Single point of cleanup, set at script scope so any interruption
-# between resource allocation and normal exit is covered. Each check
-# is defensive because the trap fires regardless of how far execution
-# got — leaked $extract_dir (~200MB squashfs-root) used to slip out
-# when the script was Ctrl-C'd before reaching the smoke-test block
-# (where the trap previously lived).
+# between resource alloc and normal exit is covered.
 _cleanup() {
 	if [[ -n ${launch_pid:-} ]]; then
 		kill -KILL -- "-$launch_pid" 2>/dev/null

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -7,6 +7,23 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=tests/test-artifact-common.sh
 source "$script_dir/test-artifact-common.sh"
 
+# Single point of cleanup, set at script scope so any interruption
+# between resource allocation and normal exit is covered. Each check
+# is defensive because the trap fires regardless of how far execution
+# got — leaked $extract_dir (~200MB squashfs-root) used to slip out
+# when the script was Ctrl-C'd before reaching the smoke-test block
+# (where the trap previously lived).
+_cleanup() {
+	if [[ -n ${launch_pid:-} ]]; then
+		kill -KILL -- "-$launch_pid" 2>/dev/null
+		pkill -KILL -f "$appimage_file" 2>/dev/null
+	fi
+	[[ -n ${cache_root:-} ]] && rm -rf "$cache_root"
+	[[ -n ${xvfb_log:-} ]] && rm -rf "$xvfb_log"
+	[[ -n ${extract_dir:-} ]] && rm -rf "$extract_dir"
+}
+trap _cleanup EXIT INT TERM
+
 component_id='io.github.aaddrick.claude-desktop-debian'
 
 # Find the AppImage file (exclude .zsync)
@@ -134,14 +151,6 @@ if command -v xvfb-run &>/dev/null \
 		dbus-run-session -- "$appimage_file" \
 		>"$xvfb_log" 2>&1 &
 	launch_pid=$!
-
-	# Safety net: covers Ctrl-C, CI timeout, or any earlier `exit` so we
-	# never leak Xvfb/electron between launch and the explicit kill below.
-	trap '
-		kill -KILL -- "-$launch_pid" 2>/dev/null
-		pkill -KILL -f "$appimage_file" 2>/dev/null
-		rm -rf "$cache_root" "$xvfb_log"
-	' EXIT INT TERM
 
 	# Wait up to 30s for the frame-fix readiness marker, or early
 	# process death. The marker is the last log line emitted by


### PR DESCRIPTION
## Summary

Two follow-ups from #592 to tighten up the AppImage headless smoke test. Test-side only — no AppImage behavior changes.

## The flat sleep

`tests/test-artifact-appimage.sh` was launching the AppImage under Xvfb, sleeping 10 seconds, then checking the main process was still alive. Worst of both worlds — burned a flat 10s on every healthy run (Electron usually reaches ready in 1–2s), and on a slow CI runner 10s wasn't always enough buffer over real startup, so we'd flake.

Replaced it with a poll loop watching `launcher.log` for `[Frame Fix] Patches built successfully`. That line is the last thing `scripts/frame-fix-wrapper.js` emits after every patch is installed and the upgrade watcher is armed, so seeing it means main-process startup finished cleanly. 30s ceiling, 0.5s tick; each tick checks the marker first, then liveness via `kill -0`, so a marker emitted right before exit still counts as a pass.

Failure output got clearer too — used to be one generic "process died" message, now it splits into `AppImage did not reach ready state within Ns` (still alive, marker never showed) vs `AppImage exited before reaching ready state (exit: N)` (died early).

## The leaky trap

The original code from #592 set the `EXIT INT TERM` trap *inside* the smoke-test block, right after launching the AppImage. That trap cleaned up `$cache_root` and `$xvfb_log` but missed `$extract_dir` — the ~190MB `squashfs-root` we'd unpacked earlier in the script. Anyone Ctrl-C'ing the script before reaching the trap, or during the smoke test, would leak the extract dir.

First instinct was to add a second trap at script scope, but bash only keeps one handler per signal — the in-block one would just override it.

So: pulled the trap up to script scope into a `_cleanup` function that handles everything (`launch_pid` process group, `cache_root`, `xvfb_log`, `extract_dir`), and dropped the in-block one. Each branch in `_cleanup` is defensive (`[[ -n ${var:-} ]] && ...`) so it can fire safely no matter how far the script got before the interruption.