### PR TITLE
fix(patches): filter .asar paths from --add-dir dispatch and session restore

### DIFF
--- a/scripts/cowork-patch-markers.tsv
+++ b/scripts/cowork-patch-markers.tsv
@@ -4,11 +4,10 @@
 #     <name><TAB><pcre_pattern><TAB><sample>
 # Lines starting with '#' and blank lines are ignored.
 #
-# Each row names a post-patch fingerprint of patch_cowork_linux() in
-# scripts/patches/cowork.sh. Both verify-patches.sh and
-# tests/verify-patches.bats consume this file, so adding a marker
-# here adds it to the runtime check and the test matrix at the same
-# time.
+# Each row names a post-patch fingerprint from the patch suite in
+# scripts/patches/. Both verify-patches.sh and tests/verify-patches.bats
+# consume this file, so adding a marker here adds it to the runtime
+# check and the test matrix at the same time.
 #
 # Columns:
 #   name     — kebab-case id; surfaces in verify output and BATS names.
@@ -16,8 +15,9 @@
 #   sample   — concrete string the pattern matches; BATS uses it to
 #              build positive and per-marker negative fixtures.
 #
-# The 9 markers below correspond 1:1 with the smoke-test set defined
-# in issue #559 (PR #555 retrofit, deliverable D6).
+# The first 9 markers correspond to the smoke-test set defined in
+# issue #559 (PR #555 retrofit, deliverable D6). Additional markers
+# cover other critical patches (e.g., .asar guards).
 vmclient-log-gate	process\.platform==="linux"\)\s*\?\s*"vmClient \(TypeScript\)"	(F||process.platform==="linux")?"vmClient (TypeScript)"
 vm-assignment-linux-gate	process\.platform==="linux"\)\?\(?[\w$]+=\{vm:[\w$]+\}	(F||process.platform==="linux")?N={vm:M}
 unix-socket-path	process\.platform==="linux"\?\(process\.env\.XDG_RUNTIME_DIR\|\|"/tmp"\)\+"/cowork-vm-service\.sock"	process.platform==="linux"?(process.env.XDG_RUNTIME_DIR||"/tmp")+"/cowork-vm-service.sock"
@@ -27,3 +27,4 @@ econnrefused-on-linux	process\.platform==="linux"&&[\w$]+\.code==="ECONNREFUSED"
 cowork-daemon-pid	global\.__coworkDaemonPid	global.__coworkDaemonPid=_c.pid
 cowork-linux-daemon-shutdown	cowork-linux-daemon-shutdown	name:"cowork-linux-daemon-shutdown"
 sharedcwdpath-threadthrough	sharedCwdPath:this\.sessions\.get\(	sharedCwdPath:this.sessions.get(t)?.userSelectedFolders?.[0]
+asar-adddir-filter	\.filter\(_d=>!_d\.endsWith\("\.asar"\)\).*"--add-dir"	.filter(_d=>!_d.endsWith(".asar")))Y.push("--add-dir"

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -117,6 +117,10 @@ console.log('Updated package.json: main entry, desktopName, and node-pty depende
 	# writes that amplify the stale-cache overwrite bug (#400)
 	patch_asar_trusted_folder_guard
 
+	# Filter .asar paths from --add-dir dispatch and session restore
+	# so corrupted pre-#640 sessions cannot crash local agent mode (#649)
+	patch_asar_additional_dirs_guard
+
 	# Copy cowork VM service daemon for Linux Cowork mode
 	echo 'Installing cowork VM service daemon...'
 	cp "$source_dir/scripts/cowork-vm-service.js" \

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -1,6 +1,7 @@
 #===============================================================================
 # Config-related patches: preserve externally-added mcpServers across config
-# writes, and guard addTrustedFolder against .asar paths.
+# writes, guard addTrustedFolder against .asar paths, and filter .asar entries
+# from the --add-dir CLI dispatch and session restore.
 #
 # Sourced by: build.sh
 # Sourced globals: project_root
@@ -135,6 +136,165 @@ console.log('  [OK] .asar guard injected in addTrustedFolder');
 "; then
 		echo 'Failed to inject .asar trusted folder guard' >&2
 		cd "$project_root" || exit 1
+		exit 1
+	fi
+
+	echo '##############################################################'
+}
+
+# ---------------------------------------------------------------------------
+# Patch: filter .asar paths from --add-dir CLI dispatch and session restore
+#
+# PR #640 guards the directory-check helper and addTrustedFolder IPC
+# handler, but .asar paths in corrupted pre-#640 sessions survive
+# restore (existsSync passes via Electron's ASAR VFS shim) and reach
+# additionalDirectories -> --add-dir -> fatal Claude Code error.
+#
+# Fix: two sub-patches:
+#   1. Filter at the --add-dir CLI dispatch loop (the single convergence
+#      point for ALL code paths that feed additionalDirectories).
+#   2. Filter at session restore to self-heal corrupted persisted state.
+# ---------------------------------------------------------------------------
+patch_asar_additional_dirs_guard() {
+	echo 'Patching --add-dir dispatch to reject .asar paths (#649)...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Idempotency
+	if grep -qF '.filter(_d=>!_d.endsWith(".asar"))' "$index_js"; then
+		echo '  .asar --add-dir filter already present (idempotent)'
+		echo '##############################################################'
+		return
+	fi
+
+	if ! INDEX_JS="$index_js" node << 'ASAR_ADDDIR_PATCH'
+const fs = require('fs');
+const indexJs = process.env.INDEX_JS;
+let code = fs.readFileSync(indexJs, 'utf8');
+let patchCount = 0;
+
+// ================================================================
+// Sub-patch 1: Filter .asar from --add-dir loop
+//
+// Target (unique, 1 occurrence):
+//   for (let O of A) Y.push("--add-dir", O);
+// Fallback (if minifier uses .forEach):
+//   A.forEach(O=>Y.push("--add-dir",O))
+// ================================================================
+{
+    // Primary: for...of pattern
+    const forOfRe = /for\s*\(\s*let\s+([\w$]+)\s+of\s+([\w$]+)\s*\)\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\1\s*\)/;
+    // Fallback: .forEach pattern
+    const forEachRe = /([\w$]+)\.forEach\(\s*([\w$]+)\s*=>\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\2\s*\)\s*\)/;
+
+    let match = code.match(forOfRe);
+    let variant = 'for-of';
+    if (!match) {
+        match = code.match(forEachRe);
+        variant = 'forEach';
+    }
+    if (!match) {
+        console.error('FATAL: Could not find --add-dir dispatch loop.');
+        console.error('Tried: for(let X of Y) Z.push("--add-dir", X)');
+        console.error('Tried: Y.forEach(X=>Z.push("--add-dir", X))');
+        process.exit(1);
+    }
+
+    // Count assertion: exactly 1 match expected
+    const escaped = match[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const allMatches = code.match(new RegExp(escaped, 'g'));
+    if (allMatches && allMatches.length > 1) {
+        console.error('FATAL: --add-dir pattern matches ' +
+            allMatches.length + ' times (expected 1).');
+        process.exit(1);
+    }
+
+    let filtered;
+    if (variant === 'for-of') {
+        const [, iterVar, arrVar, pushTarget] = match;
+        filtered = 'for(let ' + iterVar + ' of ' + arrVar +
+            '.filter(_d=>!_d.endsWith(".asar")))' +
+            pushTarget + '.push("--add-dir",' + iterVar + ')';
+    } else {
+        const [, arrVar, iterVar, pushTarget] = match;
+        filtered = arrVar +
+            '.filter(_d=>!_d.endsWith(".asar")).forEach(' +
+            iterVar + '=>' + pushTarget +
+            '.push("--add-dir",' + iterVar + '))';
+    }
+    code = code.replace(match[0], filtered);
+    console.log('  Filtered .asar entries from --add-dir dispatch (' +
+        variant + ' variant)');
+    patchCount++;
+}
+
+// ================================================================
+// Sub-patch 2: Filter .asar from session restore
+//
+// Anchor: "Filtering out deleted folder from session" (unique)
+// Target: (VAR.userSelectedFolders||[]).filter(
+// Insert: .filter(l=>!l.endsWith(".asar")) before existing .filter(
+// ================================================================
+{
+    const anchor = 'Filtering out deleted folder from session';
+    const anchorIdx = code.indexOf(anchor);
+    if (anchorIdx === -1) {
+        console.log('  WARNING: Session restore anchor not found — ' +
+            'self-healing will not work (primary --add-dir filter ' +
+            'still protects against the fatal error)');
+    } else {
+        const searchStart = Math.max(0, anchorIdx - 500);
+        const region = code.substring(searchStart, anchorIdx);
+        const usIdx = region.lastIndexOf('userSelectedFolders');
+        if (usIdx === -1) {
+            console.log('  WARNING: userSelectedFolders not found ' +
+                'near anchor');
+        } else {
+            const absUsIdx = searchStart + usIdx;
+            const afterUs = code.substring(absUsIdx, anchorIdx);
+            const bracketRe = /\|\|\s*\[\s*\]\s*\)/;
+            const bracketMatch = afterUs.match(bracketRe);
+            if (!bracketMatch) {
+                console.log('  WARNING: ||[]) pattern not found ' +
+                    'after userSelectedFolders');
+            } else {
+                const insertOffset = absUsIdx + bracketMatch.index +
+                    bracketMatch[0].length;
+                const afterBracket = code.substring(
+                    insertOffset, insertOffset + 20);
+                if (!afterBracket.match(/^\s*\.filter\s*\(/)) {
+                    console.log('  WARNING: .filter( not found ' +
+                        'after ||[])');
+                } else if (code.substring(
+                    insertOffset - 50, insertOffset + 50
+                ).includes('!l.endsWith(".asar")')) {
+                    console.log('  Session restore .asar filter ' +
+                        'already present');
+                } else {
+                    const injection =
+                        '.filter(l=>!l.endsWith(".asar"))';
+                    code = code.substring(0, insertOffset) +
+                        injection + code.substring(insertOffset);
+                    console.log('  Injected .asar filter in ' +
+                        'session restore');
+                    patchCount++;
+                }
+            }
+        }
+    }
+}
+
+fs.writeFileSync(indexJs, code);
+console.log('  Applied ' + patchCount +
+    ' .asar additionalDirectories patch(es)');
+if (patchCount < 1) {
+    console.error('FATAL: No patches applied — at minimum the ' +
+        '--add-dir filter must succeed (#649).');
+    process.exit(1);
+}
+ASAR_ADDDIR_PATCH
+	then
+		echo 'FATAL: .asar --add-dir filter patch failed' >&2
+		echo 'Local agent mode will crash without this patch (#649).' >&2
 		exit 1
 	fi
 

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -193,9 +193,9 @@ let patchCount = 0;
         variant = 'forEach';
     }
     if (!match) {
-        console.error('FATAL: Could not find --add-dir dispatch loop.');
-        console.error('Tried: for(let X of Y) Z.push("--add-dir", X)');
-        console.error('Tried: Y.forEach(X=>Z.push("--add-dir", X))');
+        console.error('FATAL: --add-dir dispatch loop not found.');
+        console.error('  for(let X of Y) Z.push("--add-dir", X)');
+        console.error('  Y.forEach(X=>Z.push("--add-dir", X))');
         process.exit(1);
     }
 
@@ -222,7 +222,7 @@ let patchCount = 0;
             '.push("--add-dir",' + iterVar + '))';
     }
     code = code.replace(match[0], filtered);
