### PR TITLE
docs(readme): credit #729 and #736 contributors in Acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,9 @@ Special thanks to:
 - **[diarized](https://github.com/diarized)** for auto-installing scoped AppArmor userns profiles from the `.deb` postinst on Ubuntu 24.04+ — one for the bundled Electron binary (fixing the launch crash without `--no-sandbox`) and one for `/usr/bin/bwrap` (keeping Cowork's sandbox isolated instead of silently falling back to host-direct), automating the workaround from #351 (#687, #694)
 - **[emandel82](https://github.com/emandel82)** for root-causing the "Attach app.asar?" prompt: every launcher passed `app.asar` as a redundant Electron argument, which the second-instance argv collector treated as a file to open — removed at the source across all four package formats (#700, #696)
 - **[svankirk](https://github.com/svankirk)** for cleaning up Desktop helper processes after an explicit quit — a quit wrapper with signal forwarding and a bundle-keyed live-UI check, so closing the app no longer strands helper processes (#682)
+- **[pjordanandrsn](https://github.com/pjordanandrsn)** for re-deriving the cowork Linux patch suite against the upstream "yukonSilver" VM refactor (1.13576+) — re-anchoring the platform gate on `startVM`'s `yukonSilver.status` check after Patch 1's removed `darwin`/`win32` anchor started `process.exit(1)`'ing and dropping every subsequent cowork patch, fixing the build's "Verify cowork patches in shipped asar" gate (#736)
+- **[chrisw1005](https://github.com/chrisw1005)** for root-causing the Linux startup hang on Claude Desktop 1.13576+ — the unconditional `@ant/claude-native.readRegistryValues()` / `getWindowsElevationType()` enterprise-policy calls throwing a swallowed missing-method `TypeError` before window creation — via probe injection, and the complete Windows-only native stub fix (#729)
+- **[colonelpanic8](https://github.com/colonelpanic8)** for independently reproducing the same 1.13576+ startup hang and contributing BATS coverage for the Linux native stub (#730)
 
 ## Sponsorship
 


### PR DESCRIPTION
Credits the contributors whose work landed in the #729 startup-hang fix and the #736 cowork re-derivation, per CONTRIBUTING.md (external PR authors → README Acknowledgments, chronological order).

Adds three entries:
- **[pjordanandrsn](https://github.com/pjordanandrsn)** — re-derived the cowork Linux patch suite for the upstream "yukonSilver" VM refactor, restoring the shipped-asar marker verification ([#736](https://github.com/aaddrick/claude-desktop-debian/pull/736))
- **[chrisw1005](https://github.com/chrisw1005)** — root-caused the Linux startup hang on 1.13576+ (unguarded Windows-only `@ant/claude-native` policy calls) and the complete native-stub fix ([#729](https://github.com/aaddrick/claude-desktop-debian/issues/729), via #734 → #737)
- **[colonelpanic8](https://github.com/colonelpanic8)** — independently reproduced the hang and contributed BATS coverage for the stub ([#730](https://github.com/aaddrick/claude-desktop-debian/pull/730) → #737)

Docs-only; no code paths touched.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>
~90% AI / ~10% Human
Claude: drafted the acknowledgment entries and opened the PR
Human: directed the credit follow-up

---
_Generated by [Claude Code](https://claude.ai/code/session_013RJqsaXbLkPycYFutEYWVy)_