### PR TITLE
fix(frame-fix): arm refocus jiggle only on tiling WMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 ### Fixed
 
+- The workspace-switch jiggle's blur→focus armed pair is now armed only when a tiling compositor is detected via its session env vars (`HYPRLAND_INSTANCE_SIGNATURE`, `SWAYSOCK`, `I3SOCK`, `NIRI_SOCKET`); `CLAUDE_TILING_WM=1`/`0` overrides the detection for compositors without a recognizable env var. On stacking WMs the pair fired on every alt-tab and the 1px jiggle visibly nudged the window and re-bounded the content view ~100 ms after each refocus — most noticeable on KDE Plasma with a maximized window. The hide→show pair (tray restore), the `resize`-event path and the KWin `moved`/state-change fixes are unchanged. ([#716](https://github.com/aaddrick/claude-desktop-debian/pull/716), fixes [#715](https://github.com/aaddrick/claude-desktop-debian/issues/715))
 - `claude-desktop --doctor` reports the installed version from the package manager that actually owns the install (probed via `rpm -qf` on the bundled Electron binary) instead of trusting `dpkg-query` alone — rpm installs on hosts that also carry a stale dpkg record (e.g. Fedora boxes with dpkg installed as a build tool) no longer show a months-old version with a PASS. ([#712](https://github.com/aaddrick/claude-desktop-debian/pull/712), fixes [#711](https://github.com/aaddrick/claude-desktop-debian/issues/711))
 
 ## [v2.0.19] — 2026-06-10

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,6 +16,7 @@ Model Context Protocol settings are stored in:
 | `CLAUDE_USE_WAYLAND` | unset (auto) | Force the display backend on Wayland: `1` = native Wayland, `0` = XWayland. Unset auto-detects per compositor (only Niri defaults to native Wayland). See [Wayland Support](#wayland-support) below. |
 | `CLAUDE_MENU_BAR` | unset (`auto`) | Controls menu bar behavior: `auto` (hidden, Alt toggles), `visible` / `1` (always shown), `hidden` / `0` (always hidden, Alt disabled). See [Menu Bar](#menu-bar) below. |
 | `CLAUDE_TITLEBAR_STYLE` | unset (`hybrid`) | Controls window decoration style: `hybrid` (system frame + in-app topbar), `native` (system frame, no in-app topbar), `hidden` (frameless WCO — broken on X11, kept for diagnostics). See [Titlebar Style](#titlebar-style) below. |
+| `CLAUDE_TILING_WM` | unset (auto) | Override tiling-WM detection for the workspace-switch refocus jiggle: `1` = treat the compositor as tiling (arm the blur→focus jiggle), `0` = treat as stacking (never jiggle on refocus). Unset auto-detects via `HYPRLAND_INSTANCE_SIGNATURE` / `SWAYSOCK` / `I3SOCK` / `NIRI_SOCKET`; unrecognized values warn and fall back to auto-detection. Set `1` on tiling WMs without a recognizable env var (xmonad, dwm, river, …) if window content goes stale on workspace switches. |
 | `COWORK_VM_BACKEND` | unset (auto-detect) | Force a specific Cowork isolation backend: `kvm` (full VM), `bwrap` (bubblewrap namespace sandbox), or `host` (no isolation). See [Cowork Backend](#cowork-backend) below. |
 
 ### Wayland Support

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -90,6 +90,26 @@ console.log(`[Frame Fix] Close-to-tray: ${CLOSE_TO_TRAY ? 'on' : 'off'}`);
 const KEEP_AWAKE = process.env.CLAUDE_KEEP_AWAKE !== '0';
 console.log(`[Frame Fix] Keep awake: ${KEEP_AWAKE ? 'on (default)' : 'suppressed (CLAUDE_KEEP_AWAKE=0)'}`);
 
+// Tiling-WM detection for the workspace-switch jiggle (the
+// blur→focus armPair below). Hyprland, sway, i3 and niri export
+// their session sockets/signatures into the environment; stacking
+// WMs (KWin, Mutter) set none of these. Tiling WMs without a
+// recognizable env var (xmonad, dwm, river, ...) can opt back in
+// with CLAUDE_TILING_WM=1; CLAUDE_TILING_WM=0 forces the refocus
+// jiggle off.
+const rawTilingWm = process.env.CLAUDE_TILING_WM;
+if (rawTilingWm !== undefined && rawTilingWm !== ''
+  && rawTilingWm !== '1' && rawTilingWm !== '0') {
+  console.warn(`[Frame Fix] Unknown CLAUDE_TILING_WM value '${rawTilingWm}', falling back to auto-detection. Valid: 1, 0`);
+}
+const TILING_WM = rawTilingWm === '1' ? true
+  : rawTilingWm === '0' ? false
+  : !!(process.env.HYPRLAND_INSTANCE_SIGNATURE
+    || process.env.SWAYSOCK || process.env.I3SOCK
+    || process.env.NIRI_SOCKET);
+console.log(`[Frame Fix] Tiling WM: ${TILING_WM}`
+  + (rawTilingWm === '1' || rawTilingWm === '0' ? ' (CLAUDE_TILING_WM override)' : ' (detected)'));
+
 // Detect if a window intends to be frameless (popup/Quick Entry/About).
 // Window kinds — see build-reference/app-extracted/.vite/build/index.js:
 //   Quick Entry:    titleBarStyle:"hidden",      frame:false  (caught early)
@@ -523,7 +543,14 @@ Module.prototype.require = function(id) {
               // (Hyprland) or hide/show pairs. Jiggle only fires
               // when fixChildBounds() finds no mismatch (stale
               // compositor cache on same-size workspace switch).
-              // Fixes: #323
+              // On stacking WMs every alt-tab is a blur→focus pair
+              // and the jiggle visibly nudges the window and
+              // re-bounds the content view, so that pair is only
+              // armed when a tiling compositor is detected
+              // (TILING_WM above). hide→show (tray restore, unhide)
+              // stays armed everywhere — it is not hit by alt-tab
+              // and keeps the fixChildBounds() safety net on
+              // restore. Fixes: #323, #715
               const armPair = (armEvt, fireEvt) => {
                 let armed = false;
                 this.on(armEvt, () => { armed = true; });
@@ -538,7 +565,9 @@ Module.prototype.require = function(id) {
               this.on('focus', () => {
                 this.flashFrame(false); // Fixes: #149
               });
-              armPair('blur', 'focus');
+              if (TILING_WM) {
+                armPair('blur', 'focus');
+              }
               armPair('hide', 'show');
             }
 


### PR DESCRIPTION
Fixes #715

Alt-tab on a stacking WM is a blur→focus pair, so the workspace-switch jiggle (#336) ran ~100 ms after every refocus — `setSize(w+1, h)`, then `setSize(w, h)` 50 ms later, plus a content-view re-bound. On KDE Plasma this visibly nudges the window; with a maximized window on a fractional-scale display it briefly pokes below the panel, can drop the window out of the maximized state, and drifts bounds ~1–2 px per cycle. Event logs and full analysis in #715.

The jiggle exists for tiling WMs (#323) whose same-size workspace switches produce no resize events. This PR arms the `blur→focus` pair only when a tiling compositor is detected via its session env vars (`HYPRLAND_INSTANCE_SIGNATURE`, `SWAYSOCK`, `I3SOCK`, `NIRI_SOCKET`), covering the WMs the jiggle was written and validated for. Tiling WMs without a recognizable env var (xmonad, dwm, river, …) can opt back in with `CLAUDE_TILING_WM=1` (documented in docs/configuration.md); `CLAUDE_TILING_WM=0` forces it off; unrecognized values warn and fall back to auto-detection. Unchanged: the `hide→show` pair (tray restore — not hit by alt-tab, keeps the fixChildBounds safety net), the `resize`-event path (#323), the ready-to-show jiggle (#84), KWin moved/state-change handling (#239).

## Testing

All on KDE Plasma 6.6 (Fedora 43, Wayland session, XWayland backend), with the main process instrumented via the Node inspector (window event listeners + 25 ms bounds polling).

- Before (unpatched AppImage built from main): blur→focus cycles produce move/resize pulses at +100/+150 ms after every `focus`; the maximized-window jiggle also dropped the window out of the maximized state, and bounds drifted ~1–2 px per cycle under fractional scaling. The same real-alt-tab signature was first captured on a stock 2.0.19 rpm install (logs in #715).
- After (AppImage built from this branch): ~15 real alt-tab cycles on a maximized window plus programmatic minimize/restore cycles — zero geometry events after `focus`; the only resize in the log is the maximize itself. No visible nudge.
- Control: launching the same AppImage with `HYPRLAND_INSTANCE_SIGNATURE=x` or `CLAUDE_TILING_WM=1` arms the pair again — `[Frame Fix] Tiling WM: true`, jiggle pulses back at +100/+150 ms after focus. `CLAUDE_TILING_WM=0` with the Hyprland var set keeps it off; an unrecognized value logs the warning and falls back to detection.
- `./build.sh --build appimage --clean no` succeeds; `node --check scripts/frame-fix-wrapper.js`; BATS suite 308/308.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
~95% AI / ~5% Human
Claude: root-cause investigation (live main-process instrumentation), fix, testing, PR text
Human: symptom report, on-device verification of fix candidates, adversarial review
