### PR TITLE
Fix Linux startup with Claude native registry shim

### DIFF
--- a/scripts/claude-native-stub.js
+++ b/scripts/claude-native-stub.js
@@ -64,6 +64,8 @@ module.exports = {
   },
 
   showNotification: () => {},
+  // Windows enterprise policy registry reads are not applicable on Linux.
+  readRegistryValues: () => [],
 
   // Progress bar is natively supported on Linux (Unity/KDE/GNOME)
   setProgressBar: (progress) => {

--- a/scripts/frame-fix-wrapper.js
+++ b/scripts/frame-fix-wrapper.js
@@ -152,6 +152,43 @@ const autoUpdaterNoop = new Proxy({}, {
   },
 });
 
+// Claude 1.14271 added an enterprise-policy probe that reads the
+// Windows registry through @ant/claude-native during main-process
+// startup. The Linux native module can exist without that Windows-only
+// helper, and upstream calls readRegistryValues() unguarded; because
+// index.pre.js installs an empty uncaughtException handler early, the
+// TypeError is swallowed and startup stalls before any window is
+// created. Make the Windows policy probe a no-op on Linux.
+function patchClaudeNative(nativeModule) {
+  if (process.platform === 'win32'
+    || !nativeModule
+    || typeof nativeModule.readRegistryValues === 'function') {
+    return nativeModule;
+  }
+
+  if (typeof nativeModule === 'object' || typeof nativeModule === 'function') {
+    try {
+      Object.defineProperty(nativeModule, 'readRegistryValues', {
+        value: () => [],
+        configurable: true,
+        writable: true,
+      });
+      console.log('[Frame Fix] Shimmed claude-native.readRegistryValues');
+      return nativeModule;
+    } catch (err) {
+      console.warn('[Frame Fix] Could not patch claude-native in place:', err.message);
+      return new Proxy(nativeModule, {
+        get(target, prop, receiver) {
+          if (prop === 'readRegistryValues') return () => [];
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+    }
+  }
+
+  return nativeModule;
+}
+
 // Build the patched BrowserWindow class and Menu interceptor once,
 // on first require('electron'), then reuse via Proxy on every access.
 let PatchedBrowserWindow = null;
@@ -160,6 +197,10 @@ let electronModule = null;
 
 Module.prototype.require = function(id) {
   const result = originalRequire.apply(this, arguments);
+
+  if (id === '@ant/claude-native') {
+    return patchClaudeNative(result);
+  }
 
   if (id === 'electron') {
     // Build patches once from the real electron module

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -309,8 +309,10 @@ build_electron_args() {
 		log_message \
 			'Previous launch hit GPU process FATAL - disabling GPU'
 	fi
-	[[ $_disable_gpu == true ]] \
-		&& electron_args+=('--disable-gpu' '--disable-software-rasterizer')
+	# Keep Chromium's software rasterizer available. Disabling both
+	# hardware GPU and the software fallback can make Electron abort
+	# with "GPU process isn't usable" instead of recovering.
+	[[ $_disable_gpu == true ]] && electron_args+=('--disable-gpu')
 
 	# X11 session - no display-backend flags needed.
 	if [[ $is_wayland != true ]]; then

--- a/tests/claude-native-stub.bats
+++ b/tests/claude-native-stub.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# claude-native-stub.bats
+# Tests for the Linux @ant/claude-native stub copied into app.asar and
+# app.asar.unpacked during packaging.
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+STUB_JS="$SCRIPT_DIR/../scripts/claude-native-stub.js"
+
+@test "claude-native stub: Windows registry reads are a Linux no-op" {
+	run node - "$STUB_JS" <<'JS'
+const stub = require(process.argv[2]);
+if (typeof stub.readRegistryValues !== 'function') {
+  throw new Error('readRegistryValues is missing');
+}
+const values = stub.readRegistryValues([
+  'HKCU\\Software\\Anthropic\\Claude',
+]);
+if (!Array.isArray(values) || values.length !== 0) {
+  throw new Error('readRegistryValues should return []');
+}
+JS
+	[[ "$status" -eq 0 ]] || {
+		echo "$output"
+		return 1
+	}
+}

--- a/tests/frame-fix-wrapper.bats
+++ b/tests/frame-fix-wrapper.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+#
+# frame-fix-wrapper.bats
+# Focused coverage for the Electron main-process require() shims in
+# scripts/frame-fix-wrapper.js.
+#
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+WRAPPER_JS="$SCRIPT_DIR/../scripts/frame-fix-wrapper.js"
+
+setup() {
+	TEST_TMP=$(mktemp -d)
+	export TEST_TMP
+}
+
+teardown() {
+	if [[ -n ${TEST_TMP:-} && -d $TEST_TMP ]]; then
+		rm -rf "$TEST_TMP"
+	fi
+}
+
+@test "frame-fix: shims missing claude-native readRegistryValues on Linux" {
+	[[ "$(node -p 'process.platform')" != 'win32' ]] \
+		|| skip 'Linux-only shim is intentionally inactive on Windows'
+
+	mkdir -p "$TEST_TMP/node_modules/@ant/claude-native"
+	cat > "$TEST_TMP/node_modules/@ant/claude-native/index.js" <<'JS'
+module.exports = { existingExport: 42 };
+JS
+
+	cat > "$TEST_TMP/probe.js" <<'JS'
+require(process.env.WRAPPER_JS);
+
+const claudeNative = require('@ant/claude-native');
+if (claudeNative.existingExport !== 42) {
+  throw new Error('existing export was not preserved');
+}
+if (typeof claudeNative.readRegistryValues !== 'function') {
+  throw new Error('readRegistryValues shim missing');
+}
+const values = claudeNative.readRegistryValues([
+  'HKCU\\Software\\Anthropic\\Claude',
+]);
+if (!Array.isArray(values) || values.length !== 0) {
+  throw new Error('readRegistryValues shim should return []');
+}
+JS
+
+	WRAPPER_JS="$WRAPPER_JS" run node "$TEST_TMP/probe.js"
+	[[ "$status" -eq 0 ]] || {
+		echo "$output"
+		return 1
+	}
+}

--- a/tests/launcher-disable-gpu.bats
+++ b/tests/launcher-disable-gpu.bats
@@ -4,9 +4,9 @@
 # Tests for the CLAUDE_DISABLE_GPU env var handling in
 # build_electron_args (scripts/launcher-common.sh). The var is an
 # opt-in workaround for the Chromium GPU process FATAL exhaustion
-# tracked in #583. CLAUDE_DISABLE_GPU=1 adds --disable-gpu and
-# --disable-software-rasterizer; co-occurrence with XRDP must not
-# stack duplicate flags.
+# tracked in #583. CLAUDE_DISABLE_GPU=1 adds --disable-gpu while
+# leaving Chromium's software rasterizer available; co-occurrence
+# with XRDP must not stack duplicate flags.
 #
 
 SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
@@ -70,13 +70,14 @@ args_count() {
 # CLAUDE_DISABLE_GPU=1 — flags must be added
 # =============================================================================
 
-@test "disable-gpu: CLAUDE_DISABLE_GPU=1 adds flags + logs message" {
+@test "disable-gpu: CLAUDE_DISABLE_GPU=1 adds flag + logs message" {
 	export CLAUDE_DISABLE_GPU=1
 
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'CLAUDE_DISABLE_GPU=1' "$log_file"
 }
 
@@ -93,7 +94,7 @@ args_count() {
 	build_electron_args deb
 
 	[[ "$(args_count '--disable-gpu')" -eq 1 ]]
-	[[ "$(args_count '--disable-software-rasterizer')" -eq 1 ]]
+	[[ "$(args_count '--disable-software-rasterizer')" -eq 0 ]]
 	# Both signals should still log (independent diagnostic value),
 	# but only one set of flags should reach electron_args.
 	grep -q 'XRDP session detected' "$log_file"
@@ -154,7 +155,8 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'Previous launch hit GPU process FATAL' "$log_file"
 }
 
@@ -176,7 +178,8 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 }
 
 @test "disable-gpu: NixOS launcher header sections are detected" {
@@ -193,7 +196,8 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'Previous launch hit GPU process FATAL' "$log_file"
 }
 

--- a/tests/launcher-xrdp-detection.bats
+++ b/tests/launcher-xrdp-detection.bats
@@ -103,7 +103,8 @@ args_count() {
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'XRDP session detected' "$log_file"
 }
 
@@ -114,7 +115,8 @@ args_count() {
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'XRDP session detected' "$log_file"
 }
 
@@ -126,7 +128,7 @@ args_count() {
 	build_electron_args deb
 
 	[[ "$(args_count '--disable-gpu')" -eq 1 ]]
-	[[ "$(args_count '--disable-software-rasterizer')" -eq 1 ]]
+	[[ "$(args_count '--disable-software-rasterizer')" -eq 0 ]]
 	[[ "$(grep -c 'XRDP session detected' "$log_file")" -eq 1 ]]
 }
 


### PR DESCRIPTION
## Summary
- add a Linux no-op for the new `@ant/claude-native.readRegistryValues()` Windows registry policy call
- defensively shim missing `readRegistryValues` from `frame-fix-wrapper.js` before Claude's main bundle runs
- keep Chromium's software rasterizer enabled when launcher GPU recovery adds `--disable-gpu`

## Root cause
Claude Desktop 1.14271 calls `@ant/claude-native.readRegistryValues()` during main-process startup while reading enterprise policy state. On Linux, the packaged native stub can exist without that Windows-only method. The resulting `TypeError` is easy to miss because the upstream bundle installs an empty `uncaughtException` handler early, so startup stalls before a window is created.

Separately, the launcher GPU recovery path added both `--disable-gpu` and `--disable-software-rasterizer`. On affected systems this can turn a GPU fallback path into Chromium's fatal "GPU process isn't usable" abort, because the software fallback is disabled too.

## Validation
- `git diff --check`
- `node --check scripts/claude-native-stub.js`
- `node --check scripts/frame-fix-wrapper.js`
- `nix shell nixpkgs#shellcheck --command shellcheck -x scripts/launcher-common.sh`
- `nix shell nixpkgs#bats --command bats --print-output-on-failure tests/claude-native-stub.bats tests/frame-fix-wrapper.bats tests/launcher-disable-gpu.bats tests/launcher-xrdp-detection.bats`

I also ran the full `tests/*.bats` suite locally. The changed tests passed; two unrelated local-environment failures remained in `tests/cowork-bwrap-config.bats` and `tests/launcher-common.bats`.