### PR TITLE
fix(doctor): report installed version from the package manager that owns the install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- `claude-desktop --doctor` reports the installed version from the package manager that actually owns the install (probed via `rpm -qf` on the bundled Electron binary) instead of trusting `dpkg-query` alone — rpm installs on hosts that also carry a stale dpkg record (e.g. Fedora boxes with dpkg installed as a build tool) no longer show a months-old version with a PASS. ([#712](https://github.com/aaddrick/claude-desktop-debian/pull/712), fixes [#711](https://github.com/aaddrick/claude-desktop-debian/issues/711))
+
 ## [v2.0.19] — 2026-06-10
 
 Tracks upstream Claude Desktop 1.11847.5.

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -618,6 +618,57 @@ _doctor_check_disk_space() {
 	fi
 }
 
+# Report the installed claude-desktop version from the package manager
+# that actually owns the install (#711). On dual-DB hosts (e.g. a
+# Fedora box with dpkg installed for deb work) a stale dpkg record
+# must not shadow the live rpm install, so rpm ownership of the real
+# Electron binary is probed first: `rpm -qf <path>` succeeds only when
+# rpm installed the file, which a stale dpkg record can never claim.
+# dpkg is consulted only when rpm does not own the path.
+#
+# AppImage and Nix installs (no package owns the path) keep the
+# existing not-found warn; hosts with no package tools stay silent.
+#
+# Usage: _doctor_check_pkg_version <electron_path>
+_doctor_check_pkg_version() {
+	local electron_path="${1:-}"
+	local probe_path="$electron_path"
+	local pkg_version=''
+
+	if [[ -z $probe_path ]]; then
+		probe_path='/usr/lib/claude-desktop'
+		probe_path+='/node_modules/electron/dist/electron'
+	fi
+
+	# rpm branch: query the file, not the package name, so the answer
+	# comes from the database that owns the actual install.
+	if command -v rpm &>/dev/null; then
+		pkg_version=$(rpm -qf --qf '%{VERSION}-%{RELEASE}' \
+			"$probe_path" 2>/dev/null) || pkg_version=''
+		if [[ -n $pkg_version ]]; then
+			_pass "Installed version: $pkg_version"
+			return 0
+		fi
+	fi
+
+	# dpkg branch: only consulted when rpm does not own the install.
+	if command -v dpkg-query &>/dev/null; then
+		pkg_version=$(dpkg-query -W -f='${Version}' \
+			claude-desktop 2>/dev/null) || pkg_version=''
+		if [[ -n $pkg_version ]]; then
+			_pass "Installed version: $pkg_version"
+			return 0
+		fi
+	fi
+
+	# Neither manager knows the install — AppImage or Nix. Only warn
+	# when a package tool exists; with none there is nothing to say.
+	if command -v rpm &>/dev/null \
+		|| command -v dpkg-query &>/dev/null; then
+		_warn 'claude-desktop not found via dpkg/rpm (AppImage?)'
+	fi
+}
+
 # Run all diagnostic checks and print results
 # Arguments: $1 = electron path (optional, for package-specific checks)
 run_doctor() {
@@ -635,16 +686,7 @@ run_doctor() {
 	echo
 
 	# -- Installed package version --
-	if command -v dpkg-query &>/dev/null; then
-		local pkg_version
-		pkg_version=$(dpkg-query -W -f='${Version}' \
-			claude-desktop 2>/dev/null) || true
-		if [[ -n $pkg_version ]]; then
-			_pass "Installed version: $pkg_version"
-		else
-			_warn 'claude-desktop not found via dpkg (AppImage?)'
-		fi
-	fi
+	_doctor_check_pkg_version "$electron_path"
 
 	# -- Display server --
 	if [[ -n "${WAYLAND_DISPLAY:-}" ]]; then

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -530,3 +530,85 @@ SHIM
 	[[ $output != *'[FAIL]'* ]]
 	[[ $output != *'[WARN]'* ]]
 }
+
+# =============================================================================
+# _doctor_check_pkg_version: package-manager ownership (#711)
+# =============================================================================
+
+# Make `command -v` report the named package tools (rpm, dpkg-query)
+# as missing so tests can simulate single-manager or tool-less hosts
+# regardless of what the CI/dev box really has installed. Same shadow
+# trick as _skip_gtk_query: `command -v` finds functions too, so
+# shadowing `command` itself is the only reliable way.
+_hide_pkg_tools() {
+	_hidden_pkg_tools=" $* "
+	command() {
+		if [[ $1 == '-v' \
+			&& $_hidden_pkg_tools == *" $2 "* ]]; then
+			return 1
+		fi
+		builtin command "$@"
+	}
+}
+
+@test "_doctor_check_pkg_version: rpm owns the path — rpm version wins over stale dpkg record (#711)" {
+	# The #711 repro: Fedora host, rpm owns the install, but a stale
+	# dpkg record from an old deb experiment still answers. The rpm
+	# answer must win; the stale dpkg version must not appear at all.
+	rpm() { printf '1.11847.5-2.0.19'; }
+	dpkg-query() { printf '1.5354.0'; }
+
+	run _doctor_check_pkg_version \
+		'/usr/lib/claude-desktop/node_modules/electron/dist/electron'
+	[[ $status -eq 0 ]]
+	[[ $output == *'[PASS]'* ]]
+	[[ $output == *'Installed version: 1.11847.5-2.0.19'* ]]
+	[[ $output != *'1.5354.0'* ]]
+}
+
+@test "_doctor_check_pkg_version: dpkg-only host reports dpkg version" {
+	_hide_pkg_tools rpm
+	dpkg-query() { printf '1.11847.5'; }
+
+	run _doctor_check_pkg_version ''
+	[[ $status -eq 0 ]]
+	[[ $output == *'[PASS]'* ]]
+	[[ $output == *'Installed version: 1.11847.5'* ]]
+	[[ $output != *'[WARN]'* ]]
+}
+
+@test "_doctor_check_pkg_version: dual-DB host where rpm does not own the path falls back to dpkg" {
+	# rpm exists but the install is a real deb: `rpm -qf` says "not
+	# owned" (rc=1, message on stdout) and dpkg must be consulted.
+	rpm() {
+		# $4 = probe path ($1=-qf $2=--qf $3=<format>)
+		printf 'file %s is not owned by any package\n' "$4"
+		return 1
+	}
+	dpkg-query() { printf '1.11847.5'; }
+
+	run _doctor_check_pkg_version ''
+	[[ $status -eq 0 ]]
+	[[ $output == *'[PASS]'* ]]
+	[[ $output == *'Installed version: 1.11847.5'* ]]
+	[[ $output != *'not owned'* ]]
+}
+
+@test "_doctor_check_pkg_version: neither manager owns the install — warn (AppImage/Nix)" {
+	rpm() { return 1; }
+	dpkg-query() { return 1; }
+
+	run _doctor_check_pkg_version ''
+	[[ $status -eq 0 ]]
+	[[ $output == *'[WARN]'* ]]
+	[[ $output == *'AppImage'* ]]
+	[[ $output != *'[PASS]'* ]]
+}
+
+@test "_doctor_check_pkg_version: silent when no package tools exist" {
+	_hide_pkg_tools rpm dpkg-query
+
+	run _doctor_check_pkg_version ''
+	[[ $status -eq 0 ]]
+	[[ -z $output ]]
+}


### PR DESCRIPTION
## Summary

`--doctor`'s "Installed package version" block gated on `command -v dpkg-query` only and trusted the dpkg database unconditionally. On a dual-DB host (Fedora with dpkg installed for deb work), a stale dpkg record shadowed the live rpm install — doctor printed `[PASS] Installed version: 1.5354.0` for an rpm install actually on `1.11847.5-2.0.19`. Same false-report family as #692.

## Fix

Decide ownership instead of trusting whichever DB answers first:

- Probe `rpm -qf` on the installed Electron binary (`/usr/lib/claude-desktop/node_modules/electron/dist/electron`, or the launcher-provided path). Querying the **path** is the discriminator — a stale dpkg record can't own a file rpm installed. If rpm owns it, report `%{VERSION}-%{RELEASE}` from the owning package.
- Otherwise fall back to `dpkg-query -W` exactly as before.
- AppImage/Nix installs keep the existing not-found warn; hosts with no package tools stay silent.

The block is extracted into `_doctor_check_pkg_version` so it's unit-testable; the output format (`Installed version: X`) is unchanged, so nothing downstream moves.

## Testing

- `bats tests/doctor.bats` — 44/44 pass (5 new cases: the #711 repro with rpm-owned path + stale dpkg record, dpkg-only host, rpm-present-but-deb-owned fallback, neither-owns warn, tool-less silence).
- Mutation check: reordering the helper to dpkg-first makes the #711 repro test fail (`Installed version: 1.11847.5-2.0.19` assertion), so a revert can't slip past CI.
- `shellcheck -x scripts/doctor.sh` — clean.
- Live sanity run on the repro host (Nobara fc43, rpm install + stale dpkg `1.5354.0` record): `_doctor_check_pkg_version ''` now prints `[PASS] Installed version: 1.11847.5-2.0.19.fc42`.

Fixes #711

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
90% AI / 10% Human
Claude: root-cause confirmation, ownership-probe implementation, bats cases, mutation check, live-host verification
Human: found the bug while dogfooding doctor on a dual-DB host, directed the fix design
