### PR TITLE
fix(config): patch --add-dir filter to handle SDK bundled twice in 1.12603.1

### DIFF
--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -206,12 +206,14 @@ let patchCount = 0;
         process.exit(1);
     }
 
-    // Count assertion: exactly 1 match expected
+    // Count sites — 2 is expected when the SDK is bundled twice
+    // (e.g. chat panel + Code/Agent panel each embed a copy).
     const escaped = match[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const allMatches = code.match(new RegExp(escaped, 'g'));
-    if (allMatches && allMatches.length > 1) {
+    const siteCount = allMatches ? allMatches.length : 1;
+    if (siteCount > 2) {
         console.error('FATAL: --add-dir pattern matches ' +
-            allMatches.length + ' times (expected 1).');
+            siteCount + ' times (expected 1–2).');
         process.exit(1);
     }
 
@@ -228,9 +230,10 @@ let patchCount = 0;
             iterVar + '=>' + pushTarget +
             '.push("--add-dir",' + iterVar + '))';
     }
-    code = code.replace(match[0], filtered);
+    // Replace all sites (split/join handles 1 or 2 occurrences)
+    code = code.split(match[0]).join(filtered);
     console.log('  Filtered --add-dir dispatch (' +
-        variant + ' variant)');
+        variant + ' variant, ' + siteCount + ' site(s))');
     patchCount++;
 }
 

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -208,9 +208,10 @@ let patchCount = 0;
 
     // Count sites — 2 is expected when the SDK is bundled twice
     // (e.g. chat panel + Code/Agent panel each embed a copy).
-    const escaped = match[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const allMatches = code.match(new RegExp(escaped, 'g'));
-    const siteCount = allMatches ? allMatches.length : 1;
+    // Split on the literal match so the count matches exactly what
+    // the replacement below substitutes.
+    const sites = code.split(match[0]);
+    const siteCount = sites.length - 1;
     if (siteCount > 2) {
         console.error('FATAL: --add-dir pattern matches ' +
             siteCount + ' times (expected 1–2).');
@@ -230,8 +231,8 @@ let patchCount = 0;
             iterVar + '=>' + pushTarget +
             '.push("--add-dir",' + iterVar + '))';
     }
-    // Replace all sites (split/join handles 1 or 2 occurrences)
-    code = code.split(match[0]).join(filtered);
+    // Replace all sites (join handles 1 or 2 occurrences)
+    code = sites.join(filtered);
     console.log('  Filtered --add-dir dispatch (' +
         variant + ' variant, ' + siteCount + ' site(s))');
     patchCount++;


### PR DESCRIPTION
## Summary

- In Claude Desktop 1.12603.1 the Claude Code SDK is bundled in two places (chat panel and Code/Agent panel), so `for(let F of e)Y.push("--add-dir",F)` appears twice in `index.js`
- The previous patch asserted exactly 1 match and fatally exited on 2, breaking the build
- Fix: accept 1–2 sites (still fatal if >2), and switch `code.replace()` to `code.split().join()` so all occurrences get the `.asar` filter applied

## Test plan

- [ ] `./build.sh --build deb --clean no` completes without error on 1.12603.1
- [ ] Build log shows `Filtered --add-dir dispatch (for-of variant, 2 site(s))`

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
95% AI / 5% Human
Claude: diagnosed the double-match root cause, wrote the fix, tested the build
Human: triggered the build, identified the failure, requested the commit and PR