### PR TITLE
Fix Fedora launch regression and KDE tray quit handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ result-*
 
 # Wrangler (Cloudflare Worker dev/deploy cache)
 worker/.wrangler/
+
+# Graphify outputs and temporary files
+graphify-out/
+.graphify_*

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,15 @@ worker/.wrangler/
 # Graphify outputs and temporary files
 graphify-out/
 .graphify_*
+
+# Local agent/editor state and helper bins
+.agents/
+.codex/
+.tmpbin/
+
+# Local package artifacts
+*.rpm
+
+# Root-level scratch extracts from app inspection
+/frame-fix-wrapper.js
+/index.js

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -163,8 +163,10 @@ the launcher won't stack duplicate flags.
 
 If the previous launch already died with the GPU-process FATAL
 signature and `CLAUDE_DISABLE_GPU` is unset, the next launch
-auto-applies the same flags. `CLAUDE_DISABLE_GPU=0` suppresses that
-auto-fallback if you need to retest hardware acceleration.
+auto-applies the same flags and keeps them applied on subsequent
+launches. Set `CLAUDE_DISABLE_GPU=0` to suppress the auto-fallback
+when retesting hardware acceleration after a driver fix — any
+explicitly set value suppresses it; only `1` forces the flags on.
 
 **When to prefer which:** the in-app toggle is friendlier if you
 can reach Settings without the app crashing. Reach for

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -161,6 +161,11 @@ applied automatically inside XRDP sessions, where software
 rendering is required regardless. Either signal is sufficient —
 the launcher won't stack duplicate flags.
 
+If the previous launch already died with the GPU-process FATAL
+signature and `CLAUDE_DISABLE_GPU` is unset, the next launch
+auto-applies the same flags. `CLAUDE_DISABLE_GPU=0` suppresses that
+auto-fallback if you need to retest hardware acceleration.
+
 **When to prefer which:** the in-app toggle is friendlier if you
 can reach Settings without the app crashing. Reach for
 `CLAUDE_DISABLE_GPU=1` when the app crashes before you can open

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -179,10 +179,10 @@ _previous_launch_hit_gpu_fatal() {
 				exit 1
 			}
 			text = sections[target]
