### PR TITLE
ci(test-artifacts): test arm64 packages + fix AppImage launch-smoke pkill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,11 @@ jobs:
       release_tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
   test-artifacts:
-    name: Test Build Artifacts
+    name: Test Build Artifacts (amd64)
     needs: [build-amd64]
     uses: ./.github/workflows/test-artifacts.yml
+    with:
+      arch: amd64
 
   build-arm64:
     name: Build Packages (arm64 - ${{ matrix.artifact_suffix }})
@@ -82,10 +84,17 @@ jobs:
       artifact_suffix: ${{ matrix.artifact_suffix }}
       release_tag: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
 
+  test-artifacts-arm64:
+    name: Test Build Artifacts (arm64)
+    needs: [build-arm64]
+    uses: ./.github/workflows/test-artifacts.yml
+    with:
+      arch: arm64
+
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test-flags, build-amd64, build-arm64, test-artifacts]
+    needs: [test-flags, build-amd64, build-arm64, test-artifacts, test-artifacts-arm64]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -82,6 +82,8 @@ jobs:
           done
 
       - name: Run artifact tests
+        env:
+          TARGET_ARCH: ${{ inputs.arch }}
         run: |
           chmod +x tests/test-artifact-${{ matrix.format }}.sh
           tests/test-artifact-${{ matrix.format }}.sh artifacts/

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -2,6 +2,11 @@ name: Test Build Artifacts (Reusable)
 
 on:
   workflow_call:
+    inputs:
+      arch:
+        description: Architecture of the artifacts under test (amd64/arm64)
+        type: string
+        default: amd64
 
 permissions:
   contents: read
@@ -13,17 +18,17 @@ jobs:
       matrix:
         include:
           - format: deb
-            artifact: package-amd64-deb
             container: ""
           - format: rpm
-            artifact: package-amd64-rpm
             container: "fedora:42"
           - format: appimage
-            artifact: package-amd64-appimage
             container: ""
 
-    name: Validate ${{ matrix.format }} package
-    runs-on: ubuntu-latest
+    name: Validate ${{ inputs.arch }} ${{ matrix.format }} package
+    # arm64 artifacts run on a native arm64 runner (matching build-arm64)
+    # so the launch smoke test actually executes the packaged binary
+    # rather than failing on a foreign architecture.
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-latest' }}
     container: ${{ matrix.container || '' }}
 
     steps:
@@ -33,7 +38,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
-          name: ${{ matrix.artifact }}
+          name: package-${{ inputs.arch }}-${{ matrix.format }}
           path: artifacts/
 
       - name: Install test dependencies (Fedora)

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -119,7 +119,11 @@ fi
 
 # --- Headless launch smoke test ---
 # The AppImage runs as the (non-root) CI user, so no privilege drop.
-run_launch_smoke_test 'AppImage' "$appimage_file" '' "$appimage_file"
+# The pkill sweep matches 'mount_claude', not the .AppImage path: a running
+# AppImage execs Electron from its FUSE mount (/tmp/.mount_claudeXXXX), so
+# the escaped zygote/electron children live there. Matching the artifact
+# path would sweep nothing. See CLAUDE.md (`pkill -9 -f "mount_claude"`).
+run_launch_smoke_test 'AppImage' 'mount_claude' '' "$appimage_file"
 
 # --- Cleanup ---
 rm -rf "$extract_dir"

--- a/tests/test-artifact-appimage.sh
+++ b/tests/test-artifact-appimage.sh
@@ -123,7 +123,11 @@ fi
 # AppImage execs Electron from its FUSE mount (/tmp/.mount_claudeXXXX), so
 # the escaped zygote/electron children live there. Matching the artifact
 # path would sweep nothing. See CLAUDE.md (`pkill -9 -f "mount_claude"`).
-run_launch_smoke_test 'AppImage' 'mount_claude' '' "$appimage_file"
+# Sweep escaped children only in CI: locally, 'mount_claude' also
+# matches a developer's live Claude Desktop AppImage session.
+smoke_sweep=''
+[[ -n ${CI:-} ]] && smoke_sweep='mount_claude'
+run_launch_smoke_test 'AppImage' "$smoke_sweep" '' "$appimage_file"
 
 # --- Cleanup ---
 rm -rf "$extract_dir"

--- a/tests/test-artifact-deb.sh
+++ b/tests/test-artifact-deb.sh
@@ -26,10 +26,16 @@ else
 	fail "Package name is not claude-desktop"
 fi
 
-if [[ $pkg_info == *'Architecture: amd64'* ]]; then
-	pass "Architecture is amd64"
+# Architecture must match the target we built for. TARGET_ARCH is set by
+# the CI workflow's per-arch matrix; fall back to the host's dpkg
+# architecture for standalone/local runs (each CI arch runs on a native
+# runner, so the host arch matches the package arch there too).
+expected_arch="${TARGET_ARCH:-$(dpkg --print-architecture 2>/dev/null)}"
+if [[ -n $expected_arch ]] \
+	&& [[ $pkg_info == *"Architecture: $expected_arch"* ]]; then
+	pass "Architecture is $expected_arch"
 else
-	fail "Architecture is not amd64"
+	fail "Architecture is not ${expected_arch:-<undetermined>}"
 fi
 
 if [[ $pkg_info == *'Version:'* ]]; then


### PR DESCRIPTION
Two hardening fixes to the artifact-test harness, found while reviewing the post-#670 launch-smoke work.

## 1. Validate arm64 packages, not just amd64

`test-artifacts` only ran against amd64. The `build-arm64` deb/rpm/appimage artifacts shipped with **zero** structural, `--doctor`, or launch-smoke coverage — an arm64-only regression could reach a release unnoticed.

- Parametrize the reusable `test-artifacts.yml` by `arch` (default `amd64`).
- Run the arm64 matrix on a native `ubuntu-22.04-arm` runner (matching `build-arm64`), so the launch smoke test executes the real arm64 binary rather than failing on a foreign architecture.
- `ci.yml` now invokes `test-artifacts` twice (amd64 + arm64); the `release` gate waits on both.

## 2. Fix the AppImage launch-smoke pkill match

A running AppImage execs Electron from its FUSE mount (`/tmp/.mount_claudeXXXX`), so escaped zygote/electron children live under that mount — not under the `.AppImage` path. The pkill sweep was passed the artifact path, so it matched only the already-reaped top-level launcher and never the strays it exists to catch, leaking electron children on the runner.

Pass `mount_claude` instead (per CLAUDE.md's pkill guidance). deb/rpm are unaffected — they already match the real `/usr/lib/claude-desktop` exec path.

## Testing

- `actionlint` + `shellcheck -x` clean.
- Verified the artifact-name contract: builds upload `package-{amd64,arm64}-{deb,rpm,appimage}`; the test job downloads `package-${arch}-${format}` — exact match.
- The arm64-runner path is proven on this CI run (no local arm64 available).

Note: a tool-presence guard (the third item from the same review) was already on `main`, so it's not included here.

Refs #670
