### PR TITLE
fix: shorten Claude Code local-session stall watchdog (10min → 5min)

### DIFF
--- a/scripts/cowork-patch-markers.tsv
+++ b/scripts/cowork-patch-markers.tsv
@@ -28,3 +28,4 @@ cowork-daemon-pid	global\.__coworkDaemonPid	global.__coworkDaemonPid=_c.pid
 cowork-linux-daemon-shutdown	cowork-linux-daemon-shutdown	name:"cowork-linux-daemon-shutdown"
 sharedcwdpath-threadthrough	sharedCwdPath:this\.sessions\.get\(	sharedCwdPath:this.sessions.get(t)?.userSelectedFolders?.[0]
 asar-adddir-filter	\.filter\(_d=>!_d\.endsWith\("\.asar"\)\).*"--add-dir"	.filter(_d=>!_d.endsWith(".asar")))Y.push("--add-dir"
+cowork-message-timeout-shortened	"coworkMessageTimeoutMs",\s*3e5	"coworkMessageTimeoutMs",3e5

--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -882,7 +882,7 @@ if (serviceErrorIdx !== -1) {
 }
 
 // ============================================================
-// Patch 11: Shorten local-session "no-stream" watchdog 10min -> 5min
+// Patch 13: Shorten local-session "no-stream" watchdog 10min -> 5min
 //
 // The local-agent health monitor (wRr.startTimeoutDetection) marks
 // a session "timed out" only after coworkMessageTimeoutMs of stdout
@@ -908,10 +908,14 @@ if (serviceErrorIdx !== -1) {
 // messages while it runs), so this must not falsely time out long
 // tool turns.
 //
-// Anchored on the stable config-key string so it survives Claude
-// version bumps; the numeric default is matched generically and we
-// only ever SHORTEN it (never lengthen), which keeps the patch
-// idempotent and safe to re-run.
+// Anchored on the stable config-key string (with whitespace
+// tolerance after the comma per CONTRIBUTING.md) so it survives
+// Claude version bumps; the numeric default is matched generically.
+// We assert a single match site, only ever SHORTEN the value (never
+// lengthen), and skip if already low — so the patch is idempotent
+// and safe to re-run. A marker is registered in
+// scripts/cowork-patch-markers.tsv so CI flags a silent no-op if the
+// anchor moves on a future upstream version.
 //
 // NOTE: coworkMessageTimeoutMs is read through a remote-config
 // getter; a remote value, if ever pushed, would override this local
@@ -919,9 +923,16 @@ if (serviceErrorIdx !== -1) {
 // ============================================================
 {
     const STALL_NEW_TIMEOUT = '3e5'; // 5 minutes
-    const stallTimeoutRe = /("coworkMessageTimeoutMs",)(\d+(?:\.\d+)?(?:e\d+)?)/;
-    const stallMatch = code.match(stallTimeoutRe);
-    if (stallMatch) {
+    const stallTimeoutRe = /("coworkMessageTimeoutMs",[ \t]*)(\d+(?:\.\d+)?(?:e\d+)?)/;
+    const stallAll = code.match(new RegExp(stallTimeoutRe.source, 'g')) || [];
+    if (stallAll.length === 0) {
+        console.log('  WARNING: coworkMessageTimeoutMs anchor not found ' +
+            '- stream-stall watchdog still 10min');
+    } else if (stallAll.length > 1) {
+        console.log('  WARNING: coworkMessageTimeoutMs matched ' +
+            stallAll.length + ' sites - skipping to avoid a wrong rewrite');
+    } else {
+        const stallMatch = code.match(stallTimeoutRe);
         const current = stallMatch[2];
         const currentMs = Number(current);
         const newMs = Number(STALL_NEW_TIMEOUT);
@@ -934,9 +945,6 @@ if (serviceErrorIdx !== -1) {
             console.log('  coworkMessageTimeoutMs already <= ' +
                 STALL_NEW_TIMEOUT + ' (' + current + '), skipping');
         }
-    } else {
-        console.log('  WARNING: coworkMessageTimeoutMs anchor not found ' +
-            '- stream-stall watchdog still 10min');
     }
 }
 

--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -881,6 +881,65 @@ if (serviceErrorIdx !== -1) {
     }
 }
 
+// ============================================================
+// Patch 11: Shorten local-session "no-stream" watchdog 10min -> 5min
+//
+// The local-agent health monitor (wRr.startTimeoutDetection) marks
+// a session "timed out" only after coworkMessageTimeoutMs of stdout
+// inactivity. Default is 6e5 ms = 10 minutes.
+//
+// When the Claude Code CLI subprocess wedges mid-stream (observed:
+// an AbortError thrown in a hook callback / control_request inside
+// cli.js sendRequest), it stops emitting stdout. The renderer then
+// shows a live elapsed-time counter with no tokens and NO error for
+// a full 10 minutes. The recovery path itself already works: on
+// timeout the manager emits
+//   {type:"error", error:"The session stopped responding. Send your
+//    message again to resume with a fresh process."}
+// and tears the query down. It is simply gated behind a 10-minute
+// threshold, so users hard-stop manually and effectively never see
+// it (it fires ~once per 100k log lines in real usage).
+//
+// Mitigation (until the upstream CLI hook-abort bug is fixed —
+// reported to anthropics/claude-code): lower the default to
+// 3e5 ms = 5 minutes so the existing, working watchdog surfaces the
+// recoverable error ~2x sooner. 5 minutes stays well above any
+// legitimate single-tool silence (a long Bash/build emits no stdout
+// messages while it runs), so this must not falsely time out long
+// tool turns.
+//
+// Anchored on the stable config-key string so it survives Claude
+// version bumps; the numeric default is matched generically and we
+// only ever SHORTEN it (never lengthen), which keeps the patch
+// idempotent and safe to re-run.
+//
+// NOTE: coworkMessageTimeoutMs is read through a remote-config
+// getter; a remote value, if ever pushed, would override this local
+// default. None is observed in current builds.
+// ============================================================
+{
+    const STALL_NEW_TIMEOUT = '3e5'; // 5 minutes
+    const stallTimeoutRe = /("coworkMessageTimeoutMs",)(\d+(?:\.\d+)?(?:e\d+)?)/;
+    const stallMatch = code.match(stallTimeoutRe);
+    if (stallMatch) {
+        const current = stallMatch[2];
+        const currentMs = Number(current);
+        const newMs = Number(STALL_NEW_TIMEOUT);
+        if (Number.isFinite(currentMs) && currentMs > newMs) {
+            code = code.replace(stallTimeoutRe, '$1' + STALL_NEW_TIMEOUT);
+            console.log('  Shortened coworkMessageTimeoutMs ' + current +
+                ' -> ' + STALL_NEW_TIMEOUT + ' (stream-stall watchdog)');
+            patchCount++;
+        } else {
+            console.log('  coworkMessageTimeoutMs already <= ' +
+                STALL_NEW_TIMEOUT + ' (' + current + '), skipping');
+        }
+    } else {
+        console.log('  WARNING: coworkMessageTimeoutMs anchor not found ' +
+            '- stream-stall watchdog still 10min');
+    }
+}
+
 fs.writeFileSync(indexJs, code);
 console.log(`  Applied ${patchCount} cowork patches`);
 if (patchCount < 5) {


### PR DESCRIPTION
## Problem

On Linux, **Claude Code local agent sessions** (and spawned subagents) occasionally **stall mid-stream**: the elapsed-time counter keeps running, no tokens arrive, and **no error is ever shown**. The only recovery is to manually click Stop and resend. Windows users hit this far less. Tracked in #651.

> **Naming note:** the bug is in the Claude Code local-session surface, *not* the Cowork VM sandbox. This patch happens to live in `cowork.sh` because that is where the `index.js` bundle string-patches live in this repo, and the watchdog's config key is literally named `coworkMessageTimeoutMs` by upstream (it governs the local agent/session timer). No Cowork-VM behaviour is changed.

## Root cause (investigated against the installed 1.8555.2 build)

Two distinct layers:

1. **The actual stall is upstream, in the Claude Code CLI — not this repackaging.** The bundled Claude Code CLI subprocess (`/$bunfs/.../cli.js`) throws an `AbortError` inside a hook callback / `control_request` (`sendRequest`) path after a tool use, then stops emitting stdout. The model stream goes silent with `hadFirstResponse=true`. Reported upstream: anthropics/claude-code#63584 (see also anthropics/claude-code#51851, the same `sendRequest` wedge).

2. **The recovery watchdog already exists and works — but is gated at 10 minutes.** The local-session health monitor (`wRr.startTimeoutDetection`) marks a session timed out after `coworkMessageTimeoutMs` of stdout inactivity (default `6e5` = 10 min), and on timeout the manager emits:

   ```
   {type:"error", error:"The session stopped responding. Send your message again to resume with a fresh process."}
   ```

   and tears the query down. That is exactly the desired UX — but at a 10-minute threshold, users hard-stop manually long before it fires. In a 100k-line `main.log` it fired **once**.

Evidence (`~/.config/Claude/logs/main.log`, 1.8555.2):

```
[CCD] Session local_… timed out after 652s of inactivity (hadFirstResponse=true, last_tool_name=Write, seconds_since_stderr=53)
[CCD] Session … stderr tail:
  AbortError:
      at A (/$bunfs/root/src/entrypoints/cli.js:9486:473)
  Error in hook callback hook_1:
```

## Fix

Lower the `coworkMessageTimeoutMs` default from `6e5` (10 min) to `3e5` (5 min) via a new bundle patch (Patch 13 in `scripts/patches/cowork.sh`). This makes the **existing, already-working** recovery surface the error ~2× sooner. 5 minutes stays well above any legitimate single-tool silence (a long Bash/build emits no stdout messages while it runs), so it should not falsely time out long tool turns.

- Anchored on the stable config-key string `"coworkMessageTimeoutMs",` (whitespace-tolerant after the comma per `CONTRIBUTING.md`) so it survives Claude version bumps; the numeric default is matched generically.
- Asserts a single match site; only ever **shortens** the value (never lengthens); skips if already low → idempotent, safe to re-run.
- Registers a `verify-patches` marker (`cowork-message-timeout-shortened`) in `scripts/cowork-patch-markers.tsv` so CI flags a silent no-op if the anchor moves upstream.

## Caveats

- This is a **stopgap**, not a cure. The real fix is upstream (the Claude Code CLI hook-abort that wedges the stream) — anthropics/claude-code#63584.
- `coworkMessageTimeoutMs` is read through a remote-config getter; a remote value, if upstream ever pushes one, would override this local default. None is observed in current builds.

## Test

- `bash -n scripts/patches/cowork.sh` passes.
- Patch 13 logic dry-run against the extracted 1.8555.2 `index.js`: rewrites `6e5`→`3e5`, second run is a no-op (idempotent).
- New marker validated: pattern matches the patched output and its own sample; all existing marker rows still pass.
- [ ] Full build + manual confirmation that a stalled session now surfaces "stopped responding" at ~5 min (needs a maintainer build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)