-			if (
-				index(text, "GPU process launch failed: error_code=") &&
-				index(text, "GPU process isn'\''t usable. Goodbye.")
-			) {
+			if (index(text,
+				"GPU process launch failed: error_code=") &&
+				index(text,
+				"GPU process isn'\''t usable. Goodbye.")) {
 				exit 0
 			}
 			exit 1

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -156,6 +156,40 @@ _detect_password_store() {
 	echo 'basic'
 }
 
+# Detect whether the previous launch ended in Chromium's
+# "GPU process isn't usable" crash signature (#583).
+#
+# setup_logging() must have run first so $log_file is available. The
+# launcher writes the current session header before build_electron_args()
+# runs, so the previous launch lives in the penultimate log section.
+_previous_launch_hit_gpu_fatal() {
+	[[ -f ${log_file:-} ]] || return 1
+
+	awk '
+		/^--- Claude Desktop (Launcher|AppImage) Start ---$/ {
+			section++
+			next
+		}
+		{
+			sections[section] = sections[section] $0 "\n"
+		}
+		END {
+			target = section > 1 ? section - 1 : section
+			if (target < 1) {
+				exit 1
+			}
+			text = sections[target]
+			if (
+				index(text, "GPU process launch failed: error_code=") &&
+				index(text, "GPU process isn'\''t usable. Goodbye.")
+			) {
+				exit 0
+			}
+			exit 1
+		}
+	' "$log_file"
+}
+
 # Build Electron arguments array based on display backend
 # Requires: is_wayland, use_x11_on_wayland to be set
 #           (call detect_display_backend first)
@@ -225,9 +259,16 @@ build_electron_args() {
 	# behaviour is reachable via Settings → disable hardware
 	# acceleration; this lets users persist it via the env without
 	# having to reach the Settings UI through repeated crashes.
-	if [[ ${CLAUDE_DISABLE_GPU:-} == '1' ]]; then
+	if [[ -v CLAUDE_DISABLE_GPU ]]; then
+		if [[ ${CLAUDE_DISABLE_GPU} == '1' ]]; then
+			_disable_gpu=true
+			log_message \
+				'CLAUDE_DISABLE_GPU=1 - hardware acceleration disabled'
+		fi
+	elif _previous_launch_hit_gpu_fatal; then
 		_disable_gpu=true
-		log_message 'CLAUDE_DISABLE_GPU=1 - hardware acceleration disabled'
+		log_message \
+			'Previous launch hit GPU process FATAL - disabling GPU'
 	fi
 	[[ $_disable_gpu == true ]] \
 		&& electron_args+=('--disable-gpu' '--disable-software-rasterizer')

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -162,11 +162,22 @@ _detect_password_store() {
 # setup_logging() must have run first so $log_file is available. The
 # launcher writes the current session header before build_electron_args()
 # runs, so the previous launch lives in the penultimate log section.
+#
+# A recovered launch (running with --disable-gpu) produces no GPU
+# output, so the crash signature alone would re-enable GPU on launch
+# N+2 and oscillate crash/work/crash on permanently broken hardware.
+# The launcher's own "disabling GPU" marker therefore also counts as
+# a trigger, making recovery sticky once tripped. CLAUDE_DISABLE_GPU=0
+# remains the escape hatch for retesting hardware acceleration.
+#
+# Section headers vary by package format: deb/rpm write "Launcher
+# Start", AppImage writes "AppImage Start", and Nix writes "Launcher
+# Start (NixOS)" (nix/claude-desktop.nix).
 _previous_launch_hit_gpu_fatal() {
 	[[ -f ${log_file:-} ]] || return 1
 
 	awk '
-		/^--- Claude Desktop (Launcher|AppImage) Start ---$/ {
+		/^--- Claude Desktop (Launcher|AppImage) Start( \(NixOS\))? ---$/ {
 			section++
 			next
 		}
@@ -183,6 +194,10 @@ _previous_launch_hit_gpu_fatal() {
 				"GPU process launch failed: error_code=") &&
 				index(text,
 				"GPU process isn'\''t usable. Goodbye.")) {
+				exit 0
+			}
+			if (index(text,
+				"Previous launch hit GPU process FATAL")) {
 				exit 0
 			}
 			exit 1

--- a/tests/launcher-disable-gpu.bats
+++ b/tests/launcher-disable-gpu.bats
@@ -158,6 +158,45 @@ LOG
 	grep -q 'Previous launch hit GPU process FATAL' "$log_file"
 }
 
+@test "disable-gpu: recovery stays sticky on launch N+2 (no oscillation)" {
+	# A recovered launch runs with --disable-gpu and writes no GPU
+	# output, so the crash signature alone would re-enable GPU on
+	# launch N+2 (crash/work/crash forever). The launcher's own
+	# "disabling GPU" marker in the penultimate section must keep
+	# recovery tripped.
+	cat > "$log_file" <<'LOG'
+--- Claude Desktop Launcher Start ---
+GPU process launch failed: error_code=1002
+GPU process isn't usable. Goodbye.
+--- Claude Desktop Launcher Start ---
+Previous launch hit GPU process FATAL - disabling GPU
+--- Claude Desktop Launcher Start ---
+LOG
+
+	build_electron_args deb
+
+	args_contain '--disable-gpu'
+	args_contain '--disable-software-rasterizer'
+}
+
+@test "disable-gpu: NixOS launcher header sections are detected" {
+	# nix/claude-desktop.nix writes "Launcher Start (NixOS)" headers;
+	# the section regex must match them or recovery silently no-ops
+	# on Nix.
+	cat > "$log_file" <<'LOG'
+--- Claude Desktop Launcher Start (NixOS) ---
+GPU process launch failed: error_code=1002
+GPU process isn't usable. Goodbye.
+--- Claude Desktop Launcher Start (NixOS) ---
+LOG
+
+	build_electron_args deb
+
+	args_contain '--disable-gpu'
+	args_contain '--disable-software-rasterizer'
+	grep -q 'Previous launch hit GPU process FATAL' "$log_file"
+}
+
 @test "disable-gpu: CLAUDE_DISABLE_GPU=0 suppresses auto fallback" {
 	cat > "$log_file" <<'LOG'
 --- Claude Desktop Launcher Start ---

--- a/tests/launcher-disable-gpu.bats
+++ b/tests/launcher-disable-gpu.bats
@@ -142,3 +142,33 @@ args_count() {
 	run args_contain '--disable-gpu'
 	[[ "$status" -ne 0 ]]
 }
+
+@test "disable-gpu: prior GPU fatal auto-disables on next launch" {
+	cat > "$log_file" <<'LOG'
+--- Claude Desktop Launcher Start ---
+GPU process launch failed: error_code=1002
+GPU process isn't usable. Goodbye.
+--- Claude Desktop Launcher Start ---
+LOG
+
+	build_electron_args deb
+
+	args_contain '--disable-gpu'
+	args_contain '--disable-software-rasterizer'
+	grep -q 'Previous launch hit GPU process FATAL' "$log_file"
+}
+
+@test "disable-gpu: CLAUDE_DISABLE_GPU=0 suppresses auto fallback" {
+	cat > "$log_file" <<'LOG'
+--- Claude Desktop Launcher Start ---
+GPU process launch failed: error_code=1002
+GPU process isn't usable. Goodbye.
+--- Claude Desktop Launcher Start ---
+LOG
+	export CLAUDE_DISABLE_GPU=0
+
+	build_electron_args deb
+
+	run args_contain '--disable-gpu'
+	[[ "$status" -ne 0 ]]
+}


### PR DESCRIPTION
## Summary
- fix the tray patch matcher for the current upstream menu/context-menu shape so KDE tray updates stop rebuilding the StatusNotifierItem unnecessarily
- fix the trusted-folder `.asar` guard injection so newer minified bundles do not produce a malformed `index.js`
- auto-disable GPU on the next launch after the known Chromium GPU-process fatal path, with docs and launcher tests

## Problem
On Fedora RPM installs we hit two separate regressions while testing the current upstream bundle:

1. The rebuilt app could fail immediately with a JavaScript `SyntaxError` inside `addTrustedFolder()` because the `.asar` guard patch in `scripts/patches/config.sh` was inserting into the wrong expression shape in the newer minified bundle.
2. After fixing that parse failure, the app still failed to stay open on Fedora KDE/Wayland because Electron 41 was hitting the known `GPU process isn't usable. Goodbye.` crash path unless `CLAUDE_DISABLE_GPU=1` was set.
3. Separately, KDE tray `Quit` was inert because the tray fast-path patch no longer matched the current upstream tray menu shape, so the app fell back to the destroy/recreate SNI path that races on Plasma.

## Fix
- update `patch_tray_inplace_update()` to support the current `menuVar = menuFunc(); tray.setContextMenu(menuVar)` pattern as well as the older direct-call shape
- retarget the trusted-folder injection to the `async addTrustedFolder(...) {` function body so the `.asar` guard lands in valid JavaScript again
- teach the launcher to automatically apply `--disable-gpu --disable-software-rasterizer` on the next launch after the prior log section shows the GPU-fatal signature, while preserving explicit env-var override behavior
- document the auto-recovery path and cover it with `launcher-disable-gpu.bats`

## Validation
- verified the rebuilt `app.asar.contents/.vite/build/index.js` passes `node --check` after the config patch fix
- verified on the Fedora install that the app progressed past the prior `SyntaxError` and that launches with GPU disabled stayed alive
- verified the launcher log shows the expected GPU-disable path once the workaround is active
- could not run `bats` or `shellcheck` locally on this Fedora machine because those tools were not installed in the environment

---
Generated with Codex (GPT-5)
Co-Authored-By: OpenAI Codex <noreply@openai.com>
90% AI / 10% Human
Codex: investigated the Fedora RPM failure, patched the tray/config/launcher logic, updated docs/tests, and verified the installed app behaviour.
Human: reproduced the Fedora install issues, requested the fix direction, and validated the real-machine packaging flow.
