### PR TITLE
fix(build): re-point AU-1 tripwire to upstream's renamed updater marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 ### Fixed
 
+- Builds against upstream 1.19367.0 no longer fail on the AU-1
+  tripwire. Upstream renamed the Linux updater's disable reason from
+  `apt_channel_pending` to `managed_by_package_manager` — the APT
+  channel went live and Linux updates are now permanently delegated to
+  the package manager. The updater gate itself is unchanged (verified
+  against the official bundle: the constant-folded early-return,
+  `platformUnsupported:!0`, and the Linux `checkForUpdates` IPC stub
+  that just opens the download page all survive), so decision D-001
+  (`docs/decisions.md`) is unaffected and the tripwire anchor now
+  tracks the renamed literal.
 - The launcher no longer hangs at startup on a large `launcher.log`. The pre-launch GPU-recovery check (`_previous_launch_hit_gpu_fatal`) accumulated each log section into an awk string, which is O(n²) in the size of the largest section — one GPU-crash-looping session could grow a single section to megabytes and make the check take minutes, blocking Electron from ever starting. The check is now a single-pass, constant-memory scan that tracks only the previous section's crash-signature flags, and `setup_logging` now rotates `launcher.log` when it exceeds 5 MB (keeping 2 old copies under `~/.cache/claude-desktop-debian/`) so it can't grow without bound across sessions. Retires the unbounded-growth half of [#582](https://github.com/aaddrick/claude-desktop-debian/issues/582) (the journald-flood half stays open pending a 3.x retest). ([#747](https://github.com/aaddrick/claude-desktop-debian/issues/747))
 - `claude-desktop-unofficial` deb/RPM installs no longer fail with a
   file conflict on

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -57,10 +57,15 @@ active_patches=(
 # uncompressed) so the check also runs in patch-zero mode, where the
 # archive is never extracted.
 #
-#   apt_channel_pending — the official updater early-returns on this
-#     marker while the APT channel is pending (decision D-001). If it
-#     disappears, upstream turned on self-updating, which fights the
-#     package manager — the 2.x autoUpdater-noop question is live again.
+#   managed_by_package_manager — the telemetry reason inside the
+#     Linux build's constant-folded updater early-return ("[updater]
+#     Linux: in-app updater off (updates via apt)"). Renamed by
+#     upstream from apt_channel_pending in the 1.18286.2 → 1.19367.0
+#     window when the APT channel went live: Linux updates are now
+#     permanently the package manager's job (decision D-001). If it
+#     disappears, upstream rewrote that gate and may have turned on
+#     self-updating, which fights the package manager — the 2.x
+#     autoUpdater-noop question is live again.
 #   menuBarEnabled:!0   — the settings default that keeps the menu bar
 #     on. If it disappears, upstream flipped the default the deleted
 #     menuBar patch used to enforce.
@@ -70,9 +75,10 @@ active_patches=(
 _check_upstream_tripwires() {
 	local asar_path="$1"
 
-	if ! LC_ALL=C grep -aq 'apt_channel_pending' "$asar_path"; then
-		echo 'Tripwire (AU-1): "apt_channel_pending" is gone from the' \
-			'official bundle — upstream may have enabled the' \
+	if ! LC_ALL=C grep -aq 'managed_by_package_manager' "$asar_path"
+	then
+		echo 'Tripwire (AU-1): "managed_by_package_manager" is gone' \
+			'from the official bundle — upstream may have enabled the' \
 			'autoupdater. Re-evaluate before shipping (see' \
 			'docs/decisions.md D-001).' >&2
 		exit 1
@@ -86,7 +92,7 @@ _check_upstream_tripwires() {
 		exit 1
 	fi
 
-	echo 'Upstream tripwires clear (autoupdater pending, menu bar on)'
+	echo 'Upstream tripwires clear (updater off on Linux, menu bar on)'
 }
 
 # Read one field out of the asar's package.json without a full extract.

--- a/tests/app-asar.bats
+++ b/tests/app-asar.bats
@@ -1,9 +1,11 @@
 #!/usr/bin/env bats
 #
 # _check_upstream_tripwires (AU-1/MB-1): the build must fail loudly if
-# the official bundle stops shipping the autoupdater-pending marker or
-# the menu-bar-on default — the deleted 2.x patches used to WARN when
-# those anchors moved, and the tripwires replace that signal.
+# the official bundle stops shipping the Linux updater-off marker
+# (managed_by_package_manager, renamed from apt_channel_pending in the
+# 1.18286.2 → 1.19367.0 window) or the menu-bar-on default — the
+# deleted 2.x patches used to WARN when those anchors moved, and the
+# tripwires replace that signal.
 
 setup() {
 	source "$BATS_TEST_DIRNAME/../scripts/patches/app-asar.sh"
@@ -19,7 +21,7 @@ _write_bundle() {
 @test "tripwires: clear when both anchors are present (minified)" {
 	local bundle="$BATS_TEST_TMPDIR/app.asar"
 	_write_bundle "$bundle" \
-		'x={autoUpdater:"apt_channel_pending"}' \
+		'nt("desktop_update_disabled",{reason:"managed_by_package_manager"})' \
 		'y={menuBarEnabled:!0}'
 	run _check_upstream_tripwires "$bundle"
 	[[ $status -eq 0 ]]
@@ -29,13 +31,13 @@ _write_bundle() {
 @test "tripwires: clear with beautified whitespace around menuBarEnabled" {
 	local bundle="$BATS_TEST_TMPDIR/app.asar"
 	_write_bundle "$bundle" \
-		'x = { autoUpdater: "apt_channel_pending" }' \
+		'x = { reason: "managed_by_package_manager" }' \
 		'y = { menuBarEnabled: !0 }'
 	run _check_upstream_tripwires "$bundle"
 	[[ $status -eq 0 ]]
 }
 
-@test "tripwires: missing apt_channel_pending fails with AU-1" {
+@test "tripwires: missing managed_by_package_manager fails with AU-1" {
 	local bundle="$BATS_TEST_TMPDIR/app.asar"
 	_write_bundle "$bundle" 'y={menuBarEnabled:!0}'
 	run _check_upstream_tripwires "$bundle"
@@ -46,7 +48,7 @@ _write_bundle() {
 
 @test "tripwires: missing menuBarEnabled:!0 fails with MB-1" {
 	local bundle="$BATS_TEST_TMPDIR/app.asar"
-	_write_bundle "$bundle" 'x="apt_channel_pending"'
+	_write_bundle "$bundle" 'x="managed_by_package_manager"'
 	run _check_upstream_tripwires "$bundle"
 	[[ $status -eq 1 ]]
 	[[ $output == *'MB-1'* ]]
@@ -56,7 +58,7 @@ _write_bundle() {
 @test "tripwires: menuBarEnabled:!1 (default flipped off) fails with MB-1" {
 	local bundle="$BATS_TEST_TMPDIR/app.asar"
 	_write_bundle "$bundle" \
-		'x="apt_channel_pending"' \
+		'x="managed_by_package_manager"' \
 		'y={menuBarEnabled:!1}'
 	run _check_upstream_tripwires "$bundle"
 	[[ $status -eq 1 ]]


### PR DESCRIPTION
Fixes the repo-wide CI failure since the 1.19367.0 pin (fcfb72f): every build leg exits on the AU-1 tripwire because upstream dropped the `apt_channel_pending` string.

## What upstream actually changed

I extracted and diffed the official 1.18286.2 and 1.19367.0 bundles before touching the tripwire. The Linux updater gate is **unchanged in shape** — a constant-folded early-return that never reaches `setFeedURL`/`checkForUpdates` scheduling. Only the wording moved:

Before (1.18286.2):
```
D.info("[updater] Linux: in-app updater off (apt channel not yet live)"),Ye("desktop_update_disabled",{reason:"apt_channel_pending"});return
```

After (1.19367.0):
```
v.info("[updater] Linux: in-app updater off (updates via apt)"),nt("desktop_update_disabled",{reason:"managed_by_package_manager"});return
```

The "pending" framing is gone because the APT channel is live: Linux updates are now *permanently* the package manager's job. Corroborating evidence in the new bundle: the updater-status accessor hardcodes `platformUnsupported:!0`, the renderer-facing `checkForUpdates` IPC on Linux just opens the claude.ai download page, and the only path to a real `autoUpdater.checkForUpdates()` is gated behind an Ed25519-signature-verified `CLAUDE_UPDATER_TOKEN` env override (Anthropic-internal test hook, defaults inert). So **D-001 is strengthened, not threatened** — this is the anchor-rename case, not the updater-flip case.

## The fix

- AU-1 now greps for `managed_by_package_manager` — exactly 1 occurrence in the asar, inside the gate itself, so it disappears iff upstream rewrites that gate (same property the old anchor had, literals-over-identifiers per docs/learnings/patching-minified-js.md).
- Tripwire comment block documents the rename and window (1.18286.2 → 1.19367.0).
- `tests/app-asar.bats` fixtures updated to the new marker (using the real bundle's `desktop_update_disabled` shape); 5/5 green.
- CHANGELOG entry under [Unreleased] → Fixed.

## Verification

- Ran `_check_upstream_tripwires` against both real bundles: 1.19367.0 → `Upstream tripwires clear` rc=0; 1.18286.2 → fires AU-1 rc=1. The check is re-pointed, not weakened.
- MB-1 confirmed still matching in 1.19367.0 (`menuBarEnabled:!0`, 1 occurrence) — it won't fire next.
- Full bats sweep green; shellcheck delta vs main is zero; 80-col clean.

Unblocks CI for #744, #745, #781, #782 once merged.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
90% AI / 10% Human
Claude: bundle diff/investigation of both official .debs, anchor selection, tripwire+test+changelog edits, both-ways verification against real bundles
Human: direction, review