### PR TITLE
fix(config): re-anchor addTrustedFolder .asar guard on method declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- `addTrustedFolder` `.asar` guard re-anchored on the `async addTrustedFolder(…)` method declaration. Upstream Claude Desktop 1.10628.x folded the `LocalAgentModeSessions.addTrustedFolder: ${i}` log call into a comma-expression inside an `if`, removing the trailing `` `); `` the old anchor matched — `./build.sh` aborted with `[FAIL] addTrustedFolder anchor not found`. Both the parameter extraction and the injection point now key off the unminified method name, so they can't drift apart if upstream drops the log line. ([#685](https://github.com/aaddrick/claude-desktop-debian/pull/685))
+
 ## [v2.0.16] — 2026-05-27
 
 Tracks upstream Claude Desktop 1.9255.0.

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -104,9 +104,16 @@ patch_asar_trusted_folder_guard() {
 		return
 	fi
 
+	# Anchor on the method declaration itself — the method name
+	# `addTrustedFolder` is not minified and is unique in the bundle.
+	# Earlier releases let us anchor on the trailing `${param}`);` of the
+	# log line, but upstream now folds that log call into the comma
+	# expression `if(D.info(`…${i}`),await ZOe(i)===null){…}`, so the
+	# `);` no longer exists. Injecting at the function body head is both
+	# more robust and semantically earlier (reject .asar on entry).
 	local folder_param
 	folder_param=$(grep -oP \
-		'LocalAgentModeSessions\.addTrustedFolder: \$\{\K[$\w]+(?=\})' \
+		'async addTrustedFolder\(\K[$\w]+(?=\)\{)' \
 		"$index_js")
 	if [[ -z $folder_param ]]; then
 		echo '  Could not extract folder parameter — skipping' >&2
@@ -121,7 +128,7 @@ const p = 'app.asar.contents/.vite/build/index.js';
 const F = process.env.FOLDER_PARAM;
 let code = fs.readFileSync(p, 'utf8');
 
-const anchor = 'LocalAgentModeSessions.addTrustedFolder: \${' + F + '}\`);';
+const anchor = 'async addTrustedFolder(' + F + '){';
 const idx = code.indexOf(anchor);
 if (idx === -1) {
   console.error('  [FAIL] addTrustedFolder anchor not found');


### PR DESCRIPTION
## Problem

`./build.sh` hard-fails on Claude Desktop **1.10628.0**. The
`patch_asar_trusted_folder_guard` step in `scripts/patches/config.sh`
aborts the entire build:

```
Patching addTrustedFolder to reject .asar paths...
  Found folder parameter: i
  [FAIL] addTrustedFolder anchor not found
Failed to inject .asar trusted folder guard
```

## Root cause

Upstream re-minification folded the log statement into the comma
expression inside the `if`:

```js
async addTrustedFolder(i){if(D.info(`LocalAgentModeSessions.addTrustedFolder: ${i}`),await ZOe(i)===null){...}
```

The old anchor assumed the log line was a standalone statement ending in
`` ${i}`); `` (with a **semicolon**). After the fold, that `` `); `` is now
`` `), ``, so `code.indexOf(anchor)` returns `-1` and the patch exits 1.

## Fix

Re-anchor on the **method declaration** `async addTrustedFolder(i){`
instead of the volatile tail of the log line:

- the method name `addTrustedFolder` is **not minified** and is unique in
  the bundle (it survives re-minification across releases);
- the guard is injected at the **function-body head** (`if(i.endsWith(".asar"))return;`),
  rejecting `.asar` on entry — semantically earlier and no longer
  dependent on trailing punctuation that drifts between releases.

```diff
-		'LocalAgentModeSessions\.addTrustedFolder: \$\{\K[$\w]+(?=\})' \
+		'async addTrustedFolder\(\K[$\w]+(?=\)\{)' \
...
-const anchor = 'LocalAgentModeSessions.addTrustedFolder: \${' + F + '}\`);';
+const anchor = 'async addTrustedFolder(' + F + '){';
```

The injected result:

```js
async addTrustedFolder(i){if(i.endsWith(".asar"))return;if(D.info(`...${i}`),await ZOe(i)===null){...}
```

## Verification

- ✅ Full patch suite re-runs cleanly — `[OK] .asar guard injected in addTrustedFolder`
- ✅ `node --check` passes on the patched `index.js`, `mainView.js`, `mainWindow.js` (guards against a white-screen from a broken injection)
- ✅ The resulting `claude-desktop-1.10628.0-amd64.AppImage` cold-starts (isolated `--user-data-dir`) and stays up with no errors; network service child process spawns and registers the custom schemes
- The `#649` `--add-dir` filter and all other patches still apply — only this one anchor was stale

Single-file change: `scripts/patches/config.sh`.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
85% AI / 15% Human
Claude: diagnosed the stale anchor via the minified bundle, rewrote the anchor + extraction regex, rebuilt and runtime-verified the AppImage
Human: reported the build failure, requested the fix and PR