### PR TITLE
fix(patches): reject .asar paths in argv file-drop collector (#668)

### DIFF
--- a/scripts/cowork-patch-markers.tsv
+++ b/scripts/cowork-patch-markers.tsv
@@ -28,3 +28,4 @@ cowork-daemon-pid	global\.__coworkDaemonPid	global.__coworkDaemonPid=_c.pid
 cowork-linux-daemon-shutdown	cowork-linux-daemon-shutdown	name:"cowork-linux-daemon-shutdown"
 sharedcwdpath-threadthrough	sharedCwdPath:this\.sessions\.get\(	sharedCwdPath:this.sessions.get(t)?.userSelectedFolders?.[0]
 asar-adddir-filter	\.filter\(_d=>!_d\.endsWith\("\.asar"\)\).*"--add-dir"	.filter(_d=>!_d.endsWith(".asar")))Y.push("--add-dir"
+asar-file-drop-guard	\.startsWith\("-"\)&&![\w$]+\.endsWith\("\.asar"\)	.startsWith("-")&&!i.endsWith(".asar")

--- a/scripts/cowork-patch-markers.tsv
+++ b/scripts/cowork-patch-markers.tsv
@@ -28,4 +28,4 @@ cowork-daemon-pid	global\.__coworkDaemonPid	global.__coworkDaemonPid=_c.pid
 cowork-linux-daemon-shutdown	cowork-linux-daemon-shutdown	name:"cowork-linux-daemon-shutdown"
 sharedcwdpath-threadthrough	sharedCwdPath:this\.sessions\.get\(	sharedCwdPath:this.sessions.get(t)?.userSelectedFolders?.[0]
 asar-adddir-filter	\.filter\(_d=>!_d\.endsWith\("\.asar"\)\).*"--add-dir"	.filter(_d=>!_d.endsWith(".asar")))Y.push("--add-dir"
-asar-file-drop-guard	\.startsWith\("-"\)&&![\w$]+\.endsWith\("\.asar"\)	.startsWith("-")&&!i.endsWith(".asar")
+asar-file-drop-guard	\.startsWith\("-"\)\s*&&\s*![\w$]+\.endsWith\("\.asar"\)	.startsWith("-")&&!i.endsWith(".asar")

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -108,6 +108,11 @@ console.log('Updated package.json: main entry, desktopName, and node-pty depende
 	# trigger false Cowork dispatch (#383, #622, #632).
 	patch_asar_path_filter
 
+	# Reject .asar paths in the argv file-drop collector so the
+	# existsSync branch doesn't dispatch app.asar as a file drop,
+	# triggering a permission prompt on every window reopen (#383, #622).
+	patch_asar_argv_file_drop_guard
+
 	# Patch Cowork mode for Linux (TypeScript VM client + Unix socket)
 	patch_cowork_linux
 

--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -114,6 +114,16 @@ ASAR_FILTER_PATCH
 # window close+reopen (#383, #622 regression in v2.0.16+).
 #
 # Fix: inject !PARAM.endsWith(".asar")&& before the existsSync call.
+#
+# Threat model: this argv path is reachable from user-launched
+# invocations (TPr's only caller is the second-instance handler, and
+# the desktop entries ship `Exec=... %u`), so it is not just the app's
+# own relaunch. The exact-suffix, case-sensitive ".asar" match is still
+# correct because the only sink here is attach-to-draft
+# (dispatchOnCoworkFromMain -> selectedFiles) — identical to a manual
+# drag, with no content read, privilege boundary, or traversal sink. So
+# don't "harden" it with toLowerCase(): that would diverge from the
+# sibling .asar guards for zero behavioral gain.
 # ---------------------------------------------------------------------------
 patch_asar_argv_file_drop_guard() {
 	echo 'Patching argv file-drop collector to reject .asar paths...'
@@ -123,7 +133,7 @@ patch_asar_argv_file_drop_guard() {
 	# !PARAM.startsWith("-")&&!PARAM.endsWith(".asar") — anchored to
 	# startsWith to avoid false-positive matches from other .asar guards
 	# (e.g. the statSync patch or the --add-dir filter).
-	if grep -qP '\.startsWith\("-"\)&&![\w$]+\.endsWith\("\.asar"\)' \
+	if grep -qP '\.startsWith\("-"\)\s*&&\s*![\w$]+\.endsWith\("\.asar"\)' \
 		"$index_js"; then
 		echo '  .asar file-drop guard already present (idempotent)'
 		echo '##############################################################'
@@ -186,7 +196,7 @@ const patched = startsPart + '!' + param + '.endsWith(".asar")&&' +
 code = code.replace(match[0], patched);
 
 // Verify the patch landed with the correct context
-if (!code.match(/\.startsWith\("-"\)&&![\w$]+\.endsWith\("\.asar"\)/)) {
+if (!code.match(/\.startsWith\("-"\)\s*&&\s*![\w$]+\.endsWith\("\.asar"\)/)) {
     console.error('FATAL: .asar file-drop guard replacement failed.');
     process.exit(1);
 }
@@ -198,7 +208,6 @@ ASAR_FILE_DROP_PATCH
 		echo 'FATAL: .asar argv file-drop guard patch failed' >&2
 		echo 'The app will show file-drop prompts on window reopen' \
 			'without this patch (#383, #622).' >&2
-		cd "$project_root" || exit 1
 		exit 1
 	fi
 

--- a/scripts/patches/cowork.sh
+++ b/scripts/patches/cowork.sh
@@ -98,6 +98,113 @@ ASAR_FILTER_PATCH
 	echo '##############################################################'
 }
 
+# ---------------------------------------------------------------------------
+# Patch: reject .asar paths in the argv file-drop collector
+#
+# PR #640 patched the directory-check helper (isDirectory path) so
+# app.asar is no longer dispatched as a "folder drop".  However, the
+# argv collector function (lKr in the current build) has a separate
+# branch:
+#
+#   if (!i.startsWith("-") && FSVAR.existsSync(i)) { A.push(i); }
+#
+# Electron's ASAR VFS shim makes existsSync return true for .asar
+# paths, so app.asar passes this check and is dispatched to the
+# "file drop" handler (cCA), triggering a permission prompt on every
+# window close+reopen (#383, #622 regression in v2.0.16+).
+#
+# Fix: inject !PARAM.endsWith(".asar")&& before the existsSync call.
+# ---------------------------------------------------------------------------
+patch_asar_argv_file_drop_guard() {
+	echo 'Patching argv file-drop collector to reject .asar paths...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Idempotency: check for the guard in context — specifically
+	# !PARAM.startsWith("-")&&!PARAM.endsWith(".asar") — anchored to
+	# startsWith to avoid false-positive matches from other .asar guards
+	# (e.g. the statSync patch or the --add-dir filter).
+	if grep -qP '\.startsWith\("-"\)&&![\w$]+\.endsWith\("\.asar"\)' \
+		"$index_js"; then
+		echo '  .asar file-drop guard already present (idempotent)'
+		echo '##############################################################'
+		return
+	fi
+
+	if ! INDEX_JS="$index_js" node << 'ASAR_FILE_DROP_PATCH'
+const fs = require('fs');
+const indexJs = process.env.INDEX_JS;
+let code = fs.readFileSync(indexJs, 'utf8');
+
+// Find the argv file-drop collector branch.
+// Beautified form:
+//   if (!i.startsWith("-") && ee.existsSync(i)) {
+//     A.push(i);
+//     continue;
+//   }
+// Minified form:
+//   if(!i.startsWith("-")&&ee.existsSync(i)){A.push(i);continue}
+//
+// Anchor: !PARAM.startsWith("-")&&FSVAR.existsSync(PARAM) — unique in
+// the bundle (verified). The .push() suffix is intentionally omitted
+// to avoid brittleness if the minifier reorders the if-body.
+// The param variable and fs variable are both minified and captured.
+const re =
+    /(![\w$]+\.startsWith\s*\(\s*"-"\s*\)\s*&&\s*)([\w$]+)\.existsSync\(\s*([\w$]+)\s*\)/;
+const match = code.match(re);
+
+if (!match) {
+    console.error('FATAL: argv file-drop collector branch not found.');
+    console.error('  Expected: !PARAM.startsWith("-")&&FSVAR.existsSync(PARAM)');
+    console.error(
+        '  This patch prevents app.asar file-drop prompts (#383, #622).');
+    process.exit(1);
+}
+
+// Verify uniqueness — startsWith("-")&&existsSync must appear exactly
+// once; multiple matches would mean we cannot safely target this site.
+const escaped = match[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const allMatches = code.match(new RegExp(escaped, 'g'));
+if (allMatches && allMatches.length > 1) {
+    console.error('FATAL: file-drop pattern matched ' +
+        allMatches.length + ' times (expected 1).');
+    process.exit(1);
+}
+
+const [, startsPart, fsVar, param] = match;
+console.log(
+    '  Found collector: param=' + param + ', fsVar=' + fsVar);
+
+// Insert guard: !PARAM.endsWith(".asar")&&
+// Before: !PARAM.startsWith("-")&&FSVAR.existsSync(PARAM)
+// After:  !PARAM.startsWith("-")&&!PARAM.endsWith(".asar")&&FSVAR.existsSync(PARAM)
+//
+// Replace the full outer match directly — no nested replace — to avoid
+// any risk of $ in minified identifiers being misread as replacement
+// pattern metacharacters.
+const patched = startsPart + '!' + param + '.endsWith(".asar")&&' +
+    fsVar + '.existsSync(' + param + ')';
+code = code.replace(match[0], patched);
+
+// Verify the patch landed with the correct context
+if (!code.match(/\.startsWith\("-"\)&&![\w$]+\.endsWith\("\.asar"\)/)) {
+    console.error('FATAL: .asar file-drop guard replacement failed.');
+    process.exit(1);
+}
+
+fs.writeFileSync(indexJs, code);
+console.log('  Added .asar guard to argv file-drop collector');
+ASAR_FILE_DROP_PATCH
+	then
+		echo 'FATAL: .asar argv file-drop guard patch failed' >&2
+		echo 'The app will show file-drop prompts on window reopen' \
+			'without this patch (#383, #622).' >&2
+		cd "$project_root" || exit 1
+		exit 1
+	fi
+
+	echo '##############################################################'
+}
+
 patch_cowork_linux() {
 	echo 'Patching Cowork mode for Linux...'
 	local index_js='app.asar.contents/.vite/build/index.js'


### PR DESCRIPTION
## Summary

Fixes the permission prompt that appears on every window close+reopen from the taskbar (#668, regression of #383 and #622).

- PR #640 patched `isDirectory()` in the directory-check helper, blocking the **folder-drop** path for `app.asar`
- The argv collector function (`lKr`) has a separate **file-drop** branch using `existsSync()` that was never patched
- Electron's ASAR VFS shim makes `existsSync()` return `true` for `.asar` paths, so `app.asar` passes the check and is dispatched to `cCA()` as a file drop every time the second-instance handler fires (i.e. every taskbar reopen)
- The startup code path already excludes the app bundle via `tA.resolve(n) !== appPath`; `lKr()` — used only for second-instance relaunches — has no equivalent guard

**Fix:** inject `!PARAM.endsWith(".asar")&&` before the `existsSync()` call in `lKr()`:

```
// Before
!i.startsWith("-") && ee.existsSync(i)

// After
!i.startsWith("-") && !i.endsWith(".asar") && ee.existsSync(i)
```

## Changes

- `patch_asar_argv_file_drop_guard()` added to `scripts/patches/cowork.sh`
- Wired into `patch_app_asar()` in `scripts/patches/app-asar.sh` immediately after `patch_asar_path_filter`
- `asar-file-drop-guard` marker added to `scripts/cowork-patch-markers.tsv`

## Test plan

- [ ] Build deb package and verify `verify-patches.sh` passes the new `asar-file-drop-guard` marker
- [ ] Close Claude window, reopen from taskbar — confirm no `app.asar` attach prompt
- [ ] Confirm `Handling file drop: .../app.asar` no longer appears in `~/.config/Claude/logs/main.log` on reopen

Verified anchor uniqueness (1 match) and idempotency against extracted `index.js` from v2.0.16 (1.9255.2). Idempotency check is context-anchored to `startsWith("-")` to avoid false-positives from other `.asar` guards (statSync patch, `--add-dir` filter).

Closes #668
Related: #383, #622, #640

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
95% AI / 5% Human
Claude: root cause investigation, patch implementation, issue analysis, code review
Human: bug report, reproduction details, direction