### PR TITLE
fix: align WM_CLASS and StartupWMClass to claude-desktop across all formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -880,6 +880,7 @@ jobs:
             -e "s/%%PKGVER%%/${PKGVER}/" \
             -e "s/%%APPIMAGE_NAME%%/${APPIMAGE_NAME}/" \
             -e "s/%%SHA256_APPIMAGE%%/${SHA256}/" \
+            -e "s/StartupWMClass=claude-desktop/StartupWMClass=Claude/" \
             PKGBUILD.template > PKGBUILD
 
       - name: Generate .SRCINFO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -880,7 +880,6 @@ jobs:
             -e "s/%%PKGVER%%/${PKGVER}/" \
             -e "s/%%APPIMAGE_NAME%%/${APPIMAGE_NAME}/" \
             -e "s/%%SHA256_APPIMAGE%%/${SHA256}/" \
-            -e "s/StartupWMClass=claude-desktop/StartupWMClass=Claude/" \
             PKGBUILD.template > PKGBUILD
 
       - name: Generate .SRCINFO

--- a/build.sh
+++ b/build.sh
@@ -159,7 +159,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;Network;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=Claude
+StartupWMClass=claude-desktop
 X-AppImage-Version=$version
 X-AppImage-Name=Claude Desktop (AppImage)
 EOF

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -793,9 +793,8 @@ Module.prototype.require = function(id) {
           return { exec: 'claude-desktop', icon: 'claude-desktop' };
         };
 
-        // StartupWMClass matches the value set by scripts/packaging/{deb,rpm}.sh
-        // so DEs group an autostarted window with user-launched instances
-        // under the same taskbar / dock entry.
+        // StartupWMClass matches --class= and desktopName so DEs group
+        // an autostarted window with user-launched instances.
         const buildAutostartContent = () => {
           const { exec, icon } = resolveAutostartTarget();
           return `[Desktop Entry]
@@ -803,7 +802,7 @@ Type=Application
 Name=Claude
 Exec=${exec}
 Icon=${icon}
-StartupWMClass=Claude
+StartupWMClass=claude-desktop
 Terminal=false
 X-GNOME-Autostart-enabled=true
 `;

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -181,12 +181,12 @@ build_electron_args() {
 		electron_args+=('--disable-features=CustomTitlebar')
 	fi
 
-	# Explicitly set the X11 WM_CLASS to match StartupWMClass=Claude in
-	# the .desktop file. Without this, Electron may derive an
-	# unpredictable class name, which breaks taskbar grouping and can
-	# trigger crashes in third-party GNOME extensions that filter by
-	# WM_CLASS. Ref: #635
-	electron_args+=('--class=Claude')
+	# Explicitly set the X11 WM_CLASS to match StartupWMClass in the
+	# .desktop file and the Wayland app_id from desktopName. Without
+	# this, Electron may derive an unpredictable class name, which
+	# breaks taskbar grouping and can trigger crashes in third-party
+	# GNOME extensions that filter by WM_CLASS. Ref: #635, #561
+	electron_args+=('--class=claude-desktop')
 
 	# Chromium's safeStorage API and cookie encryption both require a
 	# system keyring selected by --password-store. Without an explicit

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -133,7 +133,7 @@ Terminal=false
 Categories=Network;Utility;
 Comment=Claude Desktop for Linux
 MimeType=x-scheme-handler/claude;
-StartupWMClass=Claude
+StartupWMClass=claude-desktop
 X-AppImage-Version=$version
 X-AppImage-Name=Claude Desktop
 EOF

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -84,7 +84,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=Claude
+StartupWMClass=claude-desktop
 EOF
 echo 'Desktop entry created'
 

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -68,7 +68,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=Claude
+StartupWMClass=claude-desktop
 EOF
 
 # --- Create Launcher Script ---


### PR DESCRIPTION
## Summary
- Change `--class=Claude` to `--class=claude-desktop` in the launcher
- Update `StartupWMClass=Claude` to `StartupWMClass=claude-desktop` in all `.desktop` generators (deb, rpm, AppImage, build.sh, autostart)
- Revert the now-unnecessary CI sed that would have forced the AUR template to the old value

This aligns the X11 WM_CLASS with the Wayland app_id (already derived from `desktopName=claude-desktop.desktop` since #561), the `.desktop` filename, the package name, and the AUR PKGBUILD template — which already had `claude-desktop`.

Using `claude-desktop` also avoids ambiguity with the Claude Code CLI (`claude`).

Fixes #647
Ref #561, #635, #636

## Test plan
- [ ] Launch app, verify `xprop WM_CLASS` shows `claude-desktop`
- [ ] Verify taskbar grouping works on KDE/GNOME
- [ ] Verify Wayland app_id still matches (should be unchanged — `desktopName` was already `claude-desktop.desktop`)
- [ ] Verify AUR package `.desktop` now matches the window class without any CI sed override

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: investigated issue history (#561, #635, #636), implemented the fix across all formats
Human: identified the naming conflict with Claude Code CLI, directed the approach