### PR TITLE
fix(cowork-fallback): validateMountPath rejects $HOME symlinks on immutable distros (Silverblue/Bazzite)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -116,6 +116,16 @@ Requirements when flagged:
 
 Run `claude-desktop-unofficial --doctor` with the flag set to see the bwrap-path diagnostics. Isolation is namespace-level, not a VM — weaker than the KVM default, which is the trade for running where KVM can't. Any `COWORK_VM_BACKEND` value other than `bwrap` is a 2.x knob the official client ignores.
 
+Extra host paths can be exposed to the sandbox via `coworkBwrapMounts` (`additionalBinds` / `additionalROBinds`) in `~/.config/Claude/claude_desktop_linux_config.json`.
+
+> **Note for immutable distros (Fedora Silverblue, Bazzite):** on these
+> systems `/home` is a symlink to `/var/home` on the *host*, but the sandbox
+> has no such symlink — `$HOME` inside the sandbox is the literal
+> `/home/<user>` form. Use the same form in your config
+> (for example `"/home/cloud/dev"`, not `"/var/home/cloud/dev"`) so the
+> mount is accessible under `~/` inside the sandbox. Both forms are accepted
+> by the validator; only the `/home/...` form will appear under `$HOME`.
+
 ## Removed in v3.0.0
 
 The v3.0.0 rebase deleted the patches that read these variables. The doctor's legacy-environment check warns when any of them is still set:

--- a/scripts/cowork-fallback/cowork-vm-service.js
+++ b/scripts/cowork-fallback/cowork-vm-service.js
@@ -748,9 +748,17 @@ function validateMountPath(mountPath, opts) {
     }
 
     if (opts.readWrite) {
+        // Compare against both the configured $HOME and its fully-resolved
+        // form. On immutable distros (Fedora Silverblue/Bazzite) /home is a
+        // symlink to /var/home: os.homedir() returns /home/<user> while
+        // realpathSync() on the candidate path returns /var/home/<user>/...,
+        // so a single-form comparison rejects every path under home.
         const home = os.homedir();
+        let realHome = home;
+        try { realHome = fs.realpathSync(home); } catch (_) {}
         const check = resolved !== normalized ? resolved : normalized;
-        if (check !== home && !check.startsWith(home + '/')) {
+        const underHome = (h) => check === h || check.startsWith(h + '/');
+        if (!underHome(home) && !underHome(realHome)) {
             return { valid: false, reason: 'Read-write mounts must be under $HOME' };
         }
     }
@@ -886,19 +894,20 @@ function mergeBwrapArgs(defaultArgs, config) {
         }
     }
 
+    // Pre-create each destination's parent inside the empty tmpfs root.
+    // --dir on the parent (not the destination itself) creates all missing
+    // intermediate directories without colliding with single-file binds.
     for (const m of config.additionalROBinds) {
-        if (typeof m === 'string') {
-            result.push('--ro-bind', m, m);
-        } else {
-            result.push('--ro-bind', m.src, m.dst);
-        }
+        const src = typeof m === 'string' ? m : m.src;
+        const dst = typeof m === 'string' ? m : m.dst;
+        result.push('--dir', path.dirname(dst));
+        result.push('--ro-bind', src, dst);
     }
     for (const m of config.additionalBinds) {
-        if (typeof m === 'string') {
-            result.push('--bind', m, m);
-        } else {
-            result.push('--bind', m.src, m.dst);
-        }
+        const src = typeof m === 'string' ? m : m.src;
+        const dst = typeof m === 'string' ? m : m.dst;
+        result.push('--dir', path.dirname(dst));
+        result.push('--bind', src, dst);
     }
 
     return result;

--- a/scripts/cowork-fallback/tests/cowork-bwrap-config.bats
+++ b/scripts/cowork-fallback/tests/cowork-bwrap-config.bats
@@ -135,6 +135,32 @@ assertDeepEqual(result, { valid: true }, 'rw under home');
 	[[ "$status" -eq 0 ]]
 }
 
