### PR TITLE
fix(doctor): gate dpkg version branch on installed status (#711 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
   child), scopes the impact to opt-in `COWORK_VM_BACKEND=bwrap` launches on
   Ubuntu 24.04+, and points at the tracked scoped fix.
   ([#542](https://github.com/aaddrick/claude-desktop-debian/issues/542))
+- `claude-desktop-unofficial --doctor` no longer treats a removed-but-not-purged deb (dpkg `config-files`/rc state) as installed: the version-reporting branch (`claude-desktop-unofficial`) and the name-collision classifier (`claude-desktop`) both gate on `${db:Status-Status}` being `installed`, mirroring `_pkg_installed`. A leftover record from `apt remove` without `--purge` — made common by the transitional `claude-desktop` dummy being autoremoved to rc — now warns like an AppImage/Nix install (or stays silent) instead of a stale `[PASS]`/collision message. ([#713](https://github.com/aaddrick/claude-desktop-debian/pull/713), fixes [#711](https://github.com/aaddrick/claude-desktop-debian/issues/711))
 
 ## [v3.1.0] — 2026-07-10
 

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -748,10 +748,18 @@ _doctor_check_pkg_version() {
 	# Our deb is claude-desktop-unofficial since the Phase 3 rename;
 	# plain claude-desktop is Anthropic's official package on dpkg
 	# hosts and is not ours to report here.
+	# Gate on install status, not just version: dpkg-query still
+	# prints a version for a removed-but-not-purged package (rc /
+	# config-files state), so trusting the version alone PASSes for
+	# software no longer installed — the #711 false-PASS.
 	if command -v dpkg-query &>/dev/null; then
-		pkg_version=$(dpkg-query -W -f='${Version}' \
-			claude-desktop-unofficial 2>/dev/null) || pkg_version=''
-		if [[ -n $pkg_version ]]; then
+		local dpkg_status
+		dpkg_status=$(dpkg-query -W \
+			-f='${db:Status-Status} ${Version}' \
+			claude-desktop-unofficial 2>/dev/null) \
+			|| dpkg_status=''
+		if [[ $dpkg_status == 'installed '* ]]; then
+			pkg_version="${dpkg_status#installed }"
 			_installed_pkg_version="$pkg_version"
 			_pass "Installed version: $pkg_version"
 			return 0
@@ -866,6 +874,16 @@ _check_name_collision() {
 	fi
 
 	# (b) Is a package named claude-desktop installed, and whose is it?
+	# Gate on install status first: dpkg-query still answers
+	# ${Maintainer}/${Version} for a removed-but-not-purged record
+	# (config-files / rc state), which the transitional claude-desktop
+	# dummy makes common post-rename — classifying that as an install
+	# would warn/info about software no longer present (#711 family).
+	local dpkg_status
+	dpkg_status=$(dpkg-query -W -f='${db:Status-Status}' \
+		claude-desktop 2>/dev/null) || dpkg_status=''
+	[[ $dpkg_status == 'installed' ]] || return 0
+
 	local maintainer version
 	maintainer=$(dpkg-query -W -f='${Maintainer}' claude-desktop \
 		2>/dev/null) || maintainer=''

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -644,7 +644,8 @@ _hide_pkg_tools() {
 
 @test "_doctor_check_pkg_version: dpkg-only host reports dpkg version" {
 	_hide_pkg_tools rpm
-	dpkg-query() { printf '1.11847.5'; }
+	# -f='${db:Status-Status} ${Version}': status prefix first.
+	dpkg-query() { printf 'installed 1.11847.5'; }
 
 	run _doctor_check_pkg_version ''
 	[[ $status -eq 0 ]]
@@ -661,13 +662,27 @@ _hide_pkg_tools() {
 		printf 'file %s is not owned by any package\n' "$4"
 		return 1
 	}
-	dpkg-query() { printf '1.11847.5'; }
+	dpkg-query() { printf 'installed 1.11847.5'; }
 
 	run _doctor_check_pkg_version ''
 	[[ $status -eq 0 ]]
 	[[ $output == *'[PASS]'* ]]
 	[[ $output == *'Installed version: 1.11847.5'* ]]
 	[[ $output != *'not owned'* ]]
+}
+
+@test "_doctor_check_pkg_version: removed-but-not-purged dpkg record (rc state) warns, not PASS (#711 follow-up)" {
+	# apt remove without --purge leaves a config-files (rc) record;
+	# dpkg-query still answers a version for it. Must not PASS.
+	_hide_pkg_tools rpm
+	dpkg-query() { printf 'config-files 1.5354.0'; }
+
+	run _doctor_check_pkg_version ''
+	[[ $status -eq 0 ]]
+	[[ $output == *'[WARN]'* ]]
+	[[ $output == *'AppImage'* ]]
+	[[ $output != *'[PASS]'* ]]
+	[[ $output != *'1.5354.0'* ]]
 }
 
 @test "_doctor_check_pkg_version: neither manager owns the install — warn (AppImage/Nix)" {
@@ -935,14 +950,22 @@ PKGS
 # (sources dir via _DOCTOR_APT_SOURCES_DIR; deb-family only)
 # =============================================================================
 
-# Stub dpkg-query answering the ${Maintainer} and ${Version} probes for
-# the package claude-desktop. $1 = maintainer, $2 = version; empty
-# values model "package not installed" (query fails).
+# Stub dpkg-query answering the ${db:Status-Status}, ${Maintainer} and
+# ${Version} probes for the package claude-desktop. $1 = maintainer,
+# $2 = version, $3 = install status (default 'installed'); empty
+# maintainer/version model "package not installed" (query fails), and
+# the status probe fails the same way so a not-installed package also
+# fails the caller's status gate.
 _stub_dpkg_query() {
 	_STUB_DPKG_MAINTAINER="$1"
 	_STUB_DPKG_VERSION="$2"
+	_STUB_DPKG_STATUS="${3:-installed}"
 	dpkg-query() {
 		case "$2" in
+			*Status*)
+				[[ -n $_STUB_DPKG_VERSION ]] || return 1
+				printf '%s' "$_STUB_DPKG_STATUS"
+				;;
 			*Maintainer*)
 				[[ -n $_STUB_DPKG_MAINTAINER ]] || return 1
 				printf '%s' "$_STUB_DPKG_MAINTAINER"
@@ -1044,6 +1067,39 @@ LIST
 	[[ $output == *'pre-rename'* ]]
 	[[ $output == *'1.11847.5'* ]]
 	[[ $output == *'sudo apt install claude-desktop-unofficial'* ]]
+}
+
+@test "_check_name_collision: removed-but-not-purged pre-rename record (config-files) stays silent (#711 follow-up)" {
+	# apt remove without --purge leaves a config-files (rc) record for
+	# a pre-rename claude-desktop; dpkg-query still answers Maintainer
+	# and Version for it. Must not warn about software no longer
+	# installed.
+	_stub_dpkg_query 'aaddrick <aaddrick@gmail.com>' '1.11847.5' \
+		'config-files'
+	_stub_dpkg_compare
+	export _DOCTOR_APT_SOURCES_DIR="$TEST_TMP/sources.list.d"
+	mkdir -p "$_DOCTOR_APT_SOURCES_DIR"
+	run _check_name_collision
+	[[ $status -eq 0 ]]
+	[[ -z $output ]]
+	[[ $output != *'[WARN]'* ]]
+	[[ $output != *'pre-rename'* ]]
+}
+
+@test "_check_name_collision: removed-but-not-purged transitional dummy (config-files, >=1.16000) with repo configured stays silent (#711 follow-up)" {
+	# The transitional claude-desktop 1.16000.0 dummy autoremoved to rc
+	# state post-migration: non-Anthropic maintainer + version
+	# >= 1.16000 + repo configured would otherwise fall through to the
+	# repo_found branch and report an install that is no longer there.
+	_stub_dpkg_query 'Claude Desktop Team <noreply@example.com>' \
+		'1.16000.0' 'config-files'
+	_stub_dpkg_compare
+	_write_official_apt_source
+	run _check_name_collision
+	[[ $status -eq 0 ]]
+	[[ -z $output ]]
+	[[ $output != *'Anthropic'* ]]
+	[[ $output != *'[INFO]'* ]]
 }
 
 # =============================================================================


### PR DESCRIPTION
> **Updated in place 2026-07-11** — force-pushed over the original commit
> (`10251b1`), same fix re-anchored onto post-v3.0.0 `main`. The rework
> split the single function the original diff patched into two
> dpkg-consulting sites, so the status gate now lands in both. Original
> review context below still applies.

## Problem

`claude-desktop-unofficial --doctor` reports a stale `[PASS]` / bogus
collision message for a `.deb` that was removed but not purged. After
`apt remove claude-desktop-unofficial` (without `--purge`), dpkg keeps a
`config-files` (rc) record and `dpkg-query` still answers `${Version}`,
`${Maintainer}`, etc. for it — even though the software is no longer
installed. `--doctor` trusted that output. This is the #711 false-PASS.

## Root cause

`doctor.sh` trusted `dpkg-query` metadata without gating on install
**status**. The reference-correct pattern already exists in the file:
`_pkg_installed` (`scripts/doctor.sh:95-102`) greps `${Status}` for
`install ok installed`. Two `claude-desktop*` sites did not follow it.

The v3.0.0 rebase split the one function the original #713 diff patched
into two sites, so the re-anchor lands the same gate in both:

1. **`_doctor_check_pkg_version`** dpkg branch (`scripts/doctor.sh:747-767`)
   — queries `claude-desktop-unofficial`. An rc-state record produced a
   false `[PASS] Installed version: <stale>` and recorded a stale
   `_installed_pkg_version` (consumed by `_check_official_drift`). Direct
   #711 bug.
2. **`_check_name_collision`** (`scripts/doctor.sh:876-892`) — queries
   plain `claude-desktop` via `${Maintainer}`/`${Version}`. This matters
   more now than at #713's original writing: the transitional
   `claude-desktop` 1.16000.0 dummy that migrates legacy installs to
   `claude-desktop-unofficial` is routinely autoremoved to rc state
   post-migration, so rc records on this exact name are common. Without
   the gate, an rc dummy at `>= 1.16000` with Anthropic's repo configured
   falls through to a bogus "Anthropic's official package is also
   installed" INFO; an rc pre-rename record `< 1.16000` fires a bogus
   pre-rename WARN.

Patch-zero clean (D-002): the change is entirely in the diagnostic script;
no `app.asar` bytes touched.

## Fix

Both sites now gate on `${db:Status-Status}` being `installed` before
trusting any other `dpkg-query` field, mirroring `_pkg_installed`:

- `_doctor_check_pkg_version` queries
  `-f='${db:Status-Status} ${Version}'` and only reports / records the
  version when the status prefix is `installed `; otherwise it falls
  through to the existing AppImage/Nix "not found via dpkg/rpm" warn.
- `_check_name_collision` probes `-f='${db:Status-Status}'` first and
  `return 0` (silent) unless the status is `installed`, before the
  maintainer/version classification runs. Behavior is unchanged for a
  genuinely-installed `claude-desktop`; only rc / not-installed records
  now stay silent (the not-installed case already returned early, so no
  regression).

## Tests

`tests/doctor.bats` (80 → 83):

- Updated the two dpkg-only-host mocks to the new
  `${db:Status-Status} ${Version}` output format.
- Added an rc-state case to `_doctor_check_pkg_version` (`config-files`
  record → WARN, not PASS, and no stale version echoed).
- Extended `_stub_dpkg_query` with an optional 3rd status arg
  (default `installed`), so the four existing collision call sites are
  byte-for-byte unaffected.
- Added two `_check_name_collision` cases: a pre-rename rc record (stays
  silent instead of the pre-rename WARN) and the transitional-dummy rc
  scenario at `>= 1.16000` with the repo configured (stays silent instead
  of the bogus Anthropic INFO).

Real output:

```
$ bats tests/doctor.bats
...
ok 46 _doctor_check_pkg_version: rpm owns the path — rpm version wins over stale dpkg record (#711)
ok 47 _doctor_check_pkg_version: dpkg-only host reports dpkg version
ok 48 _doctor_check_pkg_version: dual-DB host where rpm does not own the path falls back to dpkg
ok 49 _doctor_check_pkg_version: removed-but-not-purged dpkg record (rc state) warns, not PASS (#711 follow-up)
...
ok 72 _check_name_collision: removed-but-not-purged pre-rename record (config-files) stays silent (#711 follow-up)
ok 73 _check_name_collision: removed-but-not-purged transitional dummy (config-files, >=1.16000) with repo configured stays silent (#711 follow-up)
...
83 tests, 0 failures
```

Full suite and lint:

```
$ for f in tests/*.bats; do bats "$f"; done   # 198/198 ok
$ shellcheck -x scripts/doctor.sh             # clean
```

Mutation check (revert the fix → the new test must fail):

```
# revert Change 1's status gate
not ok 49 _doctor_check_pkg_version: removed-but-not-purged dpkg record (rc state) warns, not PASS (#711 follow-up)

# revert Change 2's status gate
not ok 72 _check_name_collision: removed-but-not-purged pre-rename record (config-files) stays silent (#711 follow-up)
not ok 73 _check_name_collision: removed-but-not-purged transitional dummy (config-files, >=1.16000) with repo configured stays silent (#711 follow-up)
```

Restoring either gate makes its tests pass again.

## Notes

- **deb**: fixed (both sites). **rpm**: untouched — its branch probes the
  file via `rpm -qf`, which can't answer for an uninstalled path.
  **AppImage / Nix**: untouched — they hit the existing not-found warn.
- **rc path not staged on physical hardware in this pass.** Static
  analysis and the bats mocks say the `config-files` record now stays
  silent / warns correctly on both sites; I did not stage a real rc `.deb`
  on metal here. @sabiut previously reproduced the deb rc-state path on
  metal for the original #713.
- `${db:Status-Status}` is a dpkg ≥ 1.17 virtual field (universal on
  supported distros) — the same field the original #713 shipped, kept for
  consistency over switching to `${Status}` + grep.
- Change 2 is separable: a reviewer wanting the minimal #713 carry can drop
  it plus its two tests without affecting Change 1.
- @sabiut's open doctor refactors (#744/#745/#782) touch `scripts/doctor.sh`
  and `tests/doctor.bats` but not `_doctor_check_pkg_version` or
  `_check_name_collision` (the one #744 hit is a context call line, not an
  edit) — no logic conflict, only same-file adjacency. Re-check anchors if
  any of them merge first.

Fixes #711.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>
85% AI / 15% Human
Claude: implementation (Claude Sonnet 5) re-authored the two status gates
and the three new/updated bats cases; planning, gates, and this review
(Claude Opus 4.8) produced the root-cause re-anchor plan, ran the mutation
and full-suite checks, and drafted this body; orchestration (Claude Fable 5)
sequenced the workflow.
Human: triaged #711, wrote the root-cause handover brief that scoped the
two-site re-anchor and the transitional-dummy relevance, and does final
review + posting.
Co-Authored-By: Claude <claude@anthropic.com>
