### PR TITLE
fix(launcher): bound the GPU-recovery scan and rotate launcher.log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- The launcher no longer hangs at startup on a large `launcher.log`. The pre-launch GPU-recovery check (`_previous_launch_hit_gpu_fatal`) accumulated each log section into an awk string, which is O(n²) in the size of the largest section — one GPU-crash-looping session could grow a single section to megabytes and make the check take minutes, blocking Electron from ever starting. The check is now a single-pass, constant-memory scan that tracks only the previous section's crash-signature flags, and `setup_logging` now rotates `launcher.log` when it exceeds 5 MB (keeping 2 old copies under `~/.cache/claude-desktop-debian/`) so it can't grow without bound across sessions. Retires the unbounded-growth half of [#582](https://github.com/aaddrick/claude-desktop-debian/issues/582) (the journald-flood half stays open pending a 3.x retest). ([#747](https://github.com/aaddrick/claude-desktop-debian/issues/747))
+
 ## [v3.1.0] — 2026-07-10
 
 ### Added

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -6,12 +6,38 @@
 # @@WM_CLASS@@ is replaced at build time; see build.sh.
 readonly WM_CLASS='@@WM_CLASS@@'
 
+# Rotate launcher.log when it exceeds a size cap, keeping a couple of
+# old copies. Runs at the start of each launch, before the session
+# header is written, so _previous_launch_hit_gpu_fatal always scans a
+# bounded file and the log can't grow without bound across sessions
+# (#747). Every branch returns 0 -- rotation must never block launch.
+# $log_file must already be set (setup_logging runs before this).
+rotate_log_file() {
+	[[ -n ${log_file:-} && -f $log_file ]] || return 0
+
+	# 5 MiB aligns with doctor.sh's existing launcher.log size warning.
+	local max_bytes=$((5 * 1024 * 1024))
+	local keep=2 size i
+
+	size=$(stat -c '%s' "$log_file" 2>/dev/null) || return 0
+	[[ $size =~ ^[0-9]+$ ]] || return 0
+	((size > max_bytes)) || return 0
+
+	for (( i = keep - 1; i >= 1; i-- )); do
+		[[ -f "$log_file.$i" ]] && \
+			mv -f "$log_file.$i" "$log_file.$((i + 1))" 2>/dev/null
+	done
+	mv -f "$log_file" "$log_file.1" 2>/dev/null || return 0
+}
+
 # Setup logging directory and file
 # Sets: log_dir, log_file
 setup_logging() {
 	log_dir="${XDG_CACHE_HOME:-$HOME/.cache}/claude-desktop-debian"
 	mkdir -p "$log_dir" || return 1
 	log_file="$log_dir/launcher.log"
+	rotate_log_file
+	return 0
 }
 
 # Log a message to the log file
@@ -143,31 +169,59 @@ check_display() {
 # Section headers vary by package format: deb/rpm write "Launcher
 # Start", AppImage writes "AppImage Start", and Nix writes "Launcher
 # Start (NixOS)" (nix/claude-desktop.nix).
+#
+# Single-pass, constant-memory scan (#747): no section text is ever
+# accumulated. Three crash-signature booleans are tracked for the
+# section currently being read (cur_*); on each header line the
+# just-finished section's flags shift into prev_*, so at EOF prev_*
+# always holds the *penultimate* section's flags -- the same target
+# the old string-accumulating version selected via section-1. This
+# fixes the O(n^2) cost of growing an awk string per line: the cost
+# was dominated by the largest single section, not the number of
+# sections -- a GPU-crash-looping session can spew megabytes into one
+# section, and that giant section was re-scanned on every subsequent
+# launch, hanging the launcher before Electron ever started.
 _previous_launch_hit_gpu_fatal() {
 	[[ -f ${log_file:-} ]] || return 1
 
 	awk '
 		/^--- Claude Desktop (Launcher|AppImage) Start( \(NixOS\))? ---$/ {
 			section++
+			prev_failed = cur_failed
+			prev_notusable = cur_notusable
+			prev_prevfatal = cur_prevfatal
+			cur_failed = 0
+			cur_notusable = 0
+			cur_prevfatal = 0
 			next
 		}
 		{
-			sections[section] = sections[section] $0 "\n"
+			if (index($0,
+				"GPU process launch failed: error_code=")) {
+				cur_failed = 1
+			}
+			if (index($0,
+				"GPU process isn'\''t usable. Goodbye.")) {
+				cur_notusable = 1
+			}
+			if (index($0,
+				"Previous launch hit GPU process FATAL")) {
+				cur_prevfatal = 1
+			}
 		}
 		END {
-			target = section > 1 ? section - 1 : section
-			if (target < 1) {
+			if (section >= 2) {
+				t_failed = prev_failed
+				t_notusable = prev_notusable
+				t_prevfatal = prev_prevfatal
+			} else if (section == 1) {
+				t_failed = cur_failed
+				t_notusable = cur_notusable
+				t_prevfatal = cur_prevfatal
+			} else {
 				exit 1
 			}
-			text = sections[target]
-			if (index(text,
-				"GPU process launch failed: error_code=") &&
-				index(text,
-				"GPU process isn'\''t usable. Goodbye.")) {
-				exit 0
-			}
-			if (index(text,
-				"Previous launch hit GPU process FATAL")) {
+			if ((t_failed && t_notusable) || t_prevfatal) {
 				exit 0
 			}
 			exit 1

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -95,6 +95,69 @@ teardown() {
 }
 
 # =============================================================================
+# rotate_log_file / setup_logging rotation (#747)
+# =============================================================================
+
+@test "rotation: log under cap is left untouched" {
+	setup_logging
+	printf 'small log content\n' > "$log_file"
+
+	rotate_log_file
+
+	[[ -f $log_file ]]
+	[[ $(cat "$log_file") == 'small log content' ]]
+	[[ ! -f "$log_file.1" ]]
+}
+
+@test "rotation: log over cap moves to .1 and clears live file" {
+	setup_logging
+	printf 'LIVE' > "$log_file"
+	truncate -s 6M "$log_file"
+
+	rotate_log_file
+
+	[[ ! -f $log_file ]]
+	[[ -f "$log_file.1" ]]
+	[[ $(head -c 4 "$log_file.1") == 'LIVE' ]]
+}
+
+@test "rotation: keeps at most 2 old copies, drops oldest" {
+	setup_logging
+	printf 'OLD1' > "$log_file.1"
+	printf 'OLD2' > "$log_file.2"
+	printf 'LIVE' > "$log_file"
+	truncate -s 6M "$log_file"
+
+	rotate_log_file
+
+	[[ $(head -c 4 "$log_file.1") == 'LIVE' ]]
+	[[ $(head -c 4 "$log_file.2") == 'OLD1' ]]
+	[[ ! -f "$log_file.3" ]]
+}
+
+@test "rotation: missing log file is a no-op returning 0" {
+	setup_logging
+	rm -f "$log_file"
+
+	run rotate_log_file
+
+	[[ $status -eq 0 ]]
+	[[ ! -f "$log_file.1" ]]
+}
+
+@test "setup_logging: still returns 0 after rotating an over-cap file" {
+	log_dir="$XDG_CACHE_HOME/claude-desktop-debian"
+	mkdir -p "$log_dir"
+	log_file="$log_dir/launcher.log"
+	truncate -s 6M "$log_file"
+
+	run setup_logging
+
+	[[ $status -eq 0 ]]
+	[[ -f "$log_file.1" ]]
+}
+
+# =============================================================================
 # log_message
 # =============================================================================
 

--- a/tests/launcher-disable-gpu.bats
+++ b/tests/launcher-disable-gpu.bats
@@ -211,3 +211,68 @@ LOG
 	run args_contain '--disable-gpu'
 	[[ "$status" -ne 0 ]]
 }
+
+# =============================================================================
+# Bounded scan on a large launcher.log (#747)
+# =============================================================================
+
+@test "disable-gpu: large single-section log scans without O(n^2) hang" {
+	# One ~12 MB section with no header markers at all. The O(n^2)
+	# string-accumulating awk took minutes-to-hours on input this size;
+	# the single-pass rewrite completes in well under the 5s ceiling.
+	{
+		echo '--- Claude Desktop Launcher Start ---'
+		awk 'BEGIN {
+			for (i = 0; i < 300000; i++)
+				print "chromium gpu spam " i
+		}'
+		echo '--- Claude Desktop Launcher Start ---'
+	} > "$log_file"
+
+	run timeout 5 bash -c \
+		"log_file='$log_file'; source '$LAUNCHER_COMMON'; \
+		_previous_launch_hit_gpu_fatal"
+
+	# 124 = timeout killed it (the O(n^2) hang); anything else means
+	# the scan returned in time.
+	[[ "$status" -ne 124 ]]
+}
+
+@test "disable-gpu: large penultimate section keeps sticky recovery marker" {
+	# The sticky marker is written near the TOP of a section by
+	# build_electron_args. A tail-bounded scan would drop it and
+	# silently re-enable GPU (crash/work/crash oscillation), so this
+	# locks in that the rewrite reads the whole section instead.
+	{
+		echo '--- Claude Desktop Launcher Start ---'
+		echo 'Previous launch hit GPU process FATAL - disabling GPU'
+		awk 'BEGIN {
+			for (i = 0; i < 150000; i++)
+				print "electron debug noise " i
+		}'
+		echo '--- Claude Desktop Launcher Start ---'
+	} > "$log_file"
+
+	build_electron_args deb
+
+	args_contain '--disable-gpu'
+	args_contain '--disable-software-rasterizer'
+}
+
+@test "disable-gpu: crash signature deep in a large penultimate section is still detected" {
+	{
+		echo '--- Claude Desktop Launcher Start ---'
+		awk 'BEGIN {
+			for (i = 0; i < 150000; i++)
+				print "electron debug noise " i
+		}'
+		echo 'GPU process launch failed: error_code=1002'
+		echo "GPU process isn't usable. Goodbye."
+		echo '--- Claude Desktop Launcher Start ---'
+	} > "$log_file"
+
+	build_electron_args deb
+
+	args_contain '--disable-gpu'
+	args_contain '--disable-software-rasterizer'
+}


### PR DESCRIPTION
## Problem

The launcher hangs at startup once `~/.cache/claude-desktop-debian/launcher.log`
grows large. Users on permanently-broken GPU hardware (the #583 crash-loop
signature) hit this hardest: a single session can spew megabytes of Chromium
GPU-fallback stderr into the log, and every subsequent launch then stalls
before Electron is ever `exec`'d.

## Root cause

Two independent defects, both required for the fix:

1. **O(n²) pre-launch scan.** `_previous_launch_hit_gpu_fatal()` in
   `scripts/launcher-common.sh` decides whether the last run crashed on the GPU
   (so this run should auto-`--disable-gpu`). It did so by accumulating every
   log line into a per-section awk string:

   ```awk
   { sections[section] = sections[section] $0 "\n" }
   ```

   awk string concatenation reallocates and copies the whole accumulator on
   every line, so the cost is **O(bytes²) in the largest single section** — not
   in the number of sessions. One GPU-crash-looping session that dumped
   megabytes into a single section made the check take minutes. Because
   `build_electron_args` calls this before Electron launches, that giant
   section blocked startup entirely, and it was re-scanned on every subsequent
   launch.

2. **No log rotation.** `setup_logging()` only did `mkdir -p`;
   `run_electron_and_cleanup` appends Electron stdout/stderr with
   `>> "$log_file"`. `launcher.log` grew without bound across sessions, so the
   giant section persisted and the O(n²) scan kept re-paying its cost.

## Fix

Launcher-only — no `app.asar` patch, `active_patches` untouched (D-002 /
patch-zero clean). Both changes live in `scripts/launcher-common.sh`, which is
sourced identically by `deb.sh`, `rpm.sh`, and `appimage.sh`.

**Half (a) — bounded, constant-memory scan.** The awk in
`_previous_launch_hit_gpu_fatal()` no longer accumulates any text. It tracks
three crash-signature booleans for the section currently being read (`cur_*`);
on each header line the just-finished section's flags shift into `prev_*`, so
at EOF `prev_*` always holds the *penultimate* section's flags — the exact
target the old `section - 1` selection picked. The section-header regex and
both detection rules (the `launch failed` + `isn't usable` pair, and the sticky
`Previous launch hit GPU process FATAL` marker) are unchanged. Result: O(n)
time, O(1) memory, identical target selection.

A `tail -c` cap was deliberately **rejected**: the anti-oscillation stickiness
marker is written near the **top** of a section by `build_electron_args`, so a
tail-bounded read would drop it on a large penultimate section and silently
re-enable the GPU (crash / work / crash oscillation on permanently-broken
hardware). A dedicated test locks this in.

**Half (b) — rotation.** A new `rotate_log_file()` helper, called as the last
step of `setup_logging()` (before the session header is written), moves
`launcher.log` to `.1`/`.2` once it exceeds 5 MiB, keeping 2 old copies. Every
branch returns 0 — rotation must never block launch. `stat` failure or a
non-numeric size is a no-op. This bounds cross-session growth so the scan
always sees a bounded file.

## Per-format scope

`deb.sh`, `rpm.sh`, and `appimage.sh` all source `launcher-common.sh` and call
`setup_logging` before their session header, so all three get both halves. The
**Nix** build (`nix/claude-desktop.nix`) uses `makeWrapper` directly and does
**not** source `launcher-common.sh`, so it has neither the bug nor the fix —
static analysis of the launch flow says the `(NixOS)` regex branch is dormant;
it is kept unchanged. Nothing changes on the Nix leg.

Rotation ordering was verified statically against all three launchers:
`setup_logging || exit 1` runs before the `log_message '--- … Start ---'`
header write (`deb.sh:118`→`129`, `rpm.sh:109`→`120`, `appimage.sh:82`→`98`),
so the current session's header is never rotated away — only prior sessions'
content moves to `.1`.

## Tests

`bats`, mutation-checked. Added 5 rotation cases to
`tests/launcher-common.bats` and 3 bounded-scan cases to
`tests/launcher-disable-gpu.bats`; the existing NixOS / stickiness / header-regex
cases stay green untouched.

```
$ bats tests/launcher-common.bats -f rotation
1..4
ok 1 rotation: log under cap is left untouched
ok 2 rotation: log over cap moves to .1 and clears live file
ok 3 rotation: keeps at most 2 old copies, drops oldest
ok 4 rotation: missing log file is a no-op returning 0
```

```
$ bats tests/launcher-disable-gpu.bats
1..13
...
ok 11 disable-gpu: large single-section log scans without O(n^2) hang
ok 12 disable-gpu: large penultimate section keeps sticky recovery marker
ok 13 disable-gpu: crash signature deep in a large penultimate section is still detected
```

The 12 MB single-section perf test runs under a 5-second `timeout` ceiling
(O(n²) on that input is minutes-to-hours; the rewrite finishes in well under a
second) and doubles as the "<1s / multi-MB completes fast" guard.

Full local suite is green (203 tests):

```
$ bats tests/*.bats
...
ok 203 local: XRDP_SESSION empty string — flags NOT added
```

`shellcheck scripts/launcher-common.sh` reports only the pre-existing
informational `SC1091` (the `doctor.sh` source at line 935 isn't directly
analyzable) — unrelated to this change. No workflow files touched, so
`actionlint` was not run.

**Mutation checks (run live, restored after):**

- Half (a): reverting the awk to `main`'s string-accumulating version makes the
  12 MB perf test fail at the 5 s timeout (`status 124`).
- Half (b): removing the `rotate_log_file` call from `setup_logging` makes
  `setup_logging: still returns 0 after rotating an over-cap file` fail (the
  rotation never happens, so `.1` is never created).

## Relationship to #582

Closing #747 retires the **unbounded-growth half of #582** — `launcher.log`
can no longer grow without bound across sessions. **#582 stays open** for its
journald-flood half, pending a 3.x retest.

## Notes for the maintainer

- `doctor.sh` still warns on the *live* `launcher.log` only, at >10 MB, and its
  `rm '$log_path'` hint doesn't mention the rotated `.1`/`.2` copies. With the
  5 MiB rotation cap the live file is normally ≤5 MiB, so that warn now mostly
  fires only for an in-session runaway. An optional one-line hint tweak
  (`rm '$log_path'*`) was left out to keep scope tight — flagged, not bundled.
- Intra-session runaway growth (a single crash-looping session spewing into
  `launcher.log` via `>>`) is out of scope: start-of-launch rotation bounds
  *cross-session* growth and fixes the reported *startup* hang. `doctor.sh`'s
  size warning remains the backstop for the in-session case.

Fixes #747

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
70% AI / 30% Human
Claude: root-cause verification, the bounded-scan rewrite and `rotate_log_file` helper, the bats suites, mutation checks, and this write-up (implementation Claude Sonnet 5; planning, gates, and final review Claude Opus 4.8; orchestration Claude Fable 5)
Human: issue triage, the root-cause handover brief, and final review + posting