+@test "validateMountPath: accepts RW paths under real HOME on immutable distros (Silverblue/Bazzite)" {
+	# On Fedora Silverblue/Bazzite, /home is a symlink to /var/home.
+	# os.homedir() returns /home/<user> but fs.realpathSync resolves it to
+	# /var/home/<user>. Without resolving $HOME before comparing, both the
+	# symlink form (/home/user/dir) and the real form (/var/home/user/dir)
+	# were rejected with "Read-write mounts must be under $HOME".
+	run node -e "${NODE_PREAMBLE}
+const home = os.homedir();
+let realHome = home;
+try { realHome = require('fs').realpathSync(home); } catch (_) {}
+
+// Symlink form: must pass regardless of whether realpath differs
+const r1 = validateMountPath(home + '/dev', { readWrite: true });
+assert(r1.valid, 'symlink-form home path must be accepted: ' + home + '/dev');
+
+// Real path form: must also pass when realHome differs from home
+const r2 = validateMountPath(realHome + '/dev', { readWrite: true });
+assert(r2.valid, 'realpath-form home path must be accepted: ' + realHome + '/dev');
+
+// Non-home path must still be rejected
+const r3 = validateMountPath('/opt/tools', { readWrite: true });
+assert(!r3.valid, '/opt/tools must still be rejected');
+"
+	[[ "$status" -eq 0 ]]
+}
+
 @test "validateMountPath: accepts RO paths anywhere (not forbidden)" {
 	run node -e "${NODE_PREAMBLE}
 const r1 = validateMountPath('/opt/my-tools');
@@ -460,8 +486,8 @@ const result = mergeBwrapArgs(defaults, {
     disabledDefaultBinds: []
 });
 const expected = ['--tmpfs', '/', '--ro-bind', '/usr', '/usr',
-    '--ro-bind', '/opt/tools', '/opt/tools',
-    '--ro-bind', '/nix/store', '/nix/store'];
+    '--dir', '/opt', '--ro-bind', '/opt/tools', '/opt/tools',
+    '--dir', '/nix', '--ro-bind', '/nix/store', '/nix/store'];
 assertDeepEqual(result, expected, 'ro appended');
 "
 	[[ "$status" -eq 0 ]]
@@ -477,7 +503,7 @@ const result = mergeBwrapArgs(defaults, {
     disabledDefaultBinds: []
 });
 const expected = ['--tmpfs', '/', '--ro-bind', '/usr', '/usr',
-    '--bind', home + '/data', home + '/data'];
+    '--dir', home, '--bind', home + '/data', home + '/data'];
 assertDeepEqual(result, expected, 'rw appended');
 "
 	[[ "$status" -eq 0 ]]
