### PR TITLE
Fix Linux startup hang: stub Windows-only native methods (#729)

### DIFF
--- a/scripts/claude-native-stub.js
+++ b/scripts/claude-native-stub.js
@@ -42,6 +42,25 @@ class AuthRequest {
 
 module.exports = {
   getWindowsVersion: () => "10.0.0",
+
+  // Windows-only native methods that do not exist on Linux. Newer
+  // upstream (Claude Desktop >= 1.13576.0) calls readRegistryValues()
+  // UNCONDITIONALLY at startup (managed-config / enterprise-policy
+  // lookup) from index.pre.js and index.js top-level. The bundle only
+  // guards the module being null (`(o=g2())==null?void 0:o.readRegistryValues(r)`),
+  // not the method being absent, so a missing method throws
+  // "readRegistryValues is not a function" during top-level execution —
+  // before the logger and the main window are created. The app process
+  // stays alive but no window ever appears (idles in the event loop).
+  // Stub these as safe no-ops returning "nothing here" so the lookups
+  // succeed. Fixes the Linux "hangs indefinitely, app window never
+  // shows up" regression (upstream issue #729).
+  readRegistryValues: () => [],
+  writeRegistryValue: () => {},
+  writeRegistryDword: () => {},
+  getWindowsElevationType: () => "default",
+  getCurrentPackageFamilyName: () => null,
+
   setWindowEffect: () => {},
   removeWindowEffect: () => {},
 


### PR DESCRIPTION
## Problem

On Linux, Claude Desktop ≥ 1.13576.0 launches but the main window never appears — the process stays alive (idling in the libuv event loop) with no window, no renderer process, and nothing written to `~/.config/Claude/logs/main.log`. This is #729.

## Root cause

The upstream bundle (`.vite/build/index.pre.js` and `index.js`) calls Windows-only `@ant/claude-native` methods **unconditionally at module top-level** for the managed-config / enterprise-policy lookup, e.g.:

```js
const n = ((o = g2()) == null ? void 0 : o.readRegistryValues(r)) ?? [];
```

The guard only handles the native module being `null`, not the method being **absent**. Our Linux stub (`scripts/claude-native-stub.js`) doesn't implement `readRegistryValues`, so this throws `TypeError: readRegistryValues is not a function` during top-level execution of `index.pre.js` — before `require('./index.js')` and before the main window is ever created.

Because the throw is in `index.pre.js`'s own top-level (outside the `try/catch` it wraps the `index.js` require in), no `launch-failure.err` is written, which is why it presents as a silent hang rather than a crash.

Confirmed by injecting probes into a repacked `app.asar` run in a throwaway `--user-data-dir`:

```text
[P] entry top
[P] pre.js top
[P] uncaughtException: TypeError: o.readRegistryValues is not a function
        at ... index.pre.js:61
```

After guarding only that one call, startup advanced to the next identical throw — `s.readRegistryValues is not a function` in `index.js` — confirming several call sites of the same missing-method class.

## Fix

Add safe no-op stubs for the Windows-only native methods the bundle calls to `scripts/claude-native-stub.js`:

- `readRegistryValues: () => []`
- `writeRegistryValue: () => {}`
- `writeRegistryDword: () => {}`
- `getWindowsElevationType: () => "default"`
- `getCurrentPackageFamilyName: () => null`

On Linux there is no Windows registry / MSIX package / UAC elevation, so returning empty/neutral values is semantically correct, and the existing `?? []` / `?? "default"` consumers handle them. Fixing the stub (rather than each minified call site) covers every call site at the source and is robust against re-minification.

## Testing

Built the `.deb` from this branch and installed on Ubuntu (GNOME, Wayland + XWayland), Claude Desktop 1.14271.0:

- Main window appears and renders the real UI (`window_created_ms` and `main_view_dom_ready_ms` both logged).
- `main.log` shows **no** `"is not a function"` errors (previously `readRegistryValues` and `getWindowsElevationType`).
- Logged-in chat UI is fully functional.

Affected upstream versions observed: 1.13576.0 and 1.14271.0.

Fixes #729

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
85% AI / 15% Human
Claude: root-cause diagnosis via probe-injection experiment, the stub fix, build + install verification
Human: direction, environment/reproduction, verification approval
