### PR TITLE
docs(troubleshooting): AppArmor userns fix for app launch crash on Ubuntu 24.04

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -224,6 +224,58 @@ Credit: this workaround was contributed by
 [@hfyeh](https://github.com/hfyeh) in
 [#351](https://github.com/aaddrick/claude-desktop-debian/issues/351).
 
+### Claude Desktop crashes immediately on launch (Ubuntu 24.04+, AppArmor blocks user namespaces)
+
+The same `apparmor_restrict_unprivileged_userns=1` default that breaks
+Cowork (above) also kills the **main app's** Chromium sandbox during
+startup, so the window never appears. This is a distinct failure: it
+affects the bundled Electron binary, not `bwrap`, so the
+`/etc/apparmor.d/bwrap` profile above does **not** fix it. Symptoms:
+
+- The launcher log (`~/.cache/claude-desktop-debian/launcher.log`) ends
+  with `FATAL:sandbox/linux/services/credentials.cc:131] Check failed: .
+  : Permission denied (13)` (the line number varies by Electron version).
+- The process dies with a `Trace/breakpoint trap` / core dump (exit
+  code 133).
+- `claude-desktop --no-sandbox` launches fine, which confirms the
+  namespace sandbox is the culprit. Don't keep `--no-sandbox` as the
+  fix — it disables the Chromium sandbox entirely.
+
+The `.deb` `postinst` already sets `chrome-sandbox` SUID root (`4755`),
+so the SUID helper is not the problem — Chromium still spins up an
+unprivileged user-namespace zygote that AppArmor denies.
+
+Permit user namespaces for the bundled Electron binary via a scoped
+AppArmor profile (one-time setup, requires sudo):
+
+```bash
+sudo tee /etc/apparmor.d/claude-desktop <<'EOF'
+abi <abi/4.0>,
+include <tunables/global>
+
+profile claude-desktop /usr/lib/claude-desktop/node_modules/electron/dist/electron flags=(unconfined) {
+    userns,
+
+    include if exists <local/claude-desktop>
+}
+EOF
+
+sudo apparmor_parser -r /etc/apparmor.d/claude-desktop
+```
+
+After loading the profile, launch Claude Desktop normally — the window
+should appear with the Chromium sandbox intact (no `--no-sandbox`
+needed).
+
+**Security note:** this grants the unconfined profile plus the `userns`
+capability to the bundled Electron binary only, not system-wide. It is
+narrower than relaxing `kernel.apparmor_restrict_unprivileged_userns`
+globally, which would lift the restriction for every program on the
+host. Review against your threat model before applying.
+
+To revert: `sudo rm /etc/apparmor.d/claude-desktop && sudo
+apparmor_parser -R /etc/apparmor.d/claude-desktop`.
+
 ### Cowork: "VM connection timeout after 60 seconds"
 
 If Cowork fails with a VM timeout, the KVM backend is selected but the guest VM cannot connect back to the host via vsock within the timeout window. Common causes:


### PR DESCRIPTION
> [!IMPORTANT]
> **Two PRs, one bug — merge either #686 or #687, not both.** They fix the same Ubuntu 24.04+ launch crash (`sandbox/.../credentials.cc` FATAL, exit 133) two mutually-exclusive ways, and both edit the same `docs/troubleshooting.md` heading, so merging both would conflict.
>
> - **#686 — documentation only:** documents the manual AppArmor-profile fix and leaves applying it to the user. Minimal, no packaging change.
> - **#687 — full automation:** the deb's `postinst` installs the AppArmor profile automatically (with a matching `prerm` cleanup and a new `--doctor` check), so the crash never reaches the user. Larger change, zero user effort.
>
> Pick whichever matches how much you'd like the package to own.

---

## Summary

Ubuntu 24.04 ships `apparmor_restrict_unprivileged_userns=1` by default, which blocks the unprivileged user namespaces Chromium's sandbox needs. The existing **"Cowork on Ubuntu 24.04+"** troubleshooting entry only covers `bwrap` (issue #351) — but the *same root cause* also crashes the **main app on launch**, before any window appears, and the `/etc/apparmor.d/bwrap` profile does **not** fix it.

This adds a dedicated troubleshooting entry for the launch crash.

## Symptoms documented

- Launcher log ends with `FATAL:sandbox/linux/services/credentials.cc:131] Check failed: . : Permission denied (13)`
- Process dies with `Trace/breakpoint trap` / core dump (exit code 133)
- `claude-desktop --no-sandbox` launches fine (confirms the namespace sandbox is the culprit)

## Fix documented

A scoped AppArmor profile (`/etc/apparmor.d/claude-desktop`) granting `userns` to the bundled Electron binary only — keeps the Chromium sandbox enabled, narrower than relaxing the kernel toggle system-wide. Mirrors the structure of the existing `bwrap` profile fix, with a security note and a revert command.

## Reproduced and verified

On Ubuntu 24.04.4 LTS, `claude-desktop` (`1.10628.2-2.0.18`, Electron 41.5.0):

| Step | Before profile | After profile |
|------|---------------|---------------|
| Launch (no flags) | exit 133, `credentials.cc:131` FATAL, core dump | window initializes, no FATAL |
| `chrome-sandbox` perms | `4755 root:root` (already correct) | unchanged |

`chrome-sandbox` SUID was already correct, ruling out the SUID helper and isolating the cause to the userns restriction.

## Possible follow-up (not in this PR)

`doctor.sh` could grow a probe that checks the Electron binary's userns access (analogous to the existing `bwrap` probe at `doctor.sh:888`) and points at this section.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
10% AI / 90% Human
Claude: reproduced the crash, isolated the AppArmor userns root cause, drafted and verified the troubleshooting entry
Human: hit the bug, directed the investigation, chose the AppArmor-profile remediation, owns the fork and PR