@@ -495,9 +521,74 @@ const result = mergeBwrapArgs(defaults, {
 });
 const expected = ['--tmpfs', '/', '--ro-bind', '/usr', '/usr',
     '--dev', '/dev', '--proc', '/proc', '--tmpfs', '/tmp', '--tmpfs', '/run',
-    '--ro-bind', '/opt/tools', '/opt/tools',
-    '--bind', home + '/shared', home + '/shared'];
+    '--dir', '/opt', '--ro-bind', '/opt/tools', '/opt/tools',
+    '--dir', home, '--bind', home + '/shared', home + '/shared'];
 assertDeepEqual(result, expected, 'combined');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "mergeBwrapArgs: pre-creates parent dir for immutable-distro home paths" {
+	# On Fedora Silverblue/Bazzite, os.homedir() returns /var/home/<user>.
+	# bwrap auto-creates missing bind-destination parents itself, so the
+	# preceding --dir is path-creation hardening, not a fix for a dropped
+	# mount (#702's real cause is the /home vs /var/home symlink mismatch;
+	# see docs/configuration.md). The --dir must target the parent, never
+	# the destination itself, or file binds break (next two tests).
+	run node -e "${NODE_PREAMBLE}
+const varHome = '/var/home/cloud';
+const defaults = ['--tmpfs', '/'];
+const result = mergeBwrapArgs(defaults, {
+    additionalROBinds: [],
+    additionalBinds: [varHome + '/dev'],
+    disabledDefaultBinds: []
+});
+assertDeepEqual(result, [
+    '--tmpfs', '/',
+    '--dir', varHome, '--bind', varHome + '/dev', varHome + '/dev'
+], 'immutable-distro dir bind');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "mergeBwrapArgs: file bind targets --dir at parent, not the file dst" {
+	# additionalBinds may name a single file (e.g. ~/.gitconfig).
+	# Emitting --dir on the file dst itself would pre-create it as a
+	# directory and bwrap would die with 'Can't create file at ...: Is a
+	# directory'. Only the parent may be pre-created.
+	run node -e "${NODE_PREAMBLE}
+const home = os.homedir();
+const defaults = ['--tmpfs', '/'];
+const result = mergeBwrapArgs(defaults, {
+    additionalROBinds: [],
+    additionalBinds: [home + '/.gitconfig'],
+    disabledDefaultBinds: []
+});
+assertDeepEqual(result, [
+    '--tmpfs', '/',
+    '--dir', home, '--bind', home + '/.gitconfig', home + '/.gitconfig'
+], 'file bind');
+"
+	[[ "$status" -eq 0 ]]
+}
+
+@test "mergeBwrapArgs: file overlay onto RO parent emits --dir on existing parent only" {
+	# Overlaying a file onto a default RO mount (e.g. a custom /etc/hosts
+	# over the default /etc ro-bind) works today. --dir /etc/hosts would
+	# die with 'Can't mkdir /etc/hosts: Not a directory'; --dir /etc is a
+	# no-op on the already-mounted parent.
+	run node -e "${NODE_PREAMBLE}
+const home = os.homedir();
+const defaults = ['--tmpfs', '/', '--ro-bind', '/etc', '/etc'];
+const result = mergeBwrapArgs(defaults, {
+    additionalROBinds: [{ src: home + '/hosts', dst: '/etc/hosts' }],
+    additionalBinds: [],
+    disabledDefaultBinds: []
+});
+assertDeepEqual(result, [
+    '--tmpfs', '/', '--ro-bind', '/etc', '/etc',
+    '--dir', '/etc', '--ro-bind', home + '/hosts', '/etc/hosts'
+], 'file overlay onto RO parent');
 "
 	[[ "$status" -eq 0 ]]
 }
@@ -802,7 +893,7 @@ const result = mergeBwrapArgs(defaults, {
 });
 assertDeepEqual(result, [
     '--tmpfs', '/',
-    '--ro-bind', '/opt/tools', '/sandbox/tools'
+    '--dir', '/sandbox', '--ro-bind', '/opt/tools', '/sandbox/tools'
 ], 'ro object form');
 "
 	[[ "$status" -eq 0 ]]
@@ -819,7 +910,7 @@ const result = mergeBwrapArgs(defaults, {
 });
 assertDeepEqual(result, [
     '--tmpfs', '/',
-    '--bind', home + '/persistent', '/tmp'
+    '--dir', '/', '--bind', home + '/persistent', '/tmp'
 ], 'rw object form');
 "
 	[[ "$status" -eq 0 ]]
@@ -842,10 +933,10 @@ const result = mergeBwrapArgs(defaults, {
 });
 assertDeepEqual(result, [
     '--tmpfs', '/',
-    '--ro-bind', '/opt/tools', '/opt/tools',
-    '--ro-bind', '/nix/store', '/sandbox/nix',
-    '--bind', home + '/data', home + '/data',
-    '--bind', home + '/cache', '/tmp'
+    '--dir', '/opt', '--ro-bind', '/opt/tools', '/opt/tools',
+    '--dir', '/sandbox', '--ro-bind', '/nix/store', '/sandbox/nix',
+    '--dir', home, '--bind', home + '/data', home + '/data',
+    '--dir', '/', '--bind', home + '/cache', '/tmp'
 ], 'mixed forms');
 "
 	[[ "$status" -eq 0 ]]


### PR DESCRIPTION
> **Re-targeted onto the v3.1.0 layout** — the bwrap daemon now lives at `scripts/cowork-fallback/` as the opt-in `COWORK_VM_BACKEND=bwrap` backend. This fix only affects that fallback path; the default KVM/microVM path is untouched. Single squashed commit replaces the pre-v3.0.0 history (old paths no longer exist).

## Problem

On Fedora Silverblue, Bazzite, and other immutable distros, `/home` is a symlink to `/var/home`. This causes `additionalBinds` mounts to be silently dropped at daemon startup when running the bwrap fallback backend.

`validateMountPath` calls `fs.realpathSync()` on the candidate path (resolving it to `/var/home/<user>/…`), then compares against `os.homedir()` which returns the un-resolved symlink form `/home/<user>`. Since `/var/home/cloud/dev` does not start with `/home/cloud/`, every path under home is rejected — regardless of whether the user specifies the symlink or real form.

Debug output on an affected host (Bazzite DX, `bubblewrap 0.11.0`):

```
BwrapConfig: rejected mount "/var/home/cloud/dev": Read-write mounts must be under $HOME
BwrapConfig: rejected mount "/home/cloud/dev": Read-write mounts must be under $HOME
```

Reproduction against the real config:

```js
// BEFORE
loadBwrapMountsConfig('~/.config/Claude/claude_desktop_linux_config.json', warn)
// → additionalBinds: []   ← both forms rejected, nothing reaches mergeBwrapArgs

// AFTER
// → additionalBinds: ["/var/home/cloud/dev", "/home/cloud/dev"]
```

## Fix

Resolve `$HOME` before comparing; accept paths under either form. Paths outside `$HOME` (e.g. `/opt/tools`) are still rejected.

```js
const home = os.homedir();
let realHome = home;
try { realHome = fs.realpathSync(home); } catch (_) {}
const check = resolved !== normalized ? resolved : normalized;
const underHome = (h) => check === h || check.startsWith(h + '/');
if (!underHome(home) && !underHome(realHome)) {
    return { valid: false, reason: 'Read-write mounts must be under $HOME' };
}
```

## Secondary hardening

`mergeBwrapArgs` emits `--dir path.dirname(dst)` before each `--bind` / `--ro-bind` — explicit parent creation in the empty tmpfs root, targeting the parent (never the destination itself) so single-file binds (`.gitconfig`, `/etc/hosts` overlays) keep working. Includes @aaddrick's correction from the original review round.

## Live verification (sandbox layout, Bazzite DX)

```bash
# Inside a cowork Bash session
$ echo $HOME
/home/cloud
$ ls /var/home
ls: cannot access '/var/home': No such file or directory
```

The sandbox's `$HOME` is the literal `/home/<user>` form — no `/home → /var/home` symlink exists inside it. The docs note therefore tells immutable-distro users to configure the `/home/...` form (both forms pass the validator; only `/home/...` is reachable under `~/`).

## Tests

`scripts/cowork-fallback/tests/cowork-bwrap-config.bats`: 61 → 65

- `validateMountPath` accepts both home forms on immutable distros, still rejects `/opt/tools`
- `mergeBwrapArgs` pre-creates parent dir for immutable-distro home paths
- file bind targets `--dir` at parent, not the file dst
- RO-overlay onto default mount shape

All fallback suites green: **158/158** (backend-detection 13, bwrap-config 65, bwrap-patch 7, path-translation 72, protocol 1).

## Docs

`docs/configuration.md` — documents `coworkBwrapMounts` in the bwrap-fallback section with the immutable-distro note.

Fixes #702

🤖 Generated with [Claude Code](https://claude.ai/code)