### PR TITLE
fix(triage): teach the prompt the resolvable reference-source citation form

### DIFF
--- a/.github/workflows/issue-triage-v2.yml
+++ b/.github/workflows/issue-triage-v2.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install Claude CLI
         # Version-pinned like the SHA-pinned actions above: this CLI
@@ -577,9 +577,10 @@ jobs:
             echo "  - /tmp/ref-source/app-extracted/.vite/build/mainWindow.js"
             echo "  - /tmp/ref-source/app-extracted/.vite/build/mainView.js"
             echo ""
-            echo "When citing reference-source paths in findings, prefix"
-            echo "with 'reference-source/' (strip the /tmp/ref-source/"
-            echo "portion) so Stage 5 can resolve them."
+            echo "When citing reference-source paths in findings, replace"
+            echo "the '/tmp/ref-source/app-extracted/' prefix with"
+            echo "'reference-source/' so Stage 5 can resolve them, e.g."
+            echo "reference-source/.vite/build/index.js"
             echo ""
             echo "## This repo"
             echo ""
@@ -680,7 +681,7 @@ jobs:
           # * Raw response + extracted payload archived before schema
           #   checks so a reject still leaves artifacts to inspect.
           if raw=$(timeout 1200s claude -p "$(cat /tmp/triage/investigate-prompt.txt)" \
-              --allowedTools "Read,Grep,Glob,Bash(strings:*)" \
+              --allowedTools "Read,Grep,Glob,Bash(strings:*),Bash(ls:*)" \
               --output-format json \
               --json-schema "${schema}" \
               --model claude-sonnet-4-6 \


### PR DESCRIPTION
Follow-up to #809, found while auditing its dry-run (workflow run [29661292185](https://github.com/aaddrick/claude-desktop-debian/actions/runs/29661292185), dry-triaging #799). All three items are pre-existing on `main`, not #809 regressions.

## The citation-path contract mismatch

The investigate prompt told the model to cite upstream-bundle files by stripping only `/tmp/ref-source/`, keeping the `app-extracted/` segment. But Stage 5 invokes `validate.sh` with `reference_root=/tmp/ref-source/app-extracted`, and `resolve_path` prepends that root after stripping `reference-source/` — so every prompt-conformant citation resolved to a doubled path (`/tmp/ref-source/app-extracted/app-extracted/...`), failed the file check, and killed the finding plus its anchor.

Seen live in the #799 dry run: the one killed finding cited `package.json` for `desktopName` (`com.anthropic.Claude.desktop`), which the 1.22209.0 bundle really carries — a factually correct finding thrown out at the gate. The net effect was that every upstream-bundle citation silently failed validation, undercutting exactly the mechanism-verification behavior the #809 audit work paid for.

The prompt now teaches the form everything else already agrees on (`reference-source/.vite/build/index.js` — matching the `investigate.json` schema example, `tests/triage-validate.bats`, and `resolve_path`). Prompt-side fix per the contract; `resolve_path` stays strict.

## Also in this PR

- **setup-node pinned 20 → 22.** The pinned `@anthropic-ai/claude-code@2.1.214` wants `node >=22`; the runner's v20.20.2 threw `npm warn EBADENGINE` in the dry run. Worked anyway, but it breaks the day the CLI hardens the engine check.
- **`Bash(ls:*)` added to the investigator `--allowedTools`.** The dry run's only permission denial was a plain `ls` directory probe. Glob covers it, but there's no reason to burn a turn on a denial for a read-only listing.

`actionlint` clean. Not exercised live — the next real triage run (or a `dry_run` dispatch) is the honest validation that citations now survive Stage 5.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
95% AI / 5% Human
Claude: audited the #809 dry-run artifact, diagnosed the doubled-segment resolution failure, wrote the fix and PR
Human: scoped the fix list (prompt wording, node pin, ls allowlist) and directed the work