### PR TITLE
docs: black-screen softpipe workaround from #599

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -170,6 +170,49 @@ behavior to persist across reinstalls and config resets.
 
 Tracking issue: [#583](https://github.com/aaddrick/claude-desktop-debian/issues/583).
 
+### Black screen on Fedora KDE with Intel Iris Xe ([#706](https://github.com/aaddrick/claude-desktop-debian/issues/706))
+
+If the window opens but renders entirely black on Fedora KDE with
+Intel Iris Xe graphics (TigerLake-LP GT2), force Mesa's reference
+software rasterizer:
+
+```bash
+MESA_LOADER_DRIVER_OVERRIDE=softpipe claude-desktop
+```
+
+The failing launch logs this signature in
+`~/.cache/claude-desktop-debian/launcher.log`:
+
+```
+KMS: DRM_IOCTL_MODE_CREATE_DUMB failed: Permission denied
+```
+
+**Try the faster fallbacks first.** softpipe renders everything on
+the CPU with no acceleration of any kind and is noticeably slow.
+Before reaching for it:
+
+1. `CLAUDE_DISABLE_GPU=1 claude-desktop` — disables hardware
+   acceleration entirely (see the previous section).
+2. `LIBGL_ALWAYS_SOFTWARE=1 claude-desktop` — selects llvmpipe,
+   Mesa's supported software fallback, several times faster than
+   softpipe.
+
+Use `MESA_LOADER_DRIVER_OVERRIDE=softpipe` only if
+`LIBGL_ALWAYS_SOFTWARE=1` also produces a black screen. To make it
+persistent:
+
+```bash
+echo 'export MESA_LOADER_DRIVER_OVERRIDE=softpipe' >> ~/.profile
+```
+
+Tracking issue:
+[#706](https://github.com/aaddrick/claude-desktop-debian/issues/706).
+Credit: workaround discovered and confirmed by
+[@dubreal](https://github.com/dubreal) while diagnosing
+[#593](https://github.com/aaddrick/claude-desktop-debian/issues/593)
+and
+[#599](https://github.com/aaddrick/claude-desktop-debian/pull/599).
+
 ### AppImage Sandbox Warning
 
 AppImages run with `--no-sandbox` due to electron's chrome-sandbox requiring root privileges for unprivileged namespace creation. This is a known limitation of AppImage format with Electron applications.


### PR DESCRIPTION
Adds a `docs/troubleshooting.md` entry for the black screen on Fedora KDE with Intel Iris Xe (TigerLake-LP GT2), capturing the unique remaining value of #599 as it closes.

## What's in the entry

- Literal-symptom heading per the docs style guide, placed after the related GPU-process FATAL (#583) section.
- The `KMS: DRM_IOCTL_MODE_CREATE_DUMB failed: Permission denied` log signature from `~/.cache/claude-desktop-debian/launcher.log`.
- `MESA_LOADER_DRIVER_OVERRIDE=softpipe` as the confirmed manual workaround, discovered by [@dubreal](https://github.com/dubreal) while diagnosing #593 and #599.
- When to use it: only after the faster fallbacks — `CLAUDE_DISABLE_GPU=1` and `LIBGL_ALWAYS_SOFTWARE=1` (llvmpipe) — also produce a black screen.
- The tradeoff: softpipe is Mesa's unaccelerated reference rasterizer, so rendering is CPU-only and noticeably slow.
- Link to tracking issue #706, which carries the unresolved rendering half of #593.

## Credit

The workaround and the diagnostic work behind it are [@dubreal](https://github.com/dubreal)'s, from #593 and #599. They are already in the README Acknowledgments for the #611 password-store fix; this documents the rendering half of the same investigation.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
95% AI / 5% Human
Claude: drafted the troubleshooting entry from the #599 review findings, verified the workaround details against #593/#599, committed and opened the PR
Human: direction to capture the workaround as docs on the #599 close path, scope and crediting decisions
