### PR TITLE
fix(tray): route icon format to png on Linux — fixes black-square tray icon (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- The system tray / menu-bar icon no longer shows as a black square (or an invisible/empty icon) on Linux. Upstream 1.13576+ replaced the runtime platform check for the tray icon *format* with a build-time constant baked for Windows (`uPi="ico"`) routed through `switch(uPi){case"ico":…Tray-Win32.ico…;case"png":…TrayIconTemplate…}`. Because the project repackages the Windows asar verbatim, Linux kept loading the Windows multi-resolution `.ico`, which Electron's `nativeImage` renders as a black square on the freedesktop/KDE StatusNotifier. The existing icon patch was silently rewriting the now-dead `template-image`/`png` case while the live `"ico"` case stayed broken. `patch_tray_icon_selection` now wraps the switch discriminant (`switch(process.platform==="linux"?"png":uPi)`) so Linux takes the already-theme-aware `"png"` case, which selects the `TrayIconTemplate[-Dark].png` assets the build ships and processes for visibility. ([#746](https://github.com/aaddrick/claude-desktop-debian/issues/746))
+
 ## [v2.0.22] — 2026-06-25
 
 Tracks upstream Claude Desktop 1.15200.0.

--- a/scripts/patches/tray.sh
+++ b/scripts/patches/tray.sh
@@ -71,18 +71,59 @@ patch_tray_menu_handler() {
 }
 
 patch_tray_icon_selection() {
-	echo 'Patching tray icon selection for Linux visibility...'
+	echo 'Patching tray icon format selection for Linux visibility...'
 	local index_js='app.asar.contents/.vite/build/index.js'
-	local dark_check="${electron_var_re}.nativeTheme.shouldUseDarkColors"
 
-	if grep -qP ':[$\w]+="TrayIconTemplate\.png"' "$index_js"; then
-		sed -i -E \
-			"s/:([[:alnum:]_\$]+)=\"TrayIconTemplate\.png\"/:\1=${dark_check}?\"TrayIconTemplate-Dark.png\":\"TrayIconTemplate.png\"/g" \
-			"$index_js"
-		echo 'Patched tray icon selection for Linux theme support'
-	else
-		echo 'Tray icon selection pattern not found or already patched'
+	# Upstream 1.13576+ bakes the tray icon *format* as a build-time
+	# constant set for the Windows build (`uPi="ico"`) and routes it
+	# through a switch:
+	#   switch(uPi){
+	#     case"ico": e=dark?"Tray-Win32-Dark.ico":"Tray-Win32.ico"; break;
+	#     case"template-image": e="TrayIconTemplate.png"; break;
+	#     case"png": e=dark?"TrayIconTemplate-Dark.png":"TrayIconTemplate.png";
+	#   }
+	# Because we repackage the Windows asar verbatim, that constant stays
+	# "ico" on Linux, so the tray loads the Windows multi-resolution
+	# `.ico`, which Electron's nativeImage renders as a black square on the
+	# freedesktop/KDE StatusNotifier (issue #746). The "png" case already
+	# selects the theme-aware PNG templates the build ships and processes
+	# for Linux visibility (TrayIconTemplate[-Dark].png, made opaque in
+	# scripts/staging/icons.sh) — so the fix is to route Linux to that
+	# case rather than re-deriving the icon names.
+	#
+	# Anchor on the stable `switch(VAR){case"ico":` shape: the case labels
+	# are developer strings that survive minification; VAR (`uPi`) is
+	# extracted dynamically, never hardcoded. Non-fatal — on a miss the
+	# tray may show the wrong icon but the app still runs — so warn loudly
+	# instead of exiting, matching the rest of the tray patch set.
+
+	# Idempotency: our wrapped discriminant is its own marker.
+	if grep -qF 'switch(process.platform==="linux"?"png":' "$index_js"; then
+		echo '  Tray icon format already routed to png on Linux'
+		echo '##############################################################'
+		return
 	fi
+
+	local sw_count sw_var sw_var_re
+	sw_count=$(grep -coP 'switch\([$\w]+\)\{case"ico":' "$index_js")
+	if [[ $sw_count -ne 1 ]]; then
+		echo "WARNING: expected exactly 1 tray icon-format switch" \
+			"(switch(VAR){case\"ico\":), found ${sw_count} — the Linux" \
+			"tray icon may render as a black square (#746); the" \
+			"icon-format switch shape likely changed" >&2
+		echo '##############################################################'
+		return
+	fi
+	sw_var=$(grep -oP 'switch\(\K[$\w]+(?=\)\{case"ico":)' "$index_js" \
+		| head -1)
+	echo "  Found icon-format switch var: $sw_var"
+
+	# Escape `$` for the sed pattern (minified names can be e.g. `u$i`).
+	sw_var_re="${sw_var//\$/\\$}"
+	sed -i -E \
+		"s/switch\(${sw_var_re}\)\{case\"ico\":/switch(process.platform===\"linux\"?\"png\":${sw_var}){case\"ico\":/" \
+		"$index_js"
+	echo '  Routed tray icon format to png on Linux'
 	echo '##############################################################'
 }
 

--- a/tests/tray-icon-format.bats
+++ b/tests/tray-icon-format.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+#
+# tray-icon-format.bats
+# Tests for patch_tray_icon_selection in scripts/patches/tray.sh — the
+# fix that routes the tray icon *format* to the PNG case on Linux.
+#
+# Regression guard for #746: upstream 1.13576+ bakes the icon format as a
+# build-time constant (uPi="ico") and routes it through
+#   switch(uPi){case"ico":…Tray-Win32.ico…;case"png":…TrayIconTemplate…}
+# Since we repackage the Windows asar, that constant stays "ico" on Linux,
+# so the tray loads the Windows .ico and renders as a black square on the
+# freedesktop/KDE StatusNotifier. The patch wraps the switch discriminant
+# so Linux takes the already-theme-aware "png" case.
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
+TRAY_SH="$SCRIPT_DIR/../scripts/patches/tray.sh"
+
+setup() {
+	TEST_TMP=$(mktemp -d)
+	export TEST_TMP
+
+	index_js_dir="$TEST_TMP/app.asar.contents/.vite/build"
+	mkdir -p "$index_js_dir"
+	index_js="$index_js_dir/index.js"
+
+	project_root="$TEST_TMP"
+	electron_var='aA'
+	electron_var_re='aA'
+	export project_root electron_var electron_var_re
+
+	# shellcheck source=../scripts/patches/tray.sh
+	source "$TRAY_SH"
+}
+
+teardown() {
+	if [[ -n "${TEST_TMP:-}" && -d "$TEST_TMP" ]]; then
+		rm -rf "$TEST_TMP"
+	fi
+}
+
+# Minified fixture mirroring the 1.13576+ icon-format switch: a baked
+# uPi="ico" constant, the three-case switch (Windows .ico / template /
+# theme-aware png), and the Tray creation that consumes the result.
+write_icon_switch_fixture() {
+	cat > "$index_js" <<'JS'
+const aA=require("electron");
+const gPi=!0,lPi=36,uPi="ico",IPi=!0;
+function rebuild(){
+let e;switch(uPi){case"ico":e=aA.nativeTheme.shouldUseDarkColors?"Tray-Win32-Dark.ico":"Tray-Win32.ico";break;case"template-image":e="TrayIconTemplate.png";break;case"png":e=aA.nativeTheme.shouldUseDarkColors?"TrayIconTemplate-Dark.png":"TrayIconTemplate.png";break}
+const t=X.join(toi(),e);
+vE=new aA.Tray(aA.nativeImage.createFromPath(t));
+}
+JS
+}
+
+@test "icon-format: routes the switch discriminant to png on Linux" {
+	write_icon_switch_fixture
+	cd "$TEST_TMP"
+	run patch_tray_icon_selection
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -q 'Found icon-format switch var: uPi'
+	grep -qF 'switch(process.platform==="linux"?"png":uPi){case"ico":' \
+		"$index_js"
+	node --check "$index_js"
+}
+
+@test "icon-format: the routed-to png case still selects the theme-aware PNG" {
+	write_icon_switch_fixture
+	cd "$TEST_TMP"
+	patch_tray_icon_selection
+	# The case Linux now lands on must keep the dark/light PNG template
+	# selection — i.e. the fix is inert if the png case lost it.
+	grep -qF 'case"png":e=aA.nativeTheme.shouldUseDarkColors?"TrayIconTemplate-Dark.png":"TrayIconTemplate.png"' \
+		"$index_js"
+}
+
+@test "icon-format: idempotent — second run is a no-op" {
+	write_icon_switch_fixture
+	cd "$TEST_TMP"
+	patch_tray_icon_selection
+	run patch_tray_icon_selection
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -q 'already routed to png on Linux'
+	[[ "$(grep -coF 'process.platform==="linux"?"png":' "$index_js")" -eq 1 ]]
+	node --check "$index_js"
+}
+
+@test "icon-format: warns and skips when the switch shape is absent" {
+	cat > "$index_js" <<'JS'
+const aA=require("electron");
+function rebuild(){const e="TrayIconTemplate.png";vE=new aA.Tray(aA.nativeImage.createFromPath(e));}
+JS
+	cd "$TEST_TMP"
+	run patch_tray_icon_selection
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -qi 'WARNING'
+	# Must not have injected a bogus discriminant.
+	! grep -qF 'process.platform==="linux"?"png":' "$index_js"
+}
+
+@test "icon-format: warns when more than one icon-format switch exists" {
+	write_icon_switch_fixture
+	cat >> "$index_js" <<'JS'
+function other(){switch(zZ){case"ico":e=1;break}}
+JS
+	cd "$TEST_TMP"
+	run patch_tray_icon_selection
+	[[ "$status" -eq 0 ]]
+	echo "$output" | grep -qiE 'expected exactly 1|found 2'
+	! grep -qF 'process.platform==="linux"?"png":' "$index_js"
+}


### PR DESCRIPTION
Fixes #746 (and the on-device black-square repro on Nobara KDE).

## Problem

The system tray / menu-bar icon renders as a **black square** (or invisible/empty) on Linux since the upstream 1.13576+ refactor.

Upstream replaced the runtime platform check for the tray icon *format* with a build-time constant baked for the **Windows** build (`uPi="ico"`, part of a `gPi=!0,lPi=36,uPi="ico",IPi=!0,EPi="registry"` constant block), routed through:

```js
switch(uPi){                                          // uPi === "ico" — never reassigned by platform
  case"ico":            e=dark?"Tray-Win32-Dark.ico":"Tray-Win32.ico"; break;   // ← Linux lands here
  case"template-image": e="TrayIconTemplate.png"; break;
  case"png":            e=dark?"TrayIconTemplate-Dark.png":"TrayIconTemplate.png"; break;
}
```

Because the project repackages the Windows asar verbatim, that constant stays `"ico"` on Linux, so the tray loads the Windows multi-resolution `Tray-Win32.ico`. Electron's `nativeImage.createFromPath` on a Windows `.ico` renders as a **black square** on the freedesktop/KDE StatusNotifier.

## Why it slipped through

`patch_tray_icon_selection` anchored on `:VAR="TrayIconTemplate.png"`, which now matches the **`template-image` case** — a **dead branch** on Linux (the live case is `"ico"`). So the patch logged green while the icon stayed broken. Same silent-no-op class as the other 1.13576+ tray regressions (the build's tray patches warn-and-continue).

## Fix

Route Linux to the already-theme-aware `"png"` case by wrapping the switch discriminant:

```js
switch(process.platform==="linux"?"png":uPi){case"ico":…
```

The `"png"` case already does `dark?"TrayIconTemplate-Dark.png":"TrayIconTemplate.png"`, and the build already ships + processes those PNG templates for Linux visibility (`scripts/staging/icons.sh` binarizes their alpha). No icon-name re-derivation needed.

Per `docs/learnings/patching-minified-js.md`:
- **Literal anchor** — `switch(VAR){case"ico":`; the `case` labels are developer strings that survive minification, the discriminant (`uPi`) is extracted dynamically, never hardcoded.
- **Uniqueness asserted** — bails with a loud warning if the switch count isn't exactly 1.
- **Idempotent** — the wrapped discriminant is its own marker.
- **Non-fatal** — a miss warns (icon may be wrong) but doesn't abort the build.

## Tests

New `tests/tray-icon-format.bats` (5 cases): discriminant routing, theme-aware `png` case preserved, idempotency, warn-and-skip on a missing switch, and warn on an ambiguous (>1) switch. Full suite green.

## Verification

Verified end-to-end against the real **1.15962.0** `app.asar` (SHA-checked against the `detect-host.sh` pin): the patch wraps exactly one switch, output passes `node --check`, and Linux now selects `TrayIconTemplate.png`/`-Dark.png`.

**Runtime confirmation on a black-square host is still welcome** — the static layers can't see the rendered StatusNotifier.

## Relationship to #751

Independent of #751 (which fixes the duplicate-icon *race*). This one is the actual #746 black-square fix, and is a prerequisite for meaningfully testing #751 — you can't observe an in-place icon swap when the icon is a black square. Both touch `tray.sh` but different functions; they should merge cleanly.

---
Generated with [Claude Code](https://claude.ai/code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q54GPhun4M91hja2T9Gw8G)_