### PR TITLE
test(#771): artifact exec-bit assert for bundled virtiofsd + _cowork_incomplete coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Changed
+
+- The artifact tests now assert that Cowork's bundled `resources/virtiofsd` is present and executable in every package format: the [#771](https://github.com/aaddrick/claude-desktop-debian/issues/771) un-gate makes it the universal fallback and the client resolves it with `X_OK`, so a repack that drops the exec bit would silently kill Cowork on hosts without a client-probed system virtiofsd. The doctor's virtiofsd probe tests also grew coverage for the `_cowork_incomplete` readiness flag (the WARN branches were previously unasserted — `run` subshells discard the mutation), the client-path-over-bundled precedence, and the mode-stripped bundled copy falling through to WARN. ([#774](https://github.com/aaddrick/claude-desktop-debian/pull/774))
+
 ## [v3.0.1] — 2026-07-05
 
 ### Added

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -1013,7 +1013,6 @@ _stub_vfsd() {
 @test "_check_cowork_virtiofsd: client-probed path passes" {
 	_stub_vfsd "$TEST_TMP/usr/libexec/virtiofsd"
 	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/usr/libexec/virtiofsd"
-	_cowork_incomplete=false
 	run _check_cowork_virtiofsd debian ''
 	[[ $output == *'[PASS]'* ]]
 	[[ $output == *'client-probed path'* ]]
@@ -1023,7 +1022,6 @@ _stub_vfsd() {
 	_stub_vfsd "$TEST_TMP/resources/virtiofsd"
 	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/nonexistent"
 	export _COWORK_VFSD_PATHS="$TEST_TMP/nonexistent"
-	_cowork_incomplete=false
 	run _check_cowork_virtiofsd debian "$TEST_TMP/resources"
 	[[ $output == *'[PASS]'* ]]
 	[[ $output == *'bundled copy'* ]]
@@ -1033,7 +1031,6 @@ _stub_vfsd() {
 	_stub_vfsd "$TEST_TMP/usr/lib/virtiofsd"
 	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/nonexistent"
 	export _COWORK_VFSD_PATHS="$TEST_TMP/usr/lib/virtiofsd"
-	_cowork_incomplete=false
 	run _check_cowork_virtiofsd arch ''
 	[[ $output == *'[WARN]'* ]]
 	[[ $output == *'the client only'* ]]
@@ -1043,7 +1040,6 @@ _stub_vfsd() {
 @test "_check_cowork_virtiofsd: not found anywhere warns with package hint" {
 	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/nonexistent"
 	export _COWORK_VFSD_PATHS="$TEST_TMP/nonexistent"
-	_cowork_incomplete=false
 	run _check_cowork_virtiofsd arch ''
 	[[ $output == *'[WARN]'* ]]
 	[[ $output == *'virtiofsd: not found'* ]]
@@ -1055,7 +1051,62 @@ _stub_vfsd() {
 	printf 'x' > "$TEST_TMP/usr/libexec/virtiofsd"
 	chmod 444 "$TEST_TMP/usr/libexec/virtiofsd"
 	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/usr/libexec/virtiofsd"
-	_cowork_incomplete=false
 	run _check_cowork_virtiofsd debian ''
 	[[ $output == *'[PASS]'* ]]
+}
+
+@test "_check_cowork_virtiofsd: client-probed path preferred over bundled copy" {
+	_stub_vfsd "$TEST_TMP/usr/bin/virtiofsd"
+	_stub_vfsd "$TEST_TMP/resources/virtiofsd"
+	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/usr/bin/virtiofsd"
+	run _check_cowork_virtiofsd debian "$TEST_TMP/resources"
+	[[ $output == *'client-probed path'* ]]
+	[[ $output != *'bundled copy'* ]]
+}
+
+@test "_check_cowork_virtiofsd: bundled copy without exec bit does not pass (X_OK, like the client)" {
+	# The client resolves the bundled copy with X_OK; a mode-stripped
+	# resources/virtiofsd must fall through to WARN, not PASS.
+	mkdir -p "$TEST_TMP/resources"
+	printf 'x' > "$TEST_TMP/resources/virtiofsd"
+	chmod 644 "$TEST_TMP/resources/virtiofsd"
+	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/nonexistent"
+	export _COWORK_VFSD_PATHS="$TEST_TMP/nonexistent"
+	run _check_cowork_virtiofsd debian "$TEST_TMP/resources"
+	[[ $output == *'[WARN]'* ]]
+	[[ $output == *'virtiofsd: not found'* ]]
+}
+
+# The _cowork_incomplete flag feeds run_doctor's Cowork readiness
+# summary. These tests call the helper DIRECTLY — `run` executes in a
+# subshell, so a flag mutation there is invisible to the test shell
+# and can never be asserted (output goes to a file to keep bats logs
+# clean).
+
+@test "_check_cowork_virtiofsd: PASS leaves _cowork_incomplete false" {
+	_stub_vfsd "$TEST_TMP/usr/libexec/virtiofsd"
+	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/usr/libexec/virtiofsd"
+	_cowork_incomplete=false
+	_check_cowork_virtiofsd debian '' > "$TEST_TMP/out"
+	[[ $_cowork_incomplete == false ]]
+	grep -q 'client-probed path' "$TEST_TMP/out"
+}
+
+@test "_check_cowork_virtiofsd: non-probed-path WARN flips _cowork_incomplete" {
+	_stub_vfsd "$TEST_TMP/usr/lib/virtiofsd"
+	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/nonexistent"
+	export _COWORK_VFSD_PATHS="$TEST_TMP/usr/lib/virtiofsd"
+	_cowork_incomplete=false
+	_check_cowork_virtiofsd arch '' > "$TEST_TMP/out"
+	[[ $_cowork_incomplete == true ]]
+	grep -q 'the client only' "$TEST_TMP/out"
+}
+
+@test "_check_cowork_virtiofsd: not-found WARN flips _cowork_incomplete" {
+	export _COWORK_VFSD_CLIENT_PATHS="$TEST_TMP/nonexistent"
+	export _COWORK_VFSD_PATHS="$TEST_TMP/nonexistent"
+	_cowork_incomplete=false
+	_check_cowork_virtiofsd arch '' > "$TEST_TMP/out"
+	[[ $_cowork_incomplete == true ]]
+	grep -q 'virtiofsd: not found' "$TEST_TMP/out"
 }

--- a/tests/test-artifact-common.sh
+++ b/tests/test-artifact-common.sh
@@ -96,6 +96,19 @@ validate_app_contents() {
 		fail 'Unpacked: node-pty prebuild missing'
 	fi
 
+	# Cowork's bundled virtiofsd: the #771 un-gate patch makes it the
+	# universal fallback, and the client resolves it with X_OK — a
+	# repack that drops the exec bit silently kills Cowork on every
+	# host without a client-probed system virtiofsd (the mode-loss
+	# trap in docs/learnings/packaging-permissions.md).
+	if [[ -x $resources_dir/virtiofsd ]]; then
+		pass 'Bundled virtiofsd present and executable'
+	elif [[ -e $resources_dir/virtiofsd ]]; then
+		fail 'Bundled virtiofsd present but not executable'
+	else
+		fail 'Bundled virtiofsd missing from resources/'
+	fi
+
 	# Extract app.asar for deeper inspection if tools available
 	local extract_dir
 	extract_dir=$(mktemp -d)


### PR DESCRIPTION
## What

The two test follow-ups promised in the [#773 post-merge review](https://github.com/aaddrick/claude-desktop-debian/pull/773#issuecomment-4888320969).

## Why

**Artifact exec-bit tripwire.** The #771 un-gate makes `resources/virtiofsd` the universal fallback, and the client resolves it with `X_OK`. A repack that drops the exec bit (the mode-loss trap in `docs/learnings/packaging-permissions.md`) would silently kill Cowork on every host without a client-probed system virtiofsd — with all artifact tests green. `validate_app_contents` now asserts the bundled copy is present and executable, covering deb, rpm, and AppImage through the shared helper.

**`_cowork_incomplete` coverage.** The five #773 doctor tests set `_cowork_incomplete=false` before `run`, but `run` executes in a subshell, so those assignments were dead code and the WARN branches' flag flip (which feeds the Cowork readiness summary) was never asserted. The dead assignments are removed; new tests call the helper directly (output to a file) and assert the flag for both WARN branches plus a PASS-leaves-false guard. Also added: client-path-over-bundled precedence, and a mode-stripped bundled copy falling through to WARN instead of PASSing.

## Testing

- doctor.bats 75 → 80; full suite 184/0. Shellcheck clean.
- Both new guards are mutation-tested: the artifact assert was run against the real official 1.18286.0 resources tree (PASS), then with the exec bit stripped and with the file removed (both FAIL); removing `_cowork_incomplete=true` from the helper fails exactly the two flag tests.
