### PR TITLE
fix(patches): anchor addTrustedFolder guard on function definition

### DIFF
--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -121,7 +121,7 @@ const p = 'app.asar.contents/.vite/build/index.js';
 const F = process.env.FOLDER_PARAM;
 let code = fs.readFileSync(p, 'utf8');
 
-const anchor = 'LocalAgentModeSessions.addTrustedFolder: \${' + F + '}\`);';
+const anchor = 'async addTrustedFolder(' + F + '){';
 const idx = code.indexOf(anchor);
 if (idx === -1) {
   console.error('  [FAIL] addTrustedFolder anchor not found');


### PR DESCRIPTION
The `addTrustedFolder` log call moved from a standalone statement in
1.9255.x to a comma-expression inside an `if` condition in 1.9659.2:

// 1.9255.x — standalone statement, anchor ended with );
ie.debug(LocalAgentModeSessions.addTrustedFolder: ${i});

// 1.9659.2 — log call inside if-condition comma expression
if(S.info(LocalAgentModeSessions.addTrustedFolder: ${i}),await NUe(i)===null){

The old anchor `LocalAgentModeSessions.addTrustedFolder: \${F}\);`
no longer exists, causing `[FAIL] addTrustedFolder anchor not found`
and aborting the build entirely.

Replace with `async addTrustedFolder(F){` — the function definition
itself — which is unique (one occurrence in the bundle), stable across
refactors of the function body, and is the correct semantic injection
point (function entry). Per docs/learnings/patching-minified-js.md §
Anchor selection.

Fixes:
https://github.com/aaddrick/claude-desktop-debian/issues/672
https://github.com/aaddrick/claude-desktop-debian/issues/673