### PR TITLE
fix(doctor): judge only the running binary's chrome-sandbox

### DIFF
--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1437,9 +1437,12 @@ _doctor_check_electron_binary() {
 # Check the chrome-sandbox helper's setuid permissions (must be 4755,
 # owned by root). Official layout: chrome-sandbox sits at the package
 # root beside the ELF (no node_modules/electron/dist tree anymore).
-# Looks at the deb install path and, when an electron path is provided,
-# the chrome-sandbox beside it; the first existing file wins. Warns
-# when none is found (expected for AppImage).
+# When an electron path is provided, ONLY the chrome-sandbox beside it
+# is judged — that is the binary actually running; falling back to the
+# deb path would validate the wrong binary when an AppImage/Nix run
+# coexists with a stale deb tree. Without an electron path, the deb
+# install location is the best guess. Warns when the relevant file is
+# missing (expected for AppImage).
 #
 # _DOCTOR_DEB_SANDBOX overrides the hardcoded deb path (test hook; the
 # default is the real install location, so production is unaffected).
@@ -1447,35 +1450,30 @@ _doctor_check_electron_binary() {
 # Usage: _doctor_check_chrome_sandbox [electron_path]
 _doctor_check_chrome_sandbox() {
 	local electron_path="${1:-}"
-	local _deb_sandbox="${_DOCTOR_DEB_SANDBOX:-}"
-	[[ -n $_deb_sandbox ]] \
-		|| _deb_sandbox='/usr/lib/claude-desktop-unofficial/chrome-sandbox'
-	local sandbox_paths=("$_deb_sandbox")
-	# Also check relative to the provided electron path
+	local sandbox_path
 	if [[ -n $electron_path ]]; then
-		local electron_dir
-		electron_dir=$(dirname "$electron_path")
-		sandbox_paths+=("$electron_dir/chrome-sandbox")
+		# A specific binary is running: only its own chrome-sandbox is
+		# relevant.
+		sandbox_path="$(dirname "$electron_path")/chrome-sandbox"
+	else
+		# No binary path known: fall back to the deb install location.
+		sandbox_path="${_DOCTOR_DEB_SANDBOX:-}"
+		[[ -n $sandbox_path ]] \
+			|| sandbox_path='/usr/lib/claude-desktop-unofficial/chrome-sandbox'
 	fi
-	local sandbox_checked=false sandbox_path
-	for sandbox_path in "${sandbox_paths[@]}"; do
-		if [[ -f $sandbox_path ]]; then
-			sandbox_checked=true
-			local sandbox_perms sandbox_owner
-			sandbox_perms=$(stat -c '%a' "$sandbox_path" 2>/dev/null) || true
-			sandbox_owner=$(stat -c '%U' "$sandbox_path" 2>/dev/null) || true
-			if [[ $sandbox_perms == '4755' && $sandbox_owner == 'root' ]]; then
-				_pass "Chrome sandbox: permissions OK ($sandbox_path)"
-			else
-				_fail "Chrome sandbox: perms=${sandbox_perms:-?},\
+	if [[ -f $sandbox_path ]]; then
+		local sandbox_perms sandbox_owner
+		sandbox_perms=$(stat -c '%a' "$sandbox_path" 2>/dev/null) || true
+		sandbox_owner=$(stat -c '%U' "$sandbox_path" 2>/dev/null) || true
+		if [[ $sandbox_perms == '4755' && $sandbox_owner == 'root' ]]; then
+			_pass "Chrome sandbox: permissions OK ($sandbox_path)"
+		else
+			_fail "Chrome sandbox: perms=${sandbox_perms:-?},\
  owner=${sandbox_owner:-?}"
-				_info "Fix: sudo chown root:root $sandbox_path"
-				_info "     sudo chmod 4755 $sandbox_path"
-			fi
-			break
+			_info "Fix: sudo chown root:root $sandbox_path"
+			_info "     sudo chmod 4755 $sandbox_path"
 		fi
-	done
-	if [[ $sandbox_checked == false ]]; then
+	else
 		_warn 'Chrome sandbox not found (expected for AppImage)'
 	fi
 }

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -1699,19 +1699,19 @@ _stub_stat() {
 	[[ $output == *'not found'* ]]
 }
 
-@test "_doctor_check_chrome_sandbox: deb path wins when both sandboxes exist (single report)" {
-	# Pins probe precedence and the loop's break: with both the deb path
-	# and an electron-adjacent sandbox present, the deb path is judged
-	# and exactly ONE result line prints. Deleting the break (double
-	# report) or reordering the probe array fails this.
+@test "_doctor_check_chrome_sandbox: electron-adjacent sandbox wins when both exist (single report)" {
+	# FLIPPED from #745's deb-path-wins expectation: this fix judges
+	# ONLY the running binary's sandbox when an electron path is given,
+	# so with both files present the electron-adjacent one is reported.
+	# Still pins the single-report contract.
 	_DOCTOR_DEB_SANDBOX="$TEST_TMP/deb-sandbox"
 	: > "$TEST_TMP/deb-sandbox"
 	mkdir -p "$TEST_TMP/app"
 	: > "$TEST_TMP/app/chrome-sandbox"
 	_stub_stat '4755' 'root'
 	run _doctor_check_chrome_sandbox "$TEST_TMP/app/electron"
-	[[ $output == *"$TEST_TMP/deb-sandbox"* ]]
-	[[ $output != *"$TEST_TMP/app/chrome-sandbox"* ]]
+	[[ $output == *"$TEST_TMP/app/chrome-sandbox"* ]]
+	[[ $output != *"$TEST_TMP/deb-sandbox"* ]]
 	[[ $(grep -c 'Chrome sandbox' <<< "$output") -eq 1 ]]
 }
 
@@ -1722,4 +1722,44 @@ _stub_stat() {
 	run _doctor_check_chrome_sandbox ''
 	[[ $output == *'[PASS]'* ]]
 	[[ $output == *"$TEST_TMP/deb-sandbox"* ]]
+}
+
+@test "_doctor_check_chrome_sandbox: ignores a stale deb sandbox when an electron path is given" {
+	# Regression guard (#714-class false green): a valid deb sandbox
+	# exists, but the running binary (electron_path) has none. The old
+	# code validated the deb path and reported PASS for a sandbox that
+	# is not in use. The deb path must be ignored entirely -> WARN,
+	# never PASS.
+	_DOCTOR_DEB_SANDBOX="$TEST_TMP/deb-sandbox"
+	: > "$TEST_TMP/deb-sandbox"
+	mkdir -p "$TEST_TMP/app"
+	# No chrome-sandbox next to electron.
+	_stub_stat '4755' 'root'
+	run _doctor_check_chrome_sandbox "$TEST_TMP/app/electron"
+	[[ $output == *'[WARN]'* ]]
+	[[ $output != *'[PASS]'* ]]
+	[[ $output != *"$TEST_TMP/deb-sandbox"* ]]
+}
+
+@test "_doctor_check_chrome_sandbox: judges the electron-path sandbox, not the deb one, when both exist" {
+	# Regression guard: the running binary's sandbox has the wrong perms
+	# (0755) while a stale deb sandbox is fine (4755 root). The old code
+	# checked the deb path first and PASSed; the electron-path sandbox
+	# is the one that must be judged -> FAIL.
+	_DOCTOR_DEB_SANDBOX="$TEST_TMP/deb-sandbox"
+	: > "$TEST_TMP/deb-sandbox"
+	mkdir -p "$TEST_TMP/app"
+	: > "$TEST_TMP/app/chrome-sandbox"
+	# Path-aware stub: electron's sandbox is bad, everything else good.
+	stat() {
+		if [[ $3 == "$TEST_TMP/app/chrome-sandbox" ]]; then
+			if [[ $2 == '%a' ]]; then echo '0755'; else echo 'root'; fi
+		else
+			if [[ $2 == '%a' ]]; then echo '4755'; else echo 'root'; fi
+		fi
+	}
+	run _doctor_check_chrome_sandbox "$TEST_TMP/app/electron"
+	[[ $output == *'[FAIL]'* ]]
+	[[ $output == *'perms=0755'* ]]
+	[[ $output != *'[PASS]'* ]]
 }


### PR DESCRIPTION
The held behavior-changing follow-up to #745, as discussed there — rebased onto current main now that the helper it modifies has landed.

When `electron_path` is set, `_doctor_check_chrome_sandbox` now validates ONLY that binary's adjacent chrome-sandbox and never falls back to the deb install path. The old first-existing-path-wins loop reported a green PASS from a stale deb tree while the actually-running AppImage/Nix binary's sandbox went unexamined — the doctor-vs-reality disagreement class. The deb path (still `_DOCTOR_DEB_SANDBOX`-overridable) remains the fallback only when no electron path is known.

The #745 precedence test is intentionally flipped to electron-wins — that flip is the behavior change, documented as such rather than silently edited.

Two regression guards, both mutation-verified against the pre-fix helper: deb-PASS-with-no-electron-sandbox and deb-PASS-shadowing-a-bad-electron-sandbox both fail without the fix and pass with it. doctor.bats 130 → 132, full suite 445/445, shellcheck clean, verified after the rebase onto 1.24012.9-era main.