-    console.log('  Filtered .asar entries from --add-dir dispatch (' +
+    console.log('  Filtered --add-dir dispatch (' +
         variant + ' variant)');
     patchCount++;
 }
@@ -235,45 +235,40 @@ let patchCount = 0;
 // Insert: .filter(l=>!l.endsWith(".asar")) before existing .filter(
 // ================================================================
 {
-    const anchor = 'Filtering out deleted folder from session';
-    const anchorIdx = code.indexOf(anchor);
+    const warn = (msg) => console.log('  WARNING: ' + msg +
+        ' (primary --add-dir filter still protects)');
+
+    const anchorIdx = code.indexOf(
+        'Filtering out deleted folder from session');
     if (anchorIdx === -1) {
-        console.log('  WARNING: Session restore anchor not found — ' +
-            'self-healing will not work (primary --add-dir filter ' +
-            'still protects against the fatal error)');
+        warn('session restore anchor not found');
     } else {
         const searchStart = Math.max(0, anchorIdx - 500);
         const region = code.substring(searchStart, anchorIdx);
         const usIdx = region.lastIndexOf('userSelectedFolders');
         if (usIdx === -1) {
-            console.log('  WARNING: userSelectedFolders not found ' +
-                'near anchor');
+            warn('userSelectedFolders not found near anchor');
         } else {
             const absUsIdx = searchStart + usIdx;
             const afterUs = code.substring(absUsIdx, anchorIdx);
-            const bracketRe = /\|\|\s*\[\s*\]\s*\)/;
-            const bracketMatch = afterUs.match(bracketRe);
+            const bracketMatch = afterUs.match(/\|\|\s*\[\s*\]\s*\)/);
             if (!bracketMatch) {
-                console.log('  WARNING: ||[]) pattern not found ' +
-                    'after userSelectedFolders');
+                warn('||[]) pattern not found');
             } else {
-                const insertOffset = absUsIdx + bracketMatch.index +
+                const insertAt = absUsIdx + bracketMatch.index +
                     bracketMatch[0].length;
-                const afterBracket = code.substring(
-                    insertOffset, insertOffset + 20);
-                if (!afterBracket.match(/^\s*\.filter\s*\(/)) {
-                    console.log('  WARNING: .filter( not found ' +
-                        'after ||[])');
+                const peek = code.substring(insertAt, insertAt + 20);
+                if (!peek.match(/^\s*\.filter\s*\(/)) {
+                    warn('.filter( not found after ||[])');
                 } else if (code.substring(
-                    insertOffset - 50, insertOffset + 50
+                    insertAt - 50, insertAt + 50
                 ).includes('!l.endsWith(".asar")')) {
-                    console.log('  Session restore .asar filter ' +
+                    console.log('  Session restore filter ' +
                         'already present');
                 } else {
-                    const injection =
-                        '.filter(l=>!l.endsWith(".asar"))';
-                    code = code.substring(0, insertOffset) +
-                        injection + code.substring(insertOffset);
+                    code = code.substring(0, insertAt) +
+                        '.filter(l=>!l.endsWith(".asar"))' +
+                        code.substring(insertAt);
                     console.log('  Injected .asar filter in ' +
                         'session restore');
                     patchCount++;
@@ -287,8 +282,8 @@ fs.writeFileSync(indexJs, code);
 console.log('  Applied ' + patchCount +
     ' .asar additionalDirectories patch(es)');
 if (patchCount < 1) {
-    console.error('FATAL: No patches applied — at minimum the ' +
-        '--add-dir filter must succeed (#649).');
+    console.error('FATAL: No patches applied — --add-dir filter ' +
+        'must succeed (#649).');
     process.exit(1);
 }
 ASAR_ADDDIR_PATCH

--- a/tests/verify-patches.bats
+++ b/tests/verify-patches.bats
@@ -64,9 +64,9 @@ write_fixture() {
 	done
 }
 
-@test "markers file: at least 9 markers loaded" {
-	[[ "${#marker_names[@]}" -ge 9 ]] || {
-		echo "expected >= 9 markers, got ${#marker_names[@]}"
+@test "markers file: at least 10 markers loaded" {
+	[[ "${#marker_names[@]}" -ge 10 ]] || {
+		echo "expected >= 10 markers, got ${#marker_names[@]}"
 		return 1
 	}
 }


### PR DESCRIPTION
## Summary

- Filter `.asar` entries at the `--add-dir` CLI dispatch loop — the single convergence point where ALL `additionalDirectories` paths become CLI arguments to Claude Code
- Filter `.asar` entries at session restore to self-heal corrupted pre-#640 persisted state
- Add fallback regex for `.forEach` minifier variant, with count assertion for safety

Fixes #649

## Context

PR #640 patched `wFA()` and `addTrustedFolder` to reject `.asar` paths, but corrupted sessions persisted before #640 survive restore (Electron's ASAR VFS makes `existsSync` return true for `.asar` archives). The `.asar` path flows through `resolvedFolders` → `getFolderPermissionPaths` → `additionalDirectories` → `--add-dir`, where Claude Code >=2.1.111 fatally rejects it.

Rather than patching intermediate extraction functions (`dI()`, `cTe()`), this fix targets the final dispatch point where all code paths converge — including `MV()` managed settings, `computeSpawnAdditionalDirectories`, and the HostLoop merge.

## Test plan

- [x] Both sub-patches apply cleanly against 1.8555.2 reference source
- [x] Marker regex matches the patched output
- [x] Idempotency guard correctly prevents double-application
- [x] `shellcheck` passes (no new warnings)
- [x] `bats tests/verify-patches.bats` — all 9 tests pass (marker count bumped to >= 10)
- [ ] Full build (`./build.sh --build appimage --clean no`)
- [ ] Manual test: inject corrupted session with `.asar` in `userSelectedFolders`, verify no "No conversation found" error

## Open question

Need to confirm whether the bug reproduces after clearing session state (`~/.config/Claude/local-agent-mode-sessions/`). If it does, there's an active injection vector beyond stale persistence that warrants a separate follow-up. The primary patch covers both scenarios regardless.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
80% AI / 20% Human
Claude: root-cause analysis, implementation, testing against reference source
Human: directed investigation, contrarian review iterations, plan approval