### PR TITLE
fix(patches): filter every --add-dir dispatch loop (#718)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 ### Fixed
 
+- Builds (deb, RPM, AppImage, nix) no longer abort in the patch phase with `FATAL: --add-dir pattern matches 2 times (expected 1)`. Upstream Claude Desktop 1.12603.1 ships two identical `--add-dir` dispatch loops, but the `.asar` filter patch ([#650](https://github.com/aaddrick/claude-desktop-debian/pull/650)) asserted exactly one. The patch now filters every matching dispatch loop instead of bailing on a duplicate, and stays idempotent on re-runs. ([#718](https://github.com/aaddrick/claude-desktop-debian/issues/718))
 - `claude-desktop --doctor` reports the installed version from the package manager that actually owns the install (probed via `rpm -qf` on the bundled Electron binary) instead of trusting `dpkg-query` alone — rpm installs on hosts that also carry a stale dpkg record (e.g. Fedora boxes with dpkg installed as a build tool) no longer show a months-old version with a PASS. ([#712](https://github.com/aaddrick/claude-desktop-debian/pull/712), fixes [#711](https://github.com/aaddrick/claude-desktop-debian/issues/711))
 
 ## [v2.0.19] — 2026-06-10

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -166,72 +166,65 @@ patch_asar_additional_dirs_guard() {
 	echo 'Patching --add-dir dispatch to reject .asar paths (#649)...'
 	local index_js='app.asar.contents/.vite/build/index.js'
 
-	# Idempotency
-	if grep -qF '.filter(_d=>!_d.endsWith(".asar"))' "$index_js"; then
-		echo '  .asar --add-dir filter already present (idempotent)'
-		echo '##############################################################'
-		return
-	fi
-
 	if ! INDEX_JS="$index_js" node << 'ASAR_ADDDIR_PATCH'
 const fs = require('fs');
 const indexJs = process.env.INDEX_JS;
 let code = fs.readFileSync(indexJs, 'utf8');
 let patchCount = 0;
+let dispatchPatchCount = 0;
+let dispatchAlreadyPresent = code.includes(
+    '.filter(_d=>!_d.endsWith(".asar"))'
+);
 
 // ================================================================
 // Sub-patch 1: Filter .asar from --add-dir loop
 //
-// Target (unique, 1 occurrence):
+// Targets (one or more occurrences):
 //   for (let O of A) Y.push("--add-dir", O);
 // Fallback (if minifier uses .forEach):
 //   A.forEach(O=>Y.push("--add-dir",O))
 // ================================================================
 {
     // Primary: for...of pattern
-    const forOfRe = /for\s*\(\s*let\s+([\w$]+)\s+of\s+([\w$]+)\s*\)\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\1\s*\)/;
+    const forOfRe = /for\s*\(\s*let\s+([\w$]+)\s+of\s+([\w$]+)\s*\)\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\1\s*\)/g;
     // Fallback: .forEach pattern
-    const forEachRe = /([\w$]+)\.forEach\(\s*([\w$]+)\s*=>\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\2\s*\)\s*\)/;
+    const forEachRe = /([\w$]+)\.forEach\(\s*([\w$]+)\s*=>\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\2\s*\)\s*\)/g;
 
-    let match = code.match(forOfRe);
-    let variant = 'for-of';
-    if (!match) {
-        match = code.match(forEachRe);
-        variant = 'forEach';
-    }
-    if (!match) {
+    let forOfCount = 0;
+    let forEachCount = 0;
+    code = code.replace(forOfRe, (match, iterVar, arrVar, pushTarget) => {
+        forOfCount++;
+        dispatchPatchCount++;
+        patchCount++;
+        return 'for(let ' + iterVar + ' of ' + arrVar +
+            '.filter(_d=>!_d.endsWith(".asar")))' +
+            pushTarget + '.push("--add-dir",' + iterVar + ')';
+    });
+    code = code.replace(forEachRe, (match, arrVar, iterVar, pushTarget) => {
+        forEachCount++;
+        dispatchPatchCount++;
+        patchCount++;
+        return arrVar +
+            '.filter(_d=>!_d.endsWith(".asar")).forEach(' +
+            iterVar + '=>' + pushTarget +
+            '.push("--add-dir",' + iterVar + '))';
+    });
+
+    if (dispatchPatchCount === 0 && !dispatchAlreadyPresent) {
         console.error('FATAL: --add-dir dispatch loop not found.');
         console.error('  for(let X of Y) Z.push("--add-dir", X)');
         console.error('  Y.forEach(X=>Z.push("--add-dir", X))');
         process.exit(1);
     }
 
-    // Count assertion: exactly 1 match expected
-    const escaped = match[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const allMatches = code.match(new RegExp(escaped, 'g'));
-    if (allMatches && allMatches.length > 1) {
-        console.error('FATAL: --add-dir pattern matches ' +
-            allMatches.length + ' times (expected 1).');
-        process.exit(1);
-    }
-
-    let filtered;
-    if (variant === 'for-of') {
-        const [, iterVar, arrVar, pushTarget] = match;
-        filtered = 'for(let ' + iterVar + ' of ' + arrVar +
-            '.filter(_d=>!_d.endsWith(".asar")))' +
-            pushTarget + '.push("--add-dir",' + iterVar + ')';
+    if (dispatchPatchCount > 0) {
+        console.log('  Filtered ' + dispatchPatchCount +
+            ' --add-dir dispatch loop(s) (for-of=' + forOfCount +
+            ', forEach=' + forEachCount + ')');
     } else {
-        const [, arrVar, iterVar, pushTarget] = match;
-        filtered = arrVar +
-            '.filter(_d=>!_d.endsWith(".asar")).forEach(' +
-            iterVar + '=>' + pushTarget +
-            '.push("--add-dir",' + iterVar + '))';
+        console.log('  .asar --add-dir filter already present ' +
+            '(idempotent)');
     }
-    code = code.replace(match[0], filtered);
-    console.log('  Filtered --add-dir dispatch (' +
-        variant + ' variant)');
-    patchCount++;
 }
 
 // ================================================================
@@ -288,9 +281,8 @@ let patchCount = 0;
 fs.writeFileSync(indexJs, code);
 console.log('  Applied ' + patchCount +
     ' .asar additionalDirectories patch(es)');
-if (patchCount < 1) {
-    console.error('FATAL: No patches applied — --add-dir filter ' +
-        'must succeed (#649).');
+if (dispatchPatchCount < 1 && !dispatchAlreadyPresent) {
+    console.error('FATAL: --add-dir filter must succeed (#649).');
     process.exit(1);
 }
 ASAR_ADDDIR_PATCH

--- a/tests/config-patches.bats
+++ b/tests/config-patches.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+#
+# config-patches.bats
+# Tests for scripts/patches/config.sh patch helpers.
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+PATCH_SH="$SCRIPT_DIR/../scripts/patches/config.sh"
+
+setup() {
+	TEST_TMP=$(mktemp -d)
+	export TEST_TMP
+	project_root="$TEST_TMP"
+	export project_root
+	mkdir -p "$TEST_TMP/app.asar.contents/.vite/build"
+	cd "$TEST_TMP" || return 1
+
+	# shellcheck source=scripts/patches/config.sh
+	source "$PATCH_SH"
+}
+
+teardown() {
+	if [[ -n "$TEST_TMP" && -d "$TEST_TMP" ]]; then
+		rm -rf "$TEST_TMP"
+	fi
+}
+
+write_index_js() {
+	local fixture='app.asar.contents/.vite/build/index.js'
+	{
+		printf '%s' \
+			'function a(A,Y){for(let O of A)Y.push("--add-dir",O)}'
+		printf '%s' \
+			'function b(A,Y){for(let O of A)Y.push("--add-dir",O)}'
+		printf '%s' \
+			'function c(S){(S.userSelectedFolders||[]).filter(p=>true);'
+		printf '%s' \
+			'console.log("Filtering out deleted folder from session")}'
+	} > "$fixture"
+}
+
+@test "additional dirs guard filters every --add-dir dispatch loop" {
+	write_index_js
+
+	run patch_asar_additional_dirs_guard
+	[[ "$status" -eq 0 ]] || {
+		echo "$output"
+		return 1
+	}
+
+	local patched='app.asar.contents/.vite/build/index.js'
+	run grep -oF '.filter(_d=>!_d.endsWith(".asar"))' "$patched"
+	[[ "$status" -eq 0 ]] || {
+		echo 'expected .asar filters to be injected'
+		return 1
+	}
+	[[ "${#lines[@]}" -eq 2 ]] || {
+		echo "expected 2 dispatch filters, got ${#lines[@]}"
+		return 1
+	}
+
+	run grep -qF 'for(let O of A)Y.push("--add-dir",O)' "$patched"
+	[[ "$status" -eq 1 ]] || {
+		echo 'unfiltered --add-dir dispatch remained'
+		return 1
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the build failure in #718, where every build format (deb, RPM, AppImage, nix) aborts in the patch phase on upstream Claude Desktop **1.12603.1** with:

```
FATAL: --add-dir pattern matches 2 times (expected 1).
FATAL: .asar --add-dir filter patch failed
Local agent mode will crash without this patch (#649).
```

## Root cause

The `.asar` `--add-dir` filter patch (`patch_asar_additional_dirs_guard` in `scripts/patches/config.sh`, added in #650) assumed the `--add-dir` dispatch loop is **unique** in the bundle:

```js
// Count assertion: exactly 1 match expected
if (allMatches && allMatches.length > 1) {
    console.error('FATAL: --add-dir pattern matches ' +
        allMatches.length + ' times (expected 1).');
    process.exit(1);
}
```

Upstream 1.12603.1 now ships **two** identical `for(let O of A)Y.push("--add-dir",O)` dispatch loops, so the assertion trips and the build dies.

The correct invariant is not "exactly one dispatch loop" — it's "**every** unfiltered `--add-dir` dispatch must filter `.asar` paths." A second convergence point that feeds `additionalDirectories` is a site that *also* needs the guard, not a reason to bail.

## Fix

Replace the single-match-or-abort logic with a global replace over both the for-of and forEach variants, counting how many loops were filtered:

- Filters **all** matching `--add-dir` dispatch loops (`for-of` and `.forEach` variants).
- Still fails loudly when no dispatch loop is found **and** no existing filter is present, preserving the #649 protection.
- Remains idempotent: a second run is a byte-identical no-op (verified by sha256).

## Verification

Built end-to-end against real upstream 1.12603.1 (not just the beautified reference):

```
Patching --add-dir dispatch to reject .asar paths (#649)...
  Filtered 2 --add-dir dispatch loop(s) (for-of=2, forEach=0)
  Injected .asar filter in session restore
  Applied 3 .asar additionalDirectories patch(es)
```

`nix build .#claude-desktop` now completes (`exit=0`, derivation built).

- Added `tests/config-patches.bats` covering the duplicate-loop case (fails on the old code, passes on the new).
- `bats tests/config-patches.bats` → green.
- Idempotency check → byte-identical second run.
- `shellcheck` / `bash -n` on touched files → clean.

## Files

- `scripts/patches/config.sh` — global replace over both dispatch-loop variants.
- `tests/config-patches.bats` — new regression test.
- `CHANGELOG.md` — `[Unreleased] → Fixed` entry.

Fixes #718

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
85% AI / 15% Human
Claude: root-cause investigation, patch rewrite, regression test, end-to-end nix build verification, changelog
Human: issue triage direction, review, merge decision