### PR TITLE
fix(patches): anchor tray variable extraction on .Tray() literal

### DIFF
--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -26,8 +26,7 @@ patch_tray_menu_handler() {
 	tray_func_re="${tray_func//\$/\\$}"
 
 	tray_var=$(grep -oP \
-		"\}\);let \K[\$\w]+(?==null;(?:async )?function ${tray_func_re})" \
-		"$index_js")
+		'[$\w]+(?=\s*=\s*new\s+[$\w]+\.Tray\()' "$index_js" | head -1)
 	if [[ -z $tray_var ]]; then
 		echo 'Failed to extract tray variable name' >&2
 		cd "$project_root" || exit 1
@@ -113,8 +112,7 @@ patch_tray_inplace_update() {
 	# Escape `$` for PCRE patterns; matches the `tray_var_re` trick below.
 	tray_func_re="${tray_func//\$/\\$}"
 	local_tray_var=$(grep -oP \
-		"\}\);let \K[\$\w]+(?==null;(?:async )?function ${tray_func_re})" \
-		"$index_js")
+		'[$\w]+(?=\s*=\s*new\s+[$\w]+\.Tray\()' "$index_js" | head -1)
 	if [[ -z $local_tray_var ]]; then
 		echo '  Could not extract tray variable name — skipping'
 		echo '##############################################################'


### PR DESCRIPTION
## Summary
- Old pattern `});let VAR=null;function TRAY_FUNC` broke on upstream 1.9255.0 — the minifier reshuffled declarations
- New pattern `VAR = new ELECTRON.Tray(` anchors on the `.Tray(` literal (stable Electron API), per `docs/learnings/patching-minified-js.md` § Anchor selection
- Fixed in both `patch_tray_menu_handler` and `patch_tray_inplace_update`

Fixes #656

## Test plan
- [x] New pattern extracts `OE` from 1.9255.0 bundle
- [x] All downstream patterns (`.destroy()`, `.setContextMenu()`, `.isDestroyed()`) still match
- [x] `bats tests/` — 274/274 pass
- [x] `shellcheck` — no new warnings

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
90% AI / 10% Human
Claude: diagnosed pattern failure, found new anchor, implemented fix
Human: directed approach, requested doc reference