### PR TITLE
Clean up Desktop helpers after explicit quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- Explicit quit now keeps the launcher alive until Electron exits, then runs
+  stale-helper cleanup for Desktop-owned Cowork, Claude config, and extension
+  helpers. Close-to-tray still leaves the app and helpers running.
+
 ### Changed
 
 - The native-Wayland launch path now routes Quick Entry's global shortcut (`Ctrl+Alt+Space`) through the XDG GlobalShortcuts portal: `GlobalShortcutsPortal` is added to the `--enable-features` set, and all Chromium feature requests are merged into a single `--enable-features=` switch (Chromium honours only the last one, so the previous code could silently clobber features). GNOME Wayland users can opt into the portal route with `CLAUDE_USE_WAYLAND=1`, which works on GNOME ≤ 49 after a one-time portal permission dialog and fixes the focus-bound hotkey from [#404](https://github.com/aaddrick/claude-desktop-debian/issues/404). The default GNOME session stays on XWayland (no rendering/IME regression risk); auto-selecting native Wayland on GNOME is deferred until it can be gated on a real render check. **On GNOME 50 / xdg-desktop-portal ≥ 1.20 the portal route is currently a no-op** — Electron/Chromium doesn't perform the portal's new host `Registry.Register` app-id handshake (filed upstream as [electron/electron#51875](https://github.com/electron/electron/issues/51875)). `CLAUDE_USE_WAYLAND` is now tri-state: `1` native Wayland, `0` force XWayland, unset auto-detects. ([#404](https://github.com/aaddrick/claude-desktop-debian/issues/404))

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -239,6 +239,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 cleanup_orphaned_cowork_daemon
+cleanup_stale_desktop_helpers
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 
@@ -265,10 +266,11 @@ build_electron_args 'nix'
 # Add app path
 electron_args+=("$app_path")
 
-# Execute Electron (exec replaces the shell process so signals
-# like SIGINT, SIGTERM, and SIGHUP reach Electron directly)
+# Execute Electron and keep the launcher alive so explicit quit can
+# clean up Desktop-owned helpers that outlive the Electron main process.
 log_message "Executing: $electron_exec ''${electron_args[*]} $*"
-exec "$electron_exec" "''${electron_args[@]}" "$@" >> "$log_file" 2>&1
+run_electron_and_cleanup "$electron_exec" "''${electron_args[@]}" "$@"
+exit $?
 LAUNCHER
     # Substitute placeholders — electron_exec points to our custom
     # wrapper (which sets GTK/GIO env then execs our merged binary)

