### PR TITLE
fix(nix): add bubblewrap to FHS targetPkgs so cowork uses the bwrap sandbox

### DIFF
--- a/nix/fhs.nix
+++ b/nix/fhs.nix
@@ -1,5 +1,6 @@
 {
   buildFHSEnv,
+  bubblewrap,
   claude-desktop,
   nodejs,
   docker,
@@ -12,6 +13,7 @@ buildFHSEnv {
   name = "claude-desktop";
 
   targetPkgs = pkgs: [
+    bubblewrap
     claude-desktop
     docker
     docker-compose


### PR DESCRIPTION
## Problem

On the NixOS `claude-desktop-fhs` package, starting a cowork workspace fails
with `rootfs not found` (#697).

`nix/fhs.nix` omits `bubblewrap` from `targetPkgs`. Inside the FHS sandbox the
daemon's PATH is exactly `targetPkgs`, so `which bwrap` in `detectBackend()`
always fails. Detection then falls through to `KvmBackend`, which throws
`rootfs not found` because no VM rootfs is provisioned on Linux. This defeats
the bwrap-first detection added in #351 on the Nix path specifically.

## Fix

Add `bubblewrap` to `targetPkgs` so `bwrap` lands at `/usr/bin/bwrap` inside
the FHS env and `detectBackend()` can select the namespace sandbox.

## Verification

Confirmed the runtime effect on NixOS by making `bwrap` available on the
cowork daemon's PATH via the FHS env and running a cowork task with
`COWORK_VM_DEBUG=1`:

```
[cowork-vm-service] Backend: bwrap
[cowork-vm-service] BwrapBackend: started (sandbox ready)
```

The nested bwrap probe succeeds inside the FHS sandbox, so cowork runs
sandboxed (not host-direct), and the `rootfs not found` error is gone.

(Aside: once FHS users have `bwrap`, they no longer hit `doctor.sh`'s
"install bubblewrap" hint; the missing `nixos` case in `_cowork_pkg_hint()`
flagged during triage is a separate, lower-priority item.)

Closes #697
