### PR TITLE
fix(tray): re-derive in-place fast-path for the 1.13576+ rebuild refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- The tray in-place fast-path applies again on Claude Desktop 1.13576+ (verified against 1.15962.0). The "yukonSilver"-era refactor restructured the tray rebuild block — the destroy/recreate is now guarded by `if(X=[],Y=!1,TRAY&&(TRAY.destroy()…),!enabled)` instead of `;if(TRAY&&(TRAY.destroy()`, and the context menu became a prebuilt object (`M=BUILDER();TRAY.setContextMenu(M)`) with a leading `setContextMenu(null)` menu-clear. The patch's `head -1` latched that `null` clear, so the menu builder never resolved, the #680 WARNING fired, and the fast-path was skipped — silently re-arming the #515 KDE/Plasma duplicate-icon StatusNotifier race because tray patches warn-and-continue. The menu-function resolver now walks every `setContextMenu` argument, skips the `null` clear, and resolves the real builder; the injection anchors on the `;if(` that opens the destroy statement so it lands in both the old and new shapes. New `tests/tray-patches.bats` covers builder resolution, injection placement, idempotency, the loud-fail-on-missing-anchor path, and the menu-bar-default cases. ([#746](https://github.com/aaddrick/claude-desktop-debian/issues/746) investigation)
+- `patch_menu_bar_default` no longer reports a bare "pattern not found" on 1.13576+. Upstream moved `menuBarEnabled` behind a settings getter backed by a defaults map that already ships `menuBarEnabled:!0`, so the legacy `!!`-default rewrite is a no-op by design. The patch now distinguishes that case from a genuine miss and warns loudly only if neither the legacy anchor nor the upstream default is present (i.e. the default ever flips back to off).
+
 ## [v2.0.22] — 2026-06-25
 
 Tracks upstream Claude Desktop 1.15200.0.

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -245,11 +245,17 @@ const fastPath =
 // and the 1.13576+ shape with leading state resets
 //   ;if(X=[],Y=!1,TRAY&&(TRAY.destroy()...
 const destroyMark = T + '.destroy()';
