### PR TITLE
fix: centralize StartupWMClass=Claude to match upstream productName

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,8 @@ final_output_path=''
 
 # Package metadata (constants)
 readonly PACKAGE_NAME='claude-desktop'
+readonly WM_CLASS='Claude'
+export WM_CLASS
 readonly MAINTAINER='Claude Desktop Linux Maintainers'
 readonly DESCRIPTION='Claude Desktop for Linux'
 
@@ -159,7 +161,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;Network;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude-desktop
+StartupWMClass=$WM_CLASS
 X-AppImage-Version=$version
 X-AppImage-Name=Claude Desktop (AppImage)
 EOF

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -793,8 +793,8 @@ Module.prototype.require = function(id) {
           return { exec: 'claude-desktop', icon: 'claude-desktop' };
         };
 
-        // StartupWMClass matches --class= and desktopName so DEs group
-        // an autostarted window with user-launched instances.
+        // StartupWMClass derived from Electron's app.name (upstream
+        // productName) so DEs group autostarted and launched instances.
         const buildAutostartContent = () => {
           const { exec, icon } = resolveAutostartTarget();
           return `[Desktop Entry]
@@ -802,7 +802,7 @@ Type=Application
 Name=Claude
 Exec=${exec}
 Icon=${icon}
-StartupWMClass=claude-desktop
+StartupWMClass=${result.app.name}
 Terminal=false
 X-GNOME-Autostart-enabled=true
 `;

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -2,9 +2,8 @@
 # Common launcher functions for Claude Desktop (AppImage and deb)
 # This file is sourced by both launchers to avoid code duplication
 
-# X11 WM_CLASS / .desktop StartupWMClass — must match upstream Electron's
-# productName (which drives the actual window class). Build-time
-# substitution replaces @@WM_CLASS@@; see build.sh for the source of truth.
+# WM_CLASS / StartupWMClass — must match upstream productName.
+# @@WM_CLASS@@ is replaced at build time; see build.sh.
 readonly WM_CLASS='@@WM_CLASS@@'
 
 # Setup logging directory and file
@@ -186,10 +185,8 @@ build_electron_args() {
 		electron_args+=('--disable-features=CustomTitlebar')
 	fi
 
-	# Set X11 WM_CLASS to match StartupWMClass in the .desktop file.
-	# Electron derives WM_CLASS from productName in package.json and
-	# ignores --class when they conflict, so this value must match
-	# upstream's productName ("Claude"). Ref: #647, #652
+	# WM_CLASS must match the .desktop StartupWMClass and upstream's
+	# productName. Ref: #647, #652
 	electron_args+=("--class=$WM_CLASS")
 
 	# Chromium's safeStorage API and cookie encryption both require a

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -2,6 +2,11 @@
 # Common launcher functions for Claude Desktop (AppImage and deb)
 # This file is sourced by both launchers to avoid code duplication
 
+# X11 WM_CLASS / .desktop StartupWMClass — must match upstream Electron's
+# productName (which drives the actual window class). Build-time
+# substitution replaces @@WM_CLASS@@; see build.sh for the source of truth.
+readonly WM_CLASS='@@WM_CLASS@@'
+
 # Setup logging directory and file
 # Sets: log_dir, log_file
 setup_logging() {
@@ -181,12 +186,11 @@ build_electron_args() {
 		electron_args+=('--disable-features=CustomTitlebar')
 	fi
 
-	# Explicitly set the X11 WM_CLASS to match StartupWMClass in the
-	# .desktop file and the Wayland app_id from desktopName. Without
-	# this, Electron may derive an unpredictable class name, which
-	# breaks taskbar grouping and can trigger crashes in third-party
-	# GNOME extensions that filter by WM_CLASS. Ref: #635, #561
-	electron_args+=('--class=claude-desktop')
+	# Set X11 WM_CLASS to match StartupWMClass in the .desktop file.
+	# Electron derives WM_CLASS from productName in package.json and
+	# ignores --class when they conflict, so this value must match
+	# upstream's productName ("Claude"). Ref: #647, #652
+	electron_args+=("--class=$WM_CLASS")
 
 	# Chromium's safeStorage API and cookie encryption both require a
 	# system keyring selected by --password-store. Without an explicit

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -48,6 +48,7 @@ echo 'Application files copied to Electron resources directory'
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mkdir -p "$appdir_path/usr/lib/claude-desktop" || exit 1
 cp "$(dirname "$script_dir")/launcher-common.sh" "$appdir_path/usr/lib/claude-desktop/" || exit 1
+sed -i "s/@@WM_CLASS@@/$WM_CLASS/" "$appdir_path/usr/lib/claude-desktop/launcher-common.sh"
 cp "$(dirname "$script_dir")/doctor.sh" "$appdir_path/usr/lib/claude-desktop/" || exit 1
 echo 'Shared launcher library + doctor copied'
 
@@ -133,7 +134,7 @@ Terminal=false
 Categories=Network;Utility;
 Comment=Claude Desktop for Linux
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude-desktop
+StartupWMClass=$WM_CLASS
 X-AppImage-Version=$version
 X-AppImage-Name=Claude Desktop
 EOF

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -70,6 +70,7 @@ echo 'Application files copied to Electron resources directory'
 # at runtime, so both must live in the same directory)
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cp "$(dirname "$script_dir")/launcher-common.sh" "$install_dir/lib/$package_name/" || exit 1
+sed -i "s/@@WM_CLASS@@/$WM_CLASS/" "$install_dir/lib/$package_name/launcher-common.sh"
 cp "$(dirname "$script_dir")/doctor.sh" "$install_dir/lib/$package_name/" || exit 1
 echo 'Shared launcher library + doctor copied'
 
@@ -84,7 +85,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude-desktop
+StartupWMClass=$WM_CLASS
 EOF
 echo 'Desktop entry created'
 

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -68,7 +68,7 @@ Type=Application
 Terminal=false
 Categories=Office;Utility;
 MimeType=x-scheme-handler/claude;
-StartupWMClass=claude-desktop
+StartupWMClass=$WM_CLASS
 EOF
 
 # --- Create Launcher Script ---
@@ -218,6 +218,7 @@ cp -r $app_staging_dir/app.asar.unpacked %{buildroot}/usr/lib/$package_name/node
 # Copy shared launcher library (launcher-common.sh sources doctor.sh
 # at runtime, so both must live in the same directory)
 cp $(dirname "$script_dir")/launcher-common.sh %{buildroot}/usr/lib/$package_name/
+sed -i "s/@@WM_CLASS@@/$WM_CLASS/" "%{buildroot}/usr/lib/$package_name/launcher-common.sh"
 cp $(dirname "$script_dir")/doctor.sh %{buildroot}/usr/lib/$package_name/
 
 # Install desktop entry

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -53,6 +53,19 @@ fs.writeFileSync('./app.asar.contents/package.json', JSON.stringify(pkg, null, 2
 console.log('Updated package.json: main entry, desktopName, and node-pty dependency');
 " "$desktop_name"
 
+	# Verify upstream productName matches the WM_CLASS we advertise in
+	# .desktop files. If Anthropic changes productName, the build fails
+	# here rather than silently shipping a broken StartupWMClass.
+	local product_name
+	product_name=$(node -e \
+		"console.log(require('./app.asar.contents/package.json').productName)")
+	if [[ $product_name != "$WM_CLASS" ]]; then
+		echo "Error: upstream productName '${product_name}' != expected" \
+			"WM_CLASS '${WM_CLASS}'" >&2
+		echo 'Update WM_CLASS in build.sh to match the new productName.' >&2
+		exit 1
+	fi
+
 	# Create stub native module
 	echo 'Creating stub native module...'
 	mkdir -p app.asar.contents/node_modules/@ant/claude-native || exit 1

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -53,16 +53,14 @@ fs.writeFileSync('./app.asar.contents/package.json', JSON.stringify(pkg, null, 2
 console.log('Updated package.json: main entry, desktopName, and node-pty dependency');
 " "$desktop_name"
 
-	# Verify upstream productName matches the WM_CLASS we advertise in
-	# .desktop files. If Anthropic changes productName, the build fails
-	# here rather than silently shipping a broken StartupWMClass.
+	# Fail fast if upstream changed productName — a mismatch silently
+	# breaks StartupWMClass in every .desktop file we ship.
 	local product_name
 	product_name=$(node -e \
 		"console.log(require('./app.asar.contents/package.json').productName)")
 	if [[ $product_name != "$WM_CLASS" ]]; then
-		echo "Error: upstream productName '${product_name}' != expected" \
-			"WM_CLASS '${WM_CLASS}'" >&2
-		echo 'Update WM_CLASS in build.sh to match the new productName.' >&2
+		echo "Error: upstream productName '$product_name' != WM_CLASS" \
+			"'$WM_CLASS' — update WM_CLASS in build.sh" >&2
 		exit 1
 	fi
 

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -76,10 +76,8 @@ setup() {
 	unset CLAUDE_PASSWORD_STORE
 	CLAUDE_PASSWORD_STORE='basic'
 
-	# Replace the @@WM_CLASS@@ build-time placeholder before sourcing
-	# (mirrors what the packaging scripts do at build time).
-	# doctor.sh must be co-located (launcher-common.sh sources it via
-	# BASH_SOURCE dirname).
+	# Copy to temp dir so we can substitute the build-time placeholder
+	# and co-locate doctor.sh (sourced via BASH_SOURCE dirname).
 	cp "$SCRIPT_DIR/../scripts/launcher-common.sh" "$TEST_TMP/launcher-common.sh"
 	cp "$SCRIPT_DIR/../scripts/doctor.sh" "$TEST_TMP/doctor.sh"
 	sed -i 's/@@WM_CLASS@@/Claude/' "$TEST_TMP/launcher-common.sh"

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -76,8 +76,15 @@ setup() {
 	unset CLAUDE_PASSWORD_STORE
 	CLAUDE_PASSWORD_STORE='basic'
 
+	# Replace the @@WM_CLASS@@ build-time placeholder before sourcing
+	# (mirrors what the packaging scripts do at build time).
+	# doctor.sh must be co-located (launcher-common.sh sources it via
+	# BASH_SOURCE dirname).
+	cp "$SCRIPT_DIR/../scripts/launcher-common.sh" "$TEST_TMP/launcher-common.sh"
+	cp "$SCRIPT_DIR/../scripts/doctor.sh" "$TEST_TMP/doctor.sh"
+	sed -i 's/@@WM_CLASS@@/Claude/' "$TEST_TMP/launcher-common.sh"
 	# shellcheck source=scripts/launcher-common.sh
-	source "$SCRIPT_DIR/../scripts/launcher-common.sh"
+	source "$TEST_TMP/launcher-common.sh"
 }
 
 teardown() {
@@ -304,6 +311,13 @@ teardown() {
 # =============================================================================
 # build_electron_args
 # =============================================================================
+
+@test "build_electron_args: includes --class matching upstream productName" {
+	is_wayland=false
+	setup_logging
+	build_electron_args deb
+	has_electron_arg '--class=Claude'
+}
 
 @test "build_electron_args: X11 deb - only CustomTitlebar disabled" {
 	is_wayland=false


### PR DESCRIPTION
## Summary
- Electron ignores `--class=` and derives `WM_CLASS` from `productName` in `package.json` (`"Claude"`). The v2.0.14 release shipped `--class=claude-desktop` + `StartupWMClass=claude-desktop`, but [users confirmed](https://github.com/aaddrick/claude-desktop-debian/issues/652#issuecomment-4551605147) via `/proc` cmdline + `xprop` that the flag is silently ignored — `WM_CLASS` remains `"claude","Claude"` regardless. This causes orphan windows and duplicate gear icons on GNOME/KDE.
- Centralizes the value from **6 independent hardcoded locations** to **1 definition** in `build.sh` + **1 runtime derivation** in `frame-fix-wrapper.js`:
  - `build.sh`: `readonly WM_CLASS='Claude'`, exported to packaging subprocesses
  - `launcher-common.sh`: `@@WM_CLASS@@` placeholder, sed-replaced at build time by each packaging script
  - `frame-fix-wrapper.js`: autostart `.desktop` derives from `result.app.name` (upstream `productName`)
  - `app-asar.sh`: build-time assertion fails if upstream `productName` ever changes
- Wayland grouping is unaffected — it uses `desktopName` (already patched to `claude-desktop.desktop` since #561), not `StartupWMClass`

Fixes #652
Ref #647, #561, discussion #653

## Test plan
- [x] `bats tests/launcher-common.bats` — 75/75 pass (includes new `--class=Claude` regression test)
- [x] `shellcheck` — no new warnings (all pre-existing)
- [ ] Build deb, inspect `.desktop` for `StartupWMClass=Claude` and installed `launcher-common.sh` for `--class=Claude`
- [ ] Launch installed deb on GNOME/X11, verify `xprop WM_CLASS` shows `Claude` matching `.desktop`
- [ ] Launch on KDE Wayland, verify taskbar grouping still works (via `desktopName` / `app_id`)

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
70% AI / 30% Human
Claude: investigated issue history, designed centralization approach, implemented changes across 8 files
Human: directed value choice (respect upstream), chose placeholder+sed over dual-constant, identified discussion #653 evidence, reviewed contrarian feedback