### PR TITLE
fix(patches): capture $-prefixed minified names in cowork spawn guard

### DIFF
--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -424,7 +424,7 @@ if (serviceErrorIdx !== -1) {
             const funcSearchStart = Math.max(0, newServiceErrorIdx - 2000);
             const funcRegion = code.substring(funcSearchStart, newServiceErrorIdx);
             // The function is defined as: async function NAME(t,e){...for(let r=0;r<=LIMIT;r++)
-            const funcNameRe = /async function (\w+)\s*\(\s*\w+\s*,\s*\w+\s*\)\s*\{[\s\S]*?for\s*\(\s*let/g;
+            const funcNameRe = /async function ([$\w]+)\s*\(\s*[$\w]+\s*,\s*[$\w]+\s*\)\s*\{[\s\S]*?for\s*\(\s*let/g;
             let funcMatch;
             let retryFuncName = null;
             while ((funcMatch = funcNameRe.exec(funcRegion)) !== null) {
@@ -432,7 +432,7 @@ if (serviceErrorIdx !== -1) {
             }
             const spawnGuard = retryFuncName
                 ? retryFuncName + '._lastSpawn'
-                : '_globalLastSpawn';
+                : 'globalThis._lastSpawn';
             // Cooldown in ms — long enough to avoid fork storms, short enough
             // that the retry loop can re-spawn after a mid-session daemon death.
             const autoLaunch =


### PR DESCRIPTION
## Summary

- **Fix regex** in `cowork.sh:427` — `(\w+)` → `([$\w]+)` so `$`-prefixed minified function names (e.g. `$Be`) are captured correctly
- **Fix fallback guard** — bare `_globalLastSpawn` → `globalThis._lastSpawn`, a safe property access that returns `undefined` instead of throwing `ReferenceError`

## Problem

The cowork auto-launch patch extracts the enclosing retry function name to attach a dedup/cooldown guard. The regex used `\w+` which excludes `$`, so when the upstream minifier produces names like `$Be`, the match silently fails. The fallback then uses the bare identifier `_globalLastSpawn`, which throws `ReferenceError` on first read (before any assignment), breaking Cowork entirely.

Confirmed on NixOS, Debian 13, and Ubuntu 26.04.

## Test plan

- [ ] Build with `./build.sh` and verify the cowork patch logs `Added service daemon auto-launch on Linux` (not the WARNING fallback)
- [ ] Launch the app and confirm Cowork starts without `_globalLastSpawn is not defined` error
- [ ] Check `~/.config/Claude/logs/cowork_vm_node.log` for successful socket connection

Fixes #659

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
95% AI / 5% Human
Claude: investigated issue, identified root cause, implemented fix, created PR
Human: confirmed direction and requested PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nc3AK6ep6eKMdZ6hXstUKC)_