### PR TITLE
fix(tray): startup icon stuck black — make rebuild mutex trailing-edge (#679)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 ### Fixed
 
-- Tray icon no longer stuck black at startup on dark desktops. `nativeTheme.shouldUseDarkColors` reads `false` for the first ~50 ms then flips `true`, but the leading-edge rebuild mutex latched the transient `false` and dropped the corrective `"updated"` events; the mutex is now trailing-edge (re-applies the final value) and the obsolete 3 s startup-suppression window was removed. (__PRURL__, fixes [#679](https://github.com/aaddrick/claude-desktop-debian/issues/679))
-- Restored the in-place tray `setImage` fast-path ([#515](https://github.com/aaddrick/claude-desktop-debian/pull/515)), which silently stopped applying after upstream changed the context-menu wiring from `setContextMenu(BUILDER())` to a prebuilt `setContextMenu(MENU)` object — `patch_tray_inplace_update` now resolves the builder in both shapes, so the duplicate-icon SNI race no longer regresses. (__PRURL__)
+- Tray icon no longer stuck black at startup on dark desktops. `nativeTheme.shouldUseDarkColors` reads `false` for the first ~50 ms then flips `true`, but the leading-edge rebuild mutex latched the transient `false` and dropped the corrective `"updated"` events; the mutex is now trailing-edge (re-applies the final value) and the obsolete 3 s startup-suppression window was removed. ([#680](https://github.com/aaddrick/claude-desktop-debian/pull/680), fixes [#679](https://github.com/aaddrick/claude-desktop-debian/issues/679))
+- Restored the in-place tray `setImage` fast-path ([#515](https://github.com/aaddrick/claude-desktop-debian/pull/515)), which silently stopped applying after upstream changed the context-menu wiring from `setContextMenu(BUILDER())` to a prebuilt `setContextMenu(MENU)` object — `patch_tray_inplace_update` now resolves the builder in both shapes, so the duplicate-icon SNI race no longer regresses. ([#680](https://github.com/aaddrick/claude-desktop-debian/pull/680))
 
 ## [v2.0.16] — 2026-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- Tray icon no longer stuck black at startup on dark desktops. `nativeTheme.shouldUseDarkColors` reads `false` for the first ~50 ms then flips `true`, but the leading-edge rebuild mutex latched the transient `false` and dropped the corrective `"updated"` events; the mutex is now trailing-edge (re-applies the final value) and the obsolete 3 s startup-suppression window was removed. (__PRURL__, fixes [#679](https://github.com/aaddrick/claude-desktop-debian/issues/679))
+- Restored the in-place tray `setImage` fast-path ([#515](https://github.com/aaddrick/claude-desktop-debian/pull/515)), which silently stopped applying after upstream changed the context-menu wiring from `setContextMenu(BUILDER())` to a prebuilt `setContextMenu(MENU)` object — `patch_tray_inplace_update` now resolves the builder in both shapes, so the duplicate-icon SNI race no longer regresses. (__PRURL__)
+
 ## [v2.0.16] — 2026-05-27
 
 Tracks upstream Claude Desktop 1.9255.0.

--- a/docs/learnings/tray-rebuild-race.md
+++ b/docs/learnings/tray-rebuild-race.md
@@ -80,7 +80,7 @@ releases. All five are extracted dynamically in `tray.sh`:
 | `tray_func` | `on("menuBarEnabled",()=>{ … })` |
 | `tray_var` | `});let X=null;(async )?function ${tray_func}` |
 | `electron_var` | already extracted earlier in `_common.sh` |
-| `menu_func` | `${tray_var}.setContextMenu(X(`  |
+| `menu_func` | `${tray_var}.setContextMenu(X(` — or, when upstream prebuilds the menu (`M=X(); setContextMenu(M)`), resolved one hop back via `M=X(` |
 | `path_var` | `${tray_var}=new ${electron_var}.Tray(${electron_var}.nativeImage.createFromPath(X))` |
 | `enabled_var` | `const X = fn("menuBarEnabled")` |
 
@@ -110,13 +110,54 @@ cd claude-desktop-debian
 After the patch: one SNI stays registered for the app's lifetime,
 icon updates in place on every theme change.
 
+## Startup icon-colour race (leading-edge mutex drop)
+
+A subtler bug lives in the same rebuild function. On a *dark* desktop
+(e.g. GNOME `color-scheme=prefer-dark`),
+`nativeTheme.shouldUseDarkColors` reads **`false` for the first
+~50 ms** of the process, then a burst of `nativeTheme "updated"`
+events flips it to `true`. Measured with a standalone Electron probe:
+
+```
+[ready+0ms]     shouldUseDarkColors=false   <- tray created -> black icon
+[UPDATED-EVENT] shouldUseDarkColors=true    <- ~50-100 ms later
+[ready+500ms]   shouldUseDarkColors=true     (stays true)
+```
+
+The tray is created with the transient `false` (black). The
+correction never lands because the rebuild mutex was a *leading-edge*
+throttle (`if(f._running)return;f._running=true;setTimeout(...,1500)`):
+the first `"updated"` (false) takes the lock and renders black; the
+follow-up `"updated"` (true) events all arrive inside the 1500 ms
+window and are **dropped**. No further event fires on its own, so the
+icon stays black until a manual theme change forces a new `"updated"`.
+
+The fix makes the mutex *trailing-edge* — a request that arrives while
+a rebuild is in flight is remembered and re-run once when the window
+clears, so the final value wins:
+
+```js
+if (f._running) { f._pending = true; return; }
+f._running = true;
+setTimeout(() => {
+  f._running = false;
+  if (f._pending) { f._pending = false; f(); }
+}, 1500);
+```
+
+The startup-suppression `_trayStartTime > 3e3` guard was removed at
+the same time: it gated the very `"updated"` → rebuild call the
+correction now depends on. Trade-off: a ~1.5 s black flash at startup
+before the trailing re-run lands (vs. permanently black before).
+See [#679](https://github.com/aaddrick/claude-desktop-debian/issues/679).
+
 ## Pitfalls to watch for
 
-- **Fast-path runs inside the 3 s startup window too.** The
-  existing `_trayStartTime > 3e3` guard only gates the
-  `nativeTheme.on('updated')` → `tray_func()` call; once
-  `tray_func()` is running for any reason, our fast-path executes.
-  Fine — it's cheaper than the slow path even at startup.
+- **No startup window gates the rebuild any more.** An earlier
+  `_trayStartTime > 3e3` guard suppressed `tray_func()` for the first
+  3 s; it was removed because it also swallowed the startup colour
+  correction (see the section above). The trailing-edge mutex bounds
+  rebuild frequency instead.
 - **macOS path is left untouched.** The condition
   `process.platform !== 'darwin' && …setContextMenu` keeps the
   Electron macOS tray model (right-click pops up a menu via

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -137,7 +137,15 @@ patch_tray_inplace_update() {
 		fi
 	fi
 	if [[ -z $menu_func ]]; then
-		echo '  Could not extract menu function name — skipping'
+		# Both the inline grep and the menu_var fallback came up empty.
+		# A silent skip here is how the #515 duplicate-icon race
+		# regressed before — make it loud on stderr so the next silent
+		# regression surfaces in CI logs. Still skip gracefully so the
+		# build completes.
+		echo "WARNING: could not resolve tray menu function" \
+			"(inline + fallback both failed) — in-place" \
+			"fast-path NOT applied; duplicate-icon race" \
+			"(#515) may regress" >&2
 		echo '##############################################################'
 		return
 	fi

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -43,11 +43,19 @@ patch_tray_menu_handler() {
 			"$index_js"
 	fi
 
-	# Add mutex guard to prevent concurrent tray rebuilds
+	# Trailing-edge mutex guard. Still prevents concurrent/reentrant
+	# rebuilds (the slow path's 250ms DBus await can interleave), but —
+	# unlike a plain leading-edge drop — it remembers a request that
+	# arrives while a rebuild is in flight and re-runs once when the
+	# window clears, so the FINAL nativeTheme value wins. At startup
+	# shouldUseDarkColors reads false for ~50ms, then a burst of
+	# "updated" events flips it true; a dropping mutex latches the
+	# initial (wrong) value and leaves the tray icon stuck black on a
+	# dark panel. See docs/learnings/tray-rebuild-race.md.
 	if ! grep -q "${tray_func}._running" "$index_js"; then
-		sed -i -E "s/async\s+function\s+${tray_func_re}\s*\(\s*\)\s*\{/async function ${tray_func}(){if(${tray_func}._running)return;${tray_func}._running=true;setTimeout(()=>${tray_func}._running=false,1500);/g" \
+		sed -i -E "s/async\s+function\s+${tray_func_re}\s*\(\s*\)\s*\{/async function ${tray_func}(){if(${tray_func}._running){${tray_func}._pending=true;return}${tray_func}._running=true;setTimeout(()=>{${tray_func}._running=false;if(${tray_func}._pending){${tray_func}._pending=false;${tray_func}()}},1500);/g" \
 			"$index_js"
-		echo "  Added mutex guard to ${tray_func}()"
+		echo "  Added trailing-edge mutex guard to ${tray_func}()"
 	fi
 
 	# Add DBus cleanup delay after tray destroy
@@ -59,22 +67,6 @@ patch_tray_menu_handler() {
 	fi
 
 	echo 'Tray menu handler patched'
-	echo '##############################################################'
-
-	# Skip tray updates during startup (3 second window)
-	echo 'Patching nativeTheme handler for startup delay...'
-	if ! grep -q '_trayStartTime' "$index_js"; then
-		sed -i -E \
-			"s/(${electron_var_re}\.nativeTheme\.on\(\s*\"updated\"\s*,\s*\(\)\s*=>\s*\{)/let _trayStartTime=Date.now();\1/g" \
-			"$index_js"
-		sed -i -E \
-			"s/\(([[:alnum:]_\$]+\([^)]*\))\s*,\s*${tray_func_re}\(\)\s*,/(\1,Date.now()-_trayStartTime>3e3\&\&${tray_func}(),/g" \
-			"$index_js"
-		echo '  Added startup delay check (3 second window)'
-		if ! grep -q "Date.now()-_trayStartTime>3e3" "$index_js"; then
-			echo 'WARNING: Startup delay conditional not injected' >&2
-		fi
-	fi
 	echo '##############################################################'
 }
 
@@ -101,7 +93,7 @@ patch_tray_inplace_update() {
 	# Re-extract the tray variable name — `patch_tray_menu_handler`
 	# declares it `local` so it's not visible here. Same grep pattern.
 	local tray_func tray_func_re local_tray_var tray_var_re
-	local menu_func path_var enabled_var enabled_count
+	local menu_func menu_var menu_var_re path_var enabled_var enabled_count
 	tray_func=$(grep -oP \
 		'on\("menuBarEnabled",\(\)=>\{\K[\w$]+(?=\(\)\})' "$index_js")
 	if [[ -z $tray_func ]]; then
@@ -122,8 +114,24 @@ patch_tray_inplace_update() {
 
 	tray_var_re="${local_tray_var//\$/\\$}"
 
+	# Two upstream shapes wire the context menu differently:
+	#   old: ${tray_var}.setContextMenu(BUILDER())     — builder called inline
+	#   new: M=BUILDER(); ${tray_var}.setContextMenu(M) — prebuilt menu object
+	# Resolve the BUILDER name in both. The injected fast-path emits
+	# setContextMenu(BUILDER()), so landing on the menu *object* (M) instead
+	# of its builder would emit setContextMenu(M()) and throw at runtime —
+	# M is a Menu instance, not a function.
 	menu_func=$(grep -oP "${tray_var_re}\.setContextMenu\(\K[\$\w]+(?=\(\))" \
 		"$index_js" | head -1)
+	if [[ -z $menu_func ]]; then
+		menu_var=$(grep -oP "${tray_var_re}\.setContextMenu\(\K[\$\w]+(?=\))" \
+			"$index_js" | head -1)
+		if [[ -n $menu_var ]]; then
+			menu_var_re="${menu_var//\$/\\$}"
+			menu_func=$(grep -oP "[,;(]${menu_var_re}=\K[\$\w]+(?=\(\))" \
+				"$index_js" | head -1)
+		fi
+	fi
 	if [[ -z $menu_func ]]; then
 		echo '  Could not extract menu function name — skipping'
 		echo '##############################################################'

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -128,7 +128,11 @@ patch_tray_inplace_update() {
 			"$index_js" | head -1)
 		if [[ -n $menu_var ]]; then
 			menu_var_re="${menu_var//\$/\\$}"
-			menu_func=$(grep -oP "[,;(]${menu_var_re}=\K[\$\w]+(?=\(\))" \
+			# Word-boundary lookbehind, not a fixed [,;({] class, so the
+			# assignment resolves whether it follows a separator or a
+			# declarator (`let `/`const ` leaves a space before the var).
+			# First assignment site wins, matching the inline-form grep.
+			menu_func=$(grep -oP "(?<![\$\w])${menu_var_re}=\K[\$\w]+(?=\(\))" \
 				"$index_js" | head -1)
 		fi
 	fi


### PR DESCRIPTION
## Summary

Fixes the tray icon coming up **black (invisible) on a dark panel at startup** and staying that way until the user manually toggles Claude's in-app theme. Fixes #679.

This is **not** the #604/#563 "panel dark by design / `shouldUseDarkColors` stuck false" family — here the system genuinely is dark and the signal *does* become correct within ~50 ms; the correct value is just dropped before it reaches the tray. See #679 for the full distinction.

## Root cause (measured, not inferred)

A standalone Electron probe in the affected session:

```
[ready+0ms]     shouldUseDarkColors=false   <- tray created here -> black
[UPDATED-EVENT] shouldUseDarkColors=false
[UPDATED-EVENT] shouldUseDarkColors=true    <- correct value ~50-100 ms in
[ready+500ms]   shouldUseDarkColors=true     (stays true)
```

`shouldUseDarkColors` reads `false` for the first ~50 ms, then a burst of `nativeTheme "updated"` events flips it `true`. The tray is created with the transient `false` (black). The rebuild function's mutex was a **leading-edge** throttle: the first `"updated"` (false) takes the 1500 ms lock and renders black; the corrective `"updated"` (true) events all arrive inside that window and are **dropped**. No further event fires on its own, so the icon stays black until a manual theme change.

A 4-second simulation of the exact throttle confirmed it: leading-edge → final icon BLACK; trailing-edge → final icon WHITE.

## The fix (`scripts/patches/tray.sh`)

1. **Trailing-edge mutex** (`patch_tray_menu_handler`) — a request arriving while a rebuild is in flight is remembered (`_pending`) and re-run once when the window clears, so the final `nativeTheme` value wins instead of being dropped.
2. **Removed the `_trayStartTime > 3e3` startup-suppression window** — it gated the very `"updated"` → rebuild call the correction now relies on.
3. **Restored the in-place `setImage` fast-path** (#515): on current upstream `patch_tray_inplace_update` silently skipped because its `menu_func` extraction assumed `setContextMenu(BUILDER())`, but upstream now does `M=BUILDER(); setContextMenu(M)`. The fallback resolves the builder one hop back (so the injected code stays `setContextMenu(BUILDER())`, never `setContextMenu(OBJECT())`), using a word-boundary lookbehind that tolerates separator **and** `let`/`const`/`var` declarator shapes. Without this the #515 duplicate-icon race was quietly regressed on current releases.

Docs: `docs/learnings/tray-rebuild-race.md` gains a "Startup icon-colour race" section and its stale 3 s-window pitfall is corrected. CHANGELOG `[Unreleased]` updated.

## Trade-off

The trailing re-run lands when the mutex window clears, so there is a **~1.5 s black flash** at startup before the icon corrects (vs. permanently black before). Happy to tighten the window if you'd prefer a shorter flash — left at the existing 1500 ms here to keep the change minimal.

## Test plan

- [x] Built an AppImage from this branch on Fedora 44 / GNOME / Wayland (Electron via XWayland) and confirmed the tray icon now comes up **white/visible** on the dark panel without any manual toggle (previously permanently black).
- [x] Verified the patched `app.asar`: no `_trayStartTime` gate, `setImage` fast-path present, trailing-edge mutex (`G9A._pending`) present.
- [x] `bash -n` clean; `shellcheck -x` shows only the pre-existing sourced-fragment notes (no shebang / injected globals) that the CI's `git grep` filter excludes by design — no new findings.
- [x] Word-boundary fallback regex validated against `,;({` separators and `let`/`const`/`var` declarators.
- [ ] Maintainer: full pipeline / CI (note: the current upstream `1.9659.2` bundle trips an **unrelated** pre-existing `addTrustedFolder` patch drift in `config.sh`, independent of this change).

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
85% AI / 15% Human
Claude: measured the root cause (Electron probe + throttle simulation), wrote the three patch changes and the docs, built and runtime-verified the AppImage, drafted the issue and PR.
Human: reported the bug, supplied the decisive observations (manual-toggle-fixes-it; "still black" feedback that twice corrected the diagnosis), and approved the approach and scope.