--- a/nix/claude-desktop.nix
+++ b/nix/claude-desktop.nix
@@ -226,6 +226,7 @@ stdenvNoCC.mkDerivation {
 
 electron_exec="ELECTRON_PLACEHOLDER"
 app_path="RESOURCES_PLACEHOLDER/app.asar"
+claude_desktop_app_path="$app_path"
 
 source "LAUNCHER_LIB_PLACEHOLDER"
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -302,6 +302,21 @@ build_electron_args() {
 	fi
 }
 
+_claude_desktop_ui_cmdline_matches() {
+	local cmdline="$1"
+	local app_path="${claude_desktop_app_path:-}"
+
+	[[ $cmdline == *cowork-vm-service* ]] && return 1
+	[[ $cmdline == *--type=* ]] && return 1
+
+	if [[ -n $app_path ]]; then
+		[[ $cmdline == *"$app_path"* ]] && return 0
+		return 1
+	fi
+
+	[[ $cmdline == */usr/lib/claude-desktop/*/resources/app.asar* ]]
+}
+
 _claude_desktop_ui_is_alive() {
 	local pid cmdline state
 	for pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
@@ -309,10 +324,7 @@ _claude_desktop_ui_is_alive() {
 		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
 		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
 			|| continue
-		# Skip the cowork daemon (matches app.asar.unpacked path).
-		[[ $cmdline == *cowork-vm-service* ]] && continue
-		# Skip Chromium helpers: zygote, renderer, gpu, utility, etc.
-		[[ $cmdline == *--type=* ]] && continue
+		_claude_desktop_ui_cmdline_matches "$cmdline" || continue
 		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
 		state=$(awk '/^State:/ {print $2; exit}' \
 			"/proc/$pid/status" 2>/dev/null) || continue

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -411,6 +411,25 @@ _desktop_helper_cmdline_matches() {
 	return 1
 }
 
+_desktop_scoped_mcp_cmdline_matches() {
+	local cmdline="$1"
+
+	case "$cmdline" in
+		*' mcp'|*' mcp '*|*@modelcontextprotocol/*|*-mcp*)
+			return 0
+			;;
+	esac
+
+	return 1
+}
+
+_pid_in_claude_desktop_scope() {
+	local pid="$1"
+
+	grep -q '/app-claude-desktop-[^/]*\.scope' \
+		"/proc/$pid/cgroup" 2>/dev/null
+}
+
 cleanup_stale_desktop_helpers() {
 	if _claude_desktop_ui_is_alive; then
 		return 0
@@ -427,7 +446,13 @@ cleanup_stale_desktop_helpers() {
 		[[ ${_electron_child_pid:-} == "$pid" ]] && continue
 		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
 			|| continue
-		_desktop_helper_cmdline_matches "$cmdline" || continue
+		if ! _desktop_helper_cmdline_matches "$cmdline"; then
+			if ! _pid_in_claude_desktop_scope "$pid" \
+				|| ! _desktop_scoped_mcp_cmdline_matches "$cmdline"
+			then
+				continue
+			fi
+		fi
 		matched+=("$pid")
 	done
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -322,7 +322,7 @@ _claude_desktop_ui_is_alive() {
 	for pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
 		# Skip our own launcher bash and its parent.
 		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
-		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
+		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
 			|| continue
 		_claude_desktop_ui_cmdline_matches "$cmdline" || continue
 		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
@@ -430,21 +430,23 @@ _pid_in_claude_desktop_scope() {
 		"/proc/$pid/cgroup" 2>/dev/null
 }
 
+_desktop_helper_candidate_pids() {
+	pgrep -f 'cowork-vm-service\.js|--user-data-dir=.*[/]Claude|Claude Extensions|/usr/lib/claude-desktop/|[[:space:]]mcp([[:space:]]|$)|@modelcontextprotocol/|-mcp' 2>/dev/null
+}
+
 cleanup_stale_desktop_helpers() {
 	if _claude_desktop_ui_is_alive; then
 		return 0
 	fi
 
 	local pids pid cmdline
-	pids=$(
-		pgrep -f 'cowork-vm-service\.js|--user-data-dir=.*[/]Claude|Claude Extensions|/usr/lib/claude-desktop/' 2>/dev/null
-	) || return 0
+	pids=$(_desktop_helper_candidate_pids) || return 0
 
 	local matched=()
 	for pid in $pids; do
 		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
 		[[ ${_electron_child_pid:-} == "$pid" ]] && continue
-		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
+		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
 			|| continue
 		if ! _desktop_helper_cmdline_matches "$cmdline"; then
 			if ! _pid_in_claude_desktop_scope "$pid" \

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -302,6 +302,27 @@ build_electron_args() {
 	fi
 }
 
+_claude_desktop_ui_is_alive() {
+	local pid cmdline state
+	for pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
+		# Skip our own launcher bash and its parent.
+		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
+		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
+			|| continue
+		# Skip the cowork daemon (matches app.asar.unpacked path).
+		[[ $cmdline == *cowork-vm-service* ]] && continue
+		# Skip Chromium helpers: zygote, renderer, gpu, utility, etc.
+		[[ $cmdline == *--type=* ]] && continue
+		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
+		state=$(awk '/^State:/ {print $2; exit}' \
+			"/proc/$pid/status" 2>/dev/null) || continue
+		[[ $state == T || $state == t || $state == Z ]] && continue
+		# Found a genuine live Electron UI — daemon is expected
+		return 0
+	done
+	return 1
+}
+
 # Kill orphaned cowork-vm-service daemon processes.
 # After a crash or unclean shutdown the cowork daemon may outlive the
 # main Electron UI process.  The orphaned daemon holds LevelDB locks
@@ -329,23 +350,9 @@ cleanup_orphaned_cowork_daemon() {
 	# process whose cmdline references app.asar and is NOT a Chromium
 	# helper (--type=...) and NOT the cowork daemon, and is actually
 	# runnable (not stopped/zombie).
-	local pid cmdline state
-	for pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
-		# Skip our own launcher bash and its parent.
-		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
-		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
-			|| continue
-		# Skip the cowork daemon (matches app.asar.unpacked path).
-		[[ $cmdline == *cowork-vm-service* ]] && continue
-		# Skip Chromium helpers: zygote, renderer, gpu, utility, etc.
-		[[ $cmdline == *--type=* ]] && continue
-		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
-		state=$(awk '/^State:/ {print $2; exit}' \
-			"/proc/$pid/status" 2>/dev/null) || continue
-		[[ $state == T || $state == t || $state == Z ]] && continue
-		# Found a genuine live Electron UI — daemon is expected
+	if _claude_desktop_ui_is_alive; then
 		return 0
-	done
+	fi
 
 	# No UI process found — daemon is orphaned, terminate it.
 	# Escalate to SIGKILL if a daemon is stuck and does not exit
@@ -367,6 +374,79 @@ cleanup_orphaned_cowork_daemon() {
 		log_message "Killed orphaned cowork-vm-service daemon (SIGKILL, PIDs: $cowork_pids)"
 	else
 		log_message "Killed orphaned cowork-vm-service daemon (PIDs: $cowork_pids)"
+	fi
+}
+
+_desktop_helper_cmdline_matches() {
+	local cmdline="$1"
+	local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/Claude"
+
+	case "$cmdline" in
+		*cowork-vm-service.js*)
+			return 0
+			;;
+		*"--user-data-dir=$config_dir"*)
+			return 0
+			;;
+		*"$config_dir/Claude Extensions/"*)
+			return 0
+			;;
+		*/usr/lib/claude-desktop/*--type=*)
+			return 0
+			;;
+	esac
+
+	return 1
+}
+
+cleanup_stale_desktop_helpers() {
+	if _claude_desktop_ui_is_alive; then
+		return 0
+	fi
+
+	local pids pid cmdline
+	pids=$(
+		pgrep -f 'cowork-vm-service\.js|--user-data-dir=.*[/]Claude|Claude Extensions|/usr/lib/claude-desktop/' 2>/dev/null
+	) || return 0
+
+	local matched=()
+	for pid in $pids; do
+		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
+		[[ ${_electron_child_pid:-} == "$pid" ]] && continue
+		cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) \
+			|| continue
+		_desktop_helper_cmdline_matches "$cmdline" || continue
+		matched+=("$pid")
+	done
+
+	[[ ${#matched[@]} -gt 0 ]] || return 0
+
+	for pid in "${matched[@]}"; do
+		kill "$pid" 2>/dev/null || true
+	done
+
+	local wait_count=0 alive
+	while ((wait_count < 20)); do
+		alive=false
+		for pid in "${matched[@]}"; do
+			if kill -0 "$pid" 2>/dev/null; then
+				alive=true
+				break
+			fi
+		done
+		[[ $alive == false ]] && break
+		sleep 0.1
+		((wait_count++))
+	done
+
+	if [[ $alive == true ]]; then
+		for pid in "${matched[@]}"; do
+			kill -KILL "$pid" 2>/dev/null || true
+		done
+		log_message \
+			"Killed stale Claude Desktop helpers (SIGKILL, PIDs: ${matched[*]})"
+	else
+		log_message "Killed stale Claude Desktop helpers (PIDs: ${matched[*]})"
 	fi
 }
 
@@ -428,6 +508,44 @@ cleanup_stale_cowork_socket() {
 	# No daemon — the socket file is left over from a crash.
 	rm -f "$sock"
 	log_message "Removed stale cowork-vm-service socket (no daemon running)"
+}
+
+cleanup_after_electron_exit() {
+	cleanup_orphaned_cowork_daemon
+	cleanup_stale_desktop_helpers
+	cleanup_stale_lock
+	cleanup_stale_cowork_socket
+}
+
+_electron_launcher_forward_signal() {
+	local signal="$1"
+
+	if [[ -n ${_electron_child_pid:-} ]]; then
+		kill "-$signal" "$_electron_child_pid" 2>/dev/null || true
+	fi
+}
+
+run_electron_and_cleanup() {
+	local status
+
+	"$@" >> "$log_file" 2>&1 &
+	_electron_child_pid=$!
+
+	trap '_electron_launcher_forward_signal TERM' TERM
+	trap '_electron_launcher_forward_signal INT' INT
+	trap '_electron_launcher_forward_signal HUP' HUP
+
+	wait "$_electron_child_pid"
+	status=$?
+
+	trap - TERM INT HUP
+	_electron_child_pid=''
+
+	log_message "Electron exited with code: $status"
+	cleanup_after_electron_exit
+	log_message '--- Claude Desktop Launcher End ---'
+
+	return "$status"
 }
 
 # Set common environment variables

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -319,7 +319,7 @@ _claude_desktop_ui_cmdline_matches() {
 
 _claude_desktop_ui_is_alive() {
 	local pid cmdline state
-	for pid in $(pgrep -f 'app\.asar' 2>/dev/null); do
+	for pid in $(pgrep -u "$(id -u)" -f 'app\.asar' 2>/dev/null); do
 		# Skip our own launcher bash and its parent.
 		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
 		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
@@ -397,7 +397,7 @@ _desktop_helper_cmdline_matches() {
 		*cowork-vm-service.js*)
 			return 0
 			;;
-		*"--user-data-dir=$config_dir"*)
+		*"--user-data-dir=$config_dir "*)
 			return 0
 			;;
 		*"$config_dir/Claude Extensions/"*)
@@ -411,30 +411,13 @@ _desktop_helper_cmdline_matches() {
 	return 1
 }
 
-_desktop_scoped_mcp_cmdline_matches() {
-	local cmdline="$1"
-
-	case "$cmdline" in
-		*' mcp'|*' mcp '*|*@modelcontextprotocol/*|*-mcp*)
-			return 0
-			;;
-	esac
-
-	return 1
-}
-
-_pid_in_claude_desktop_scope() {
-	local pid="$1"
-
-	grep -q '/app-claude-desktop-[^/]*\.scope' \
-		"/proc/$pid/cgroup" 2>/dev/null
-}
-
 _desktop_helper_candidate_pids() {
-	pgrep -f 'cowork-vm-service\.js|--user-data-dir=.*[/]Claude|Claude Extensions|/usr/lib/claude-desktop/|[[:space:]]mcp([[:space:]]|$)|@modelcontextprotocol/|-mcp' 2>/dev/null
+	pgrep -u "$(id -u)" -f 'cowork-vm-service\.js|--user-data-dir=.*[/]Claude|Claude Extensions|/usr/lib/claude-desktop/' 2>/dev/null
 }
 
 cleanup_stale_desktop_helpers() {
+	# A live UI (any instance) suppresses all cleanup. We don't scope
+	# helpers per-instance. Safe, not complete.
 	if _claude_desktop_ui_is_alive; then
 		return 0
 	fi
@@ -448,13 +431,7 @@ cleanup_stale_desktop_helpers() {
 		[[ ${_electron_child_pid:-} == "$pid" ]] && continue
 		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
 			|| continue
-		if ! _desktop_helper_cmdline_matches "$cmdline"; then
-			if ! _pid_in_claude_desktop_scope "$pid" \
-				|| ! _desktop_scoped_mcp_cmdline_matches "$cmdline"
-			then
-				continue
-			fi
-		fi
+		_desktop_helper_cmdline_matches "$cmdline" || continue
 		matched+=("$pid")
 	done
 
@@ -475,7 +452,7 @@ cleanup_stale_desktop_helpers() {
 		done
 		[[ $alive == false ]] && break
 		sleep 0.1
-		((wait_count++))
+		wait_count=$((wait_count + 1))
 	done
 
 	if [[ $alive == true ]]; then

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -576,12 +576,15 @@ run_electron_and_cleanup() {
 
 	wait "$_electron_child_pid"
 	status=$?
+	while kill -0 "$_electron_child_pid" 2>/dev/null; do
+		wait "$_electron_child_pid"  # reap only; keep status
+	done
 
 	trap - TERM INT HUP
-	_electron_child_pid=''
 
 	log_message "Electron exited with code: $status"
 	cleanup_after_electron_exit
+	_electron_child_pid=''
 	log_message '--- Claude Desktop Launcher End ---'
 
 	return "$status"

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -87,6 +87,12 @@ fi
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env
+
+# Path to the bundled Electron executable and app
+electron_exec="$appdir/usr/lib/node_modules/electron/dist/electron"
+app_path="$appdir/usr/lib/node_modules/electron/dist/resources/app.asar"
+claude_desktop_app_path="$app_path"
+
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock
@@ -101,10 +107,6 @@ log_message "Timestamp: $(date)"
 log_message "Arguments: $@"
 log_message "APPDIR: $appdir"
 log_session_env
-
-# Path to the bundled Electron executable and app
-electron_exec="$appdir/usr/lib/node_modules/electron/dist/electron"
-app_path="$appdir/usr/lib/node_modules/electron/dist/resources/app.asar"
 
 # Build electron args (appimage mode adds --no-sandbox)
 build_electron_args 'appimage'

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -88,6 +88,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 cleanup_orphaned_cowork_daemon
+cleanup_stale_desktop_helpers
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 
@@ -114,9 +115,11 @@ electron_args+=("$app_path")
 # Change to HOME directory before exec'ing Electron to avoid CWD permission issues
 cd "$HOME" || exit 1
 
-# Execute Electron
+# Execute Electron and keep AppRun alive so explicit quit can clean up
+# Desktop-owned helpers that outlive the Electron main process.
 log_message "Executing: $electron_exec ${electron_args[*]} $*"
-exec "$electron_exec" "${electron_args[@]}" "$@" >> "$log_file" 2>&1
+run_electron_and_cleanup "$electron_exec" "${electron_args[@]}" "$@"
+exit $?
 EOF
 chmod +x "$appdir_path/AppRun" || exit 1
 echo 'AppRun script created'

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -107,6 +107,11 @@ fi
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env
+
+# App path
+app_path="/usr/lib/$package_name/node_modules/electron/dist/resources/app.asar"
+claude_desktop_app_path="\$app_path"
+
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock
@@ -153,9 +158,6 @@ else
 		exit 1
 	fi
 fi
-
-# App path
-app_path="/usr/lib/$package_name/node_modules/electron/dist/resources/app.asar"
 
 # Build electron args
 build_electron_args 'deb'

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -108,6 +108,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 cleanup_orphaned_cowork_daemon
+cleanup_stale_desktop_helpers
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 
@@ -167,10 +168,11 @@ app_dir="/usr/lib/$package_name"
 log_message "Changing directory to \$app_dir"
 cd "\$app_dir" || { log_message "Failed to cd to \$app_dir"; exit 1; }
 
-# Execute Electron (exec replaces the shell process so signals
-# like SIGINT, SIGTERM, and SIGHUP reach Electron directly)
+# Execute Electron and keep the launcher alive so explicit quit can
+# clean up Desktop-owned helpers that outlive the Electron main process.
 log_message "Executing: \$electron_exec \${electron_args[*]} \$*"
-exec "\$electron_exec" "\${electron_args[@]}" "\$@" >> "\$log_file" 2>&1
+run_electron_and_cleanup "\$electron_exec" "\${electron_args[@]}" "\$@"
+exit \$?
 EOF
 chmod +x "$install_dir/bin/claude-desktop" || exit 1
 echo 'Launcher script created'

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -89,6 +89,11 @@ fi
 # Setup logging and environment
 setup_logging || exit 1
 setup_electron_env
+
+# App path
+app_path="/usr/lib/$package_name/node_modules/electron/dist/resources/app.asar"
+claude_desktop_app_path="\$app_path"
+
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock
@@ -135,9 +140,6 @@ else
 		exit 1
 	fi
 fi
-
-# App path
-app_path="/usr/lib/$package_name/node_modules/electron/dist/resources/app.asar"
 
 # Build electron args - use 'deb' type (same sandbox behavior)
 build_electron_args 'deb'

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -90,6 +90,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 cleanup_orphaned_cowork_daemon
+cleanup_stale_desktop_helpers
 cleanup_stale_lock
 cleanup_stale_cowork_socket
 
@@ -149,10 +150,11 @@ app_dir="/usr/lib/$package_name"
 log_message "Changing directory to \$app_dir"
 cd "\$app_dir" || { log_message "Failed to cd to \$app_dir"; exit 1; }
 
-# Execute Electron (exec replaces the shell process so signals
-# like SIGINT, SIGTERM, and SIGHUP reach Electron directly)
+# Execute Electron and keep the launcher alive so explicit quit can
+# clean up Desktop-owned helpers that outlive the Electron main process.
 log_message "Executing: \$electron_exec \${electron_args[*]} \$*"
-exec "\$electron_exec" "\${electron_args[@]}" "\$@" >> "\$log_file" 2>&1
+run_electron_and_cleanup "\$electron_exec" "\${electron_args[@]}" "\$@"
+exit \$?
 EOF
 chmod +x "$staging_dir/claude-desktop"
 

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -872,6 +872,22 @@ s.close()
 	[[ $status -ne 0 ]]
 }
 
+@test "_claude_desktop_ui_cmdline_matches: ignores other Electron apps" {
+	claude_desktop_app_path='/usr/lib/claude-desktop/node_modules/electron/dist/resources/app.asar'
+
+	run _claude_desktop_ui_cmdline_matches \
+		"/usr/lib/claude-desktop/node_modules/electron/dist/electron $claude_desktop_app_path"
+	[[ $status -eq 0 ]]
+
+	run _claude_desktop_ui_cmdline_matches \
+		"/opt/other-electron-app/resources/app.asar"
+	[[ $status -ne 0 ]]
+
+	run _claude_desktop_ui_cmdline_matches \
+		"/usr/lib/claude-desktop/node_modules/electron/dist/electron --type=utility --user-data-dir=$XDG_CONFIG_HOME/Claude"
+	[[ $status -ne 0 ]]
+}
+
 @test "run_electron_and_cleanup: runs cleanup after Electron exits and preserves status" {
 	local marker="$TEST_TMP/cleanup-ran"
 	local electron="$TEST_TMP/electron"

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -888,6 +888,28 @@ s.close()
 	[[ $status -ne 0 ]]
 }
 
+@test "_desktop_scoped_mcp_cmdline_matches: matches MCP commands only" {
+	run _desktop_scoped_mcp_cmdline_matches \
+		"/usr/bin/node /home/scott/dev/dude/core/agent-dude/dist/index.js mcp"
+	[[ $status -eq 0 ]]
+
+	run _desktop_scoped_mcp_cmdline_matches \
+		"npx -y @modelcontextprotocol/server-filesystem /home/scott"
+	[[ $status -eq 0 ]]
+
+	run _desktop_scoped_mcp_cmdline_matches \
+		"uvx computer-control-mcp@latest"
+	[[ $status -eq 0 ]]
+
+	run _desktop_scoped_mcp_cmdline_matches \
+		"xed /home/scott/.config/Claude/logs/mcp-server-agent-dude.log"
+	[[ $status -ne 0 ]]
+
+	run _desktop_scoped_mcp_cmdline_matches \
+		"termium daemon-server"
+	[[ $status -ne 0 ]]
+}
+
 @test "run_electron_and_cleanup: runs cleanup after Electron exits and preserves status" {
 	local marker="$TEST_TMP/cleanup-ran"
 	local electron="$TEST_TMP/electron"

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -841,6 +841,61 @@ s.close()
 }
 
 # =============================================================================
+# cleanup_stale_desktop_helpers
+# =============================================================================
+
+@test "_desktop_helper_cmdline_matches: matches known Desktop helpers only" {
+	local config_dir="$XDG_CONFIG_HOME/Claude"
+
+	run _desktop_helper_cmdline_matches \
+		"/usr/lib/claude-desktop/node_modules/electron/dist/electron --type=utility --user-data-dir=$config_dir"
+	[[ $status -eq 0 ]]
+
+	run _desktop_helper_cmdline_matches \
+		"/usr/lib/claude-desktop/node_modules/electron/dist/resources/app.asar.unpacked/cowork-vm-service.js"
+	[[ $status -eq 0 ]]
+
+	run _desktop_helper_cmdline_matches \
+		"node $config_dir/Claude Extensions/ant.dir.example/server.js"
+	[[ $status -eq 0 ]]
+
+	run _desktop_helper_cmdline_matches \
+		"/usr/lib/claude-desktop/node_modules/electron/dist/electron /usr/lib/claude-desktop/node_modules/electron/dist/resources/app.asar"
+	[[ $status -ne 0 ]]
+
+	run _desktop_helper_cmdline_matches \
+		"claude --dangerously-skip-permissions"
+	[[ $status -ne 0 ]]
+
+	run _desktop_helper_cmdline_matches \
+		"/home/scott/dev/dude/core/agent-dude/dist/index.js mcp"
+	[[ $status -ne 0 ]]
+}
+
+@test "run_electron_and_cleanup: runs cleanup after Electron exits and preserves status" {
+	local marker="$TEST_TMP/cleanup-ran"
+	local electron="$TEST_TMP/electron"
+
+	cat > "$electron" <<'STUB'
+#!/usr/bin/env bash
+echo "electron argv: $*"
+exit 7
+STUB
+	chmod +x "$electron"
+
+	cleanup_after_electron_exit() {
+		touch "$marker"
+	}
+
+	setup_logging
+	run run_electron_and_cleanup "$electron" '--flag' 'value'
+	[[ $status -eq 7 ]]
+	[[ -f $marker ]]
+	run cat "$log_file"
+	[[ $output == *'electron argv: --flag value'* ]]
+}
+
+# =============================================================================
 # Doctor helper functions
 # =============================================================================
 

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -761,10 +761,12 @@ s.close()
 	sleep 300 &
 	ui_pid=$!
 
+	# Match on "$*", not "$2": the UI scan passes -u <uid> before -f,
+	# so the pattern is no longer at a fixed argument position.
 	pgrep() {
-		if [[ $2 == *cowork-vm-service* ]]; then
+		if [[ $* == *cowork-vm-service* ]]; then
 			echo 4242
-		elif [[ $2 == *app* ]]; then
+		elif [[ $* == *app* ]]; then
 			echo "$ui_pid"
 		fi
 	}
@@ -851,6 +853,16 @@ s.close()
 		"/usr/lib/claude-desktop/node_modules/electron/dist/electron --type=utility --user-data-dir=$config_dir"
 	[[ $status -eq 0 ]]
 
+	# tr '\0' ' ' joins cmdline args with a trailing space, so the
+	# --user-data-dir arm anchors on "$config_dir " — exact dir only.
+	run _desktop_helper_cmdline_matches \
+		"/tmp/.mount_claudeXXXXXX/electron --type=utility --user-data-dir=$config_dir "
+	[[ $status -eq 0 ]]
+
+	run _desktop_helper_cmdline_matches \
+		"/tmp/.mount_claudeXXXXXX/electron --type=utility --user-data-dir=${config_dir}Dev "
+	[[ $status -ne 0 ]]
+
 	run _desktop_helper_cmdline_matches \
 		"/usr/lib/claude-desktop/node_modules/electron/dist/resources/app.asar.unpacked/cowork-vm-service.js"
 	[[ $status -eq 0 ]]
@@ -886,38 +898,6 @@ s.close()
 	run _claude_desktop_ui_cmdline_matches \
 		"/usr/lib/claude-desktop/node_modules/electron/dist/electron --type=utility --user-data-dir=$XDG_CONFIG_HOME/Claude"
 	[[ $status -ne 0 ]]
-}
-
-@test "_desktop_scoped_mcp_cmdline_matches: matches MCP commands only" {
-	run _desktop_scoped_mcp_cmdline_matches \
-		"/usr/bin/node /home/scott/dev/dude/core/agent-dude/dist/index.js mcp"
-	[[ $status -eq 0 ]]
-
-	run _desktop_scoped_mcp_cmdline_matches \
-		"npx -y @modelcontextprotocol/server-filesystem /home/scott"
-	[[ $status -eq 0 ]]
-
-	run _desktop_scoped_mcp_cmdline_matches \
-		"uvx computer-control-mcp@latest"
-	[[ $status -eq 0 ]]
-
-	run _desktop_scoped_mcp_cmdline_matches \
-		"xed /home/scott/.config/Claude/logs/mcp-server-agent-dude.log"
-	[[ $status -ne 0 ]]
-
-	run _desktop_scoped_mcp_cmdline_matches \
-		"termium daemon-server"
-	[[ $status -ne 0 ]]
-}
-
-@test "_desktop_helper_candidate_pids: includes MCP-like commands" {
-	pgrep() {
-		[[ $1 == '-f' ]] || return 1
-		[[ $2 == *'[[:space:]]mcp([[:space:]]|$)'* ]]
-	}
-
-	run _desktop_helper_candidate_pids
-	[[ $status -eq 0 ]]
 }
 
 @test "run_electron_and_cleanup: runs cleanup after Electron exits and preserves status" {

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -754,11 +754,14 @@ s.close()
 }
 
 @test "cleanup_orphaned_cowork_daemon: live UI present — daemon left running" {
-	# A real background process stands in for the live Electron UI: its
-	# cmdline ('sleep ...') is neither the cowork daemon nor a --type=
-	# helper, and its state is sleeping (not T/t/Z), so the function
-	# treats it as a live UI and must NOT kill the daemon.
-	sleep 300 &
+	# A real background process stands in for the live Electron UI so
+	# the /proc cmdline and status reads resolve naturally. UI detection
+	# is keyed on the Claude bundle's app.asar path, so the stand-in's
+	# argv[0] is renamed to it via exec -a. Its state is sleeping (not
+	# T/t/Z), so the function treats it as a live UI and must NOT kill
+	# the daemon.
+	bash -c \
+		'exec -a /usr/lib/claude-desktop/electron/resources/app.asar sleep 300' &
 	ui_pid=$!
 
 	# Match on "$*", not "$2": the UI scan passes -u <uid> before -f,

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -910,6 +910,16 @@ s.close()
 	[[ $status -ne 0 ]]
 }
 
+@test "_desktop_helper_candidate_pids: includes MCP-like commands" {
+	pgrep() {
+		[[ $1 == '-f' ]] || return 1
+		[[ $2 == *'[[:space:]]mcp([[:space:]]|$)'* ]]
+	}
+
+	run _desktop_helper_candidate_pids
+	[[ $status -eq 0 ]]
+}
+
 @test "run_electron_and_cleanup: runs cleanup after Electron exits and preserves status" {
 	local marker="$TEST_TMP/cleanup-ran"
 	local electron="$TEST_TMP/electron"


### PR DESCRIPTION
## Summary

- keep the Linux launcher alive while Electron runs, so explicit quit can run post-exit cleanup
- add stale-helper cleanup for known Claude Desktop-owned Cowork, user-data, installed Electron helper, and Claude Extension processes when no live UI exists
- wire deb, RPM, AppImage, and Nix launchers through the shared cleanup runner
- add BATS coverage for safe helper matching and post-exit cleanup preserving Electron exit status

## Notes

This preserves close-to-tray semantics: cleanup only runs after the Electron process exits. Closing the window to tray keeps the app and helpers running.

## Verification

- `npx --yes bats tests/launcher-common.bats`
- `npx --yes shellcheck -x scripts/launcher-common.sh scripts/doctor.sh scripts/packaging/deb.sh scripts/packaging/rpm.sh scripts/packaging/appimage.sh`
- `git diff --check`

---
Generated with OpenAI Codex via Codex CLI
Co-Authored-By: OpenAI Codex <codex@openai.com>
85% AI / 15% Human
Codex: investigation, patch, tests, verification, PR preparation
Human: reported Linux Desktop quit cleanup behavior and clarified close-to-tray vs explicit quit semantics