-const di = code.indexOf(destroyMark);
-if (di === -1) {
-  console.error('  [FAIL] TRAY.destroy() site not found');
+// Assert the anchor is unique before trusting indexOf's first hit: a
+// second TRAY.destroy() (a new teardown path, or the string surfacing in
+// a merged chunk) would silently mis-place the injection. Bail loudly so
+// a future upstream surfaces here instead of shipping a wrong fast-path.
+const destroyCount = code.split(destroyMark).length - 1;
+if (destroyCount !== 1) {
+  console.error('  [FAIL] expected exactly 1 ' + destroyMark +
+    ', found ' + destroyCount);
   process.exit(1);
 }
+const di = code.indexOf(destroyMark);
 const ifIdx = code.lastIndexOf(';if(', di);
 if (ifIdx === -1) {
   console.error('  [FAIL] enclosing destroy-recreate if( not found');
@@ -294,7 +300,7 @@ patch_menu_bar_default() {
 	# `menuBarEnabled:!0` (true). When that default is present this patch
 	# is a no-op by design — distinguish that from a genuine miss so a
 	# future default flip back to false surfaces instead of hiding.
-	elif grep -qP 'menuBarEnabled:\s*!0\b' "$index_js"; then
+	elif grep -qP 'menuBarEnabled:[ \t]*!0\b' "$index_js"; then
 		echo '  menuBarEnabled already defaults to true upstream' \
 			'(defaults map) — no patch needed'
 	else

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -124,17 +124,26 @@ patch_tray_inplace_update() {
 	menu_func=$(grep -oP "${tray_var_re}\.setContextMenu\(\K[\$\w]+(?=\(\))" \
 		"$index_js" | head -1)
 	if [[ -z $menu_func ]]; then
-		menu_var=$(grep -oP "${tray_var_re}\.setContextMenu\(\K[\$\w]+(?=\))" \
-			"$index_js" | head -1)
-		if [[ -n $menu_var ]]; then
+		# Prebuilt-object form. Two traps a plain `head -1` falls into on
+		# 1.13576+ bundles: (1) the *first* setContextMenu call site is a
+		# menu-*clear* — `${tray_var}.setContextMenu(null)` on
+		# invalidation — so latching the first arg yields the literal
+		# `null`; (2) the menu object is assigned from the builder by name
+		# (`M=BUILDER()`), so the builder is one hop away. Walk every
+		# setContextMenu argument, skip the `null` clear, and take the
+		# first that resolves to a `VAR=BUILDER()` assignment. The
+		# word-boundary lookbehind resolves the assignment whether it
+		# follows a separator or a declarator (`let `/`const ` leaves a
+		# space before the var).
+		while IFS= read -r menu_var; do
+			[[ -z $menu_var || $menu_var == 'null' ]] && continue
 			menu_var_re="${menu_var//\$/\\$}"
-			# Word-boundary lookbehind, not a fixed [,;({] class, so the
-			# assignment resolves whether it follows a separator or a
-			# declarator (`let `/`const ` leaves a space before the var).
-			# First assignment site wins, matching the inline-form grep.
-			menu_func=$(grep -oP "(?<![\$\w])${menu_var_re}=\K[\$\w]+(?=\(\))" \
+			menu_func=$(grep -oP \
+				"(?<![\$\w])${menu_var_re}=\K[\$\w]+(?=\(\))" \
 				"$index_js" | head -1)
-		fi
+			[[ -n $menu_func ]] && break
+		done < <(grep -oP \
+			"${tray_var_re}\.setContextMenu\(\K[\$\w]+(?=\))" "$index_js")
 	fi
 	if [[ -z $menu_func ]]; then
 		# Both the inline grep and the menu_var fallback came up empty.
@@ -221,17 +230,6 @@ const P = process.env.PATH_VAR;
 const V = process.env.ENABLED_VAR;
 let code = fs.readFileSync(p, 'utf8');
 
-// Anchor at the start of the existing destroy+recreate block,
-// tolerating optional inner whitespace.
-const reEsc = (s) => s.replace(/[.*+?^\${}()|[\\]\\\\]/g, '\\\\\$&');
-const anchor = new RegExp(
-  ';if\\\\(' + reEsc(T) + '&&\\\\(' + reEsc(T) + '\\\\.destroy\\\\(\\\\)'
-);
-if (!anchor.test(code)) {
-  console.error('  [FAIL] destroy-recreate anchor not found');
-  process.exit(1);
-}
-
 const fastPath =
   'if(' + T + '&&' + V + '!==false){' +
     T + '.setImage(' + E + '.nativeImage.createFromPath(' + P + '));' +
@@ -239,9 +237,26 @@ const fastPath =
     'return' +
   '}';
 
-// Prefix the destroy block with the fast-path, keeping the matched
-// portion ';if(TRAY&&(TRAY.destroy()' intact.
-code = code.replace(anchor, (m) => ';' + fastPath + m.slice(1));
+// Inject the fast-path just before the destroy+recreate statement.
+// Locate the TRAY.destroy() call, then walk back to the ';if(' that
+// opens its statement, so the fast-path lands on a clean statement
+// boundary. Robust across both block shapes: the old
+//   ;if(TRAY&&(TRAY.destroy()...
+// and the 1.13576+ shape with leading state resets
+//   ;if(X=[],Y=!1,TRAY&&(TRAY.destroy()...
+const destroyMark = T + '.destroy()';
+const di = code.indexOf(destroyMark);
+if (di === -1) {
+  console.error('  [FAIL] TRAY.destroy() site not found');
+  process.exit(1);
+}
+const ifIdx = code.lastIndexOf(';if(', di);
+if (ifIdx === -1) {
+  console.error('  [FAIL] enclosing destroy-recreate if( not found');
+  process.exit(1);
+}
+// Insert after the ';' so the existing if-statement stays intact.
+code = code.slice(0, ifIdx + 1) + fastPath + code.slice(ifIdx + 1);
 fs.writeFileSync(p, code);
 console.log('  [OK] Fast-path injected before destroy-recreate');
 "; then
@@ -268,14 +283,25 @@ patch_menu_bar_default() {
 	fi
 	echo "  Found menuBarEnabled variable: $menu_bar_var"
 
-	# Change !!var to var!==false so undefined defaults to true
+	# Change !!var to var!==false so undefined defaults to true.
 	if grep -qP ",\s*!!${menu_bar_var}\s*\)" "$index_js"; then
 		sed -i -E \
 			"s/,\s*!!${menu_bar_var}\s*\)/,${menu_bar_var}!==false)/g" \
 			"$index_js"
 		echo '  Patched menuBarEnabled to default to true'
+	# Upstream 1.13576+ moved the preference behind a settings getter
+	# (Di("menuBarEnabled")) backed by a defaults map that already ships
+	# `menuBarEnabled:!0` (true). When that default is present this patch
+	# is a no-op by design — distinguish that from a genuine miss so a
+	# future default flip back to false surfaces instead of hiding.
+	elif grep -qP 'menuBarEnabled:\s*!0\b' "$index_js"; then
+		echo '  menuBarEnabled already defaults to true upstream' \
+			'(defaults map) — no patch needed'
 	else
-		echo '  menuBarEnabled pattern not found or already patched'
+		echo "WARNING: menuBarEnabled neither carries the legacy" \
+			"!!-default anchor nor the upstream defaults-map" \
+			"\`menuBarEnabled:!0\` — the tray may default OFF on a" \
+			"fresh install; the default shape likely changed" >&2
 	fi
 	echo '##############################################################'
 }

--- a/tests/tray-patches.bats
+++ b/tests/tray-patches.bats
@@ -1,0 +1,154 @@
+#!/usr/bin/env bats
+#
+# tray-patches.bats
+# Tests for scripts/patches/tray.sh — focused on patch_tray_inplace_update
+# (the in-place fast-path that dodges the #515 KDE duplicate-icon
+# StatusNotifier race) and patch_menu_bar_default.
+#
+# Regression guard for the 1.13576+ "yukonSilver"-era tray rebuild
+# refactor, which restructured the destroy/recreate block and switched
+# the context menu from an inline builder call to a prebuilt object,
+# while introducing a setContextMenu(null) menu-clear that a naive
+# head -1 latches onto. Both broke the fast-path silently (tray patches
+# warn-and-continue, so it shipped via green CI).
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+TRAY_SH="$SCRIPT_DIR/../scripts/patches/tray.sh"
+
+setup() {
+	TEST_TMP=$(mktemp -d)
+	export TEST_TMP
+
+	# The patch functions read/write a path relative to cwd.
+	index_js_dir="$TEST_TMP/app.asar.contents/.vite/build"
+	mkdir -p "$index_js_dir"
+	index_js="$index_js_dir/index.js"
+
+	# Globals the partial expects from build.sh.
+	project_root="$TEST_TMP"
+	electron_var='aA'
+	electron_var_re='aA'
+	export project_root electron_var electron_var_re
+
+	# shellcheck source=../scripts/patches/tray.sh
+	source "$TRAY_SH"
+}
+
+teardown() {
+	if [[ -n "${TEST_TMP:-}" && -d "$TEST_TMP" ]]; then
+		rm -rf "$TEST_TMP"
+	fi
+}
+
+# A minified fixture mirroring the 1.13576+ tray rebuild shape:
+#  - destroy/recreate guarded by `if(A9=[],e9=!1,vE&&(vE.destroy()...),!A)`
+#  - the menu is a *prebuilt object* `yh=S5A()`, set via setContextMenu(yh)
+#  - a decoy `setContextMenu(null)` menu-clear precedes the real call
+#  - menuBarEnabled read through a settings getter with a defaults map
+write_new_shape_fixture() {
+	cat > "$index_js" <<'JS'
+const aA=require("electron");
+function Di(k){return({menuBarEnabled:!0,legacyQuickEntryEnabled:!0})[k]}
+function S5A(){return aA.Menu.buildFromTemplate([{label:"Show App"},{label:"Quit"}])}
+function VIe(){return!1}
+function rebuild(){
+const A=Di("menuBarEnabled");if(VIe())return;let e;
+e=aA.nativeTheme.shouldUseDarkColors?"TrayIconTemplate-Dark.png":"TrayIconTemplate.png";
+const t=X.join(toi(),e),i=!xrt;
+if(A9=[],e9=!1,vE&&(vE.destroy(),vE=null),!A){JhA();return}
+vE=new aA.Tray(aA.nativeImage.createFromPath(t)),xrt=!0,vEA=!1,yh=S5A(),vE.on("click",()=>void Loi()),vE.on("right-click",()=>{WN()&&(vEA=!0,vE.setContextMenu(null)),(vEA||!yh)&&(yh=S5A(),vEA=!1),vE.popUpContextMenu(yh)}),WN()||(vE.setContextMenu(yh),e9=!0);
+}
+kd.on("menuBarEnabled",()=>{rebuild()});
+JS
+}
+
+@test "inplace: resolves the real menu builder, not the setContextMenu(null) decoy" {
+	write_new_shape_fixture
+	cd "$TEST_TMP"
+	run patch_tray_inplace_update
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -q 'Found menu function: S5A'
+	# The fast-path must call the builder, never null().
+	grep -qF 'vE.setContextMenu(S5A())' "$index_js"
+	! grep -qF 'setContextMenu(null())' "$index_js"
+}
+
+@test "inplace: fast-path lands before the destroy/recreate block and stays valid JS" {
+	write_new_shape_fixture
+	cd "$TEST_TMP"
+	run patch_tray_inplace_update
+	[[ "$status" -eq 0 ]]
+	# Fast-path returns before the destroy block runs.
+	grep -qF 'if(vE&&A!==false){vE.setImage(aA.nativeImage.createFromPath(t));' \
+		"$index_js"
+	local fp dr
+	fp=$(grep -boF 'vE.setImage(aA.nativeImage.createFromPath(t))' "$index_js" \
+		| head -1 | cut -d: -f1)
+	dr=$(grep -boF 'vE.destroy()' "$index_js" | head -1 | cut -d: -f1)
+	[[ -n "$fp" && -n "$dr" && "$fp" -lt "$dr" ]]
+	node --check "$index_js"
+}
+
+@test "inplace: idempotent — second run is a no-op and keeps valid JS" {
+	write_new_shape_fixture
+	cd "$TEST_TMP"
+	patch_tray_inplace_update
+	run patch_tray_inplace_update
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -q 'already present (idempotent)'
+	[[ "$(grep -cF 'vE.setImage(aA.nativeImage.createFromPath(t))' \
+		"$index_js")" -eq 1 ]]
+	node --check "$index_js"
+}
+
+@test "inplace: missing TRAY.destroy() site is a loud failure, not a silent skip" {
+	# A bundle with a context menu but no destroy/recreate block: the
+	# resolver succeeds but the injection anchor is gone — must exit non-zero.
+	cat > "$index_js" <<'JS'
+const aA=require("electron");
+function S5A(){return aA.Menu.buildFromTemplate([])}
+function rebuild(){
+const A=Di("menuBarEnabled");
+const t=X.join(toi(),e);
+vE=new aA.Tray(aA.nativeImage.createFromPath(t)),yh=S5A(),vE.setContextMenu(yh);
+}
+kd.on("menuBarEnabled",()=>{rebuild()});
+JS
+	cd "$TEST_TMP"
+	run patch_tray_inplace_update
+	[[ "$status" -ne 0 ]]
+	echo "$output" | grep -q 'destroy'
+}
+
+@test "menu-bar-default: recognizes the upstream defaults map as already-true" {
+	write_new_shape_fixture
+	cd "$TEST_TMP"
+	run patch_menu_bar_default
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -q 'already defaults to true upstream'
+}
+
+@test "menu-bar-default: still rewrites the legacy !!var shape" {
+	cat > "$index_js" <<'JS'
+const aA=require("electron");
+const A=Di("menuBarEnabled");
+const cfg=mk({tray:1},!!A);
+JS
+	cd "$TEST_TMP"
+	run patch_menu_bar_default
+	[[ "$status" -eq 0 ]]
+	grep -qF ',A!==false)' "$index_js"
+	! grep -qF ',!!A)' "$index_js"
+}
+
+@test "menu-bar-default: warns when neither legacy anchor nor upstream default exists" {
+	cat > "$index_js" <<'JS'
+const aA=require("electron");
+const A=Di("menuBarEnabled");
+const cfg=mk({tray:1},A);
+JS
+	cd "$TEST_TMP"
+	run patch_menu_bar_default
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -qi 'WARNING'
+}

--- a/tests/tray-patches.bats
+++ b/tests/tray-patches.bats
@@ -120,6 +120,19 @@ JS
 	echo "$output" | grep -q 'destroy'
 }
 
+@test "inplace: ambiguous TRAY.destroy() (two sites) is a loud failure" {
+	# Two destroy sites: indexOf would mis-place the injection. The
+	# count==1 guard must bail rather than trust the first hit.
+	write_new_shape_fixture
+	cat >> "$index_js" <<'JS'
+function teardownAgain(){vE.destroy();}
+JS
+	cd "$TEST_TMP"
+	run patch_tray_inplace_update
+	[[ "$status" -ne 0 ]]
+	echo "$output" | grep -qiE 'expected exactly 1|found 2'
+}
+
 @test "menu-bar-default: recognizes the upstream defaults map as already-true" {
 	write_new_shape_fixture
 	cd "$TEST_TMP"


### PR DESCRIPTION
The "yukonSilver"-era refactor (1.13576+, verified against 1.15962.0)
restructured the tray rebuild block in two ways that silently broke
patch_tray_inplace_update:

  - The destroy/recreate guard became
    `if(X=[],Y=!1,TRAY&&(TRAY.destroy()...),!enabled)` instead of the
    old `;if(TRAY&&(TRAY.destroy()`, so the injection anchor missed.
  - The context menu is now a prebuilt object
    (`M=BUILDER();TRAY.setContextMenu(M)`), and the *first* setContextMenu
    call site is a `setContextMenu(null)` menu-clear. The resolver's
    `head -1` latched that `null`, so the builder never resolved, the
    #680 WARNING fired, and the fast-path was skipped — re-arming the
    #515 KDE/Plasma duplicate-icon StatusNotifier race. Tray patches
    warn-and-continue, so this shipped through green CI.

Fixes:
  - Menu-function resolver walks every setContextMenu argument, skips the
    `null` clear, and takes the first that resolves to a VAR=BUILDER()
    assignment.
  - Injection switched from a backslash-heavy regex anchor to locating
    TRAY.destroy() and walking back to the `;if(` that opens its
    statement, landing correctly in both the old and new shapes.
  - patch_menu_bar_default now recognizes that upstream defaults
    menuBarEnabled to true via its defaults map (`menuBarEnabled:!0`), so
    the legacy !!-rewrite is a no-op by design rather than a bare miss;
    it warns loudly only if neither shape is present.

Adds tests/tray-patches.bats (7 cases): builder resolution past the null
decoy, injection placement before the destroy block + valid JS,
idempotency, loud-fail on a missing destroy site, and the three
menu-bar-default branches. Full suite 329/329.

Verified end-to-end against the real 1.15962.0 app.asar. Runtime
confirmation of the #515 race avoidance still needs a KDE Plasma host.

Co-Authored-By: Claude <claude@anthropic.com>