### PR TITLE
fix(patches): per-anchor file resolution for the 1.26832.0 bundler swap

### DIFF
--- a/docs/learnings/patching-minified-js.md
+++ b/docs/learnings/patching-minified-js.md
@@ -69,6 +69,69 @@ context is bounded enough that newline-spanning is harmless, and
 literal token sequences (`",b:` etc.) when stricter adjacency is
 required.
 
+## Quote style: `"` is not stable either
+
+Whitespace tolerance assumes the *tokens* hold still and only the
+spacing moves. Upstream 1.26832.0 broke that assumption: the bundler
+changed and every string literal flipped from double quotes to
+backticks. Same code, same strings, different delimiter.
+
+Measured across the main-process files of both bundles:
+
+| bundle | `"short-literal"` | `` `short-literal` `` |
+| --- | --- | --- |
+| 1.24012.11 | 46,526 | 429 |
+| 1.26832.0 | 3,050 | 44,701 |
+
+A near-total inversion. Four of the ten anchors in the active suite
+matched on a `"`-delimited literal and went to zero matches; they came
+back the instant the delimiter was generalized. The build-fatal ones
+failed the build, which is the outcome the guards are for, but the
+diagnosis cost a full triage cycle because "anchor not found" reads as
+"upstream deleted the feature" and the feature was untouched.
+
+**Never write a bare quote in an anchor.** Use a quote class so all
+three delimiters match:
+
+```bash
+# Bad: pins the delimiter the current minifier happens to emit
+grep -oP '[$\w]+(?=\.setAlwaysOnTop\(\s*!0\s*,\s*"pop-up-menu"\))'
+
+# Good: tolerates ", ' and `
+grep -oP '[$\w]+(?=\.setAlwaysOnTop\(\s*!0\s*,\s*[`"'"'"']pop-up-menu[`"'"'"']\))'
+```
+
+In the `node` heredoc patches, build the class once and concatenate it
+rather than repeating the escaping:
+
+```js
+// Quote-class helper: match a literal under any delimiter.
+const q = s => '[`"\']' + s + '[`"\']';
+const arrRe = new RegExp('\\[\\s*' + q('\\/usr\\/libexec\\/virtiofsd') +
+    '\\s*,\\s*' + q('\\/usr\\/bin\\/virtiofsd') + '\\s*\\]');
+```
+
+Two related shifts landed in the same bump, so a bundler swap should be
+treated as a class of breakage rather than one delimiter change:
+
+- **Syntax level rose.** Optional chaining is now preserved instead of
+  being downleveled. An anchor written against
+  `(e==null?void 0:e.id)==="ubuntu"` has to also accept
+  ``e?.id===`ubuntu` ``. `let` likewise replaced most `const`/`var`
+  emission, so `(?:const|let)` beats either alone.
+- **Callee indirection appeared where there was none.** `X.spawn(` became
+  `(0,ye.spawn)(`. The tray patch already tolerated this shape
+  (`(?:\(0,\s*[\w$]+(?:\.[\w$]+)*\)|[\w$]+)`); it is now the default, not
+  a special case, and every call-site anchor wants it.
+
+One inference worth flagging rather than asserting: when concatenation
+is re-emitted as interpolation, a message that was one contiguous
+literal (`"...completed in "+m+"ms"`) becomes a template with a
+`${...}` hole in the middle, so an anchor spanning that hole breaks
+even though the delimiter class is right. Anchor on the *stable prefix*
+before the first interpolation (`[warm] Promoting warm file`), not on a
+whole sentence.
+
 ## Replacement-string escaping: `\1`, `&`, `$1`
 
 A regex can match correctly and still produce corrupted output
@@ -165,6 +228,11 @@ minification untouched (true for the upstream bundler used here; a
 Anchor on those. A hardcoded minified name silently no-ops the next
 release; the build log still says "patched."
 
+The string *content* survives; its *delimiter* does not, and neither
+does the syntax around it. Match literals through a quote class and
+keep the surrounding call shape loose — see "Quote style: `"` is not
+stable either" above, which is how the whole suite broke on 1.26832.0.
+
 Three patterns from the suite (quick-window survives the v3.0.0
 rebase; the cowork and tray examples are historical — patches deleted
 in v3.0.0, lessons stand):
@@ -232,7 +300,8 @@ For years the whole main process lived in one file,
 `.vite/build/index.js`, and every patch hardcoded that path. Upstream
 1.19367.0 code-split it: `index.js` became a ~700-byte entry stub that
 `require()`s a content-hashed main chunk (`index.chunk-<hash>.js`),
-which pulls in ~40 more `index.chunk-<hash>.js` files. The hash changes
+which pulls in ~40 more `index.chunk-<hash>.js` files (86 by
+1.24012.11, 325 by 1.26832.0). The hash changes
 every release, so the name can't be hardcoded either. Every patch
 anchored on the literal `index.js` path silently missed — the
 build-fatal ones (`virtiofsd-probe`, `cowork-bwrap` A/B) failed the
@@ -250,12 +319,85 @@ Two rules fall out, both now in `app-asar.sh` / the patch suite:
 
 - **One logical patch can span chunks.** The split follows dynamic
   `import()` boundaries, so an optional subsystem can land in its own
-  chunk apart from the code that gates it. `cowork-bwrap`'s A/B/C1 are
+  chunk apart from the code that gates it. `cowork-bwrap`'s A/B/C1 were
   in the main chunk, but its warm-prefetch block (C2) moved to a
-  separate warm chunk — resolved there by its stable `[warm] Warm
-  download disabled` log literal, exactly the "anchor on a developer
-  string, then find the file that carries it" move. Don't assume the
-  whole patch touches one file.
+  separate warm chunk — resolved there by a stable `[warm]` log literal,
+  exactly the "anchor on a developer string, then find the file that
+  carries it" move. Don't assume the whole patch touches one file.
+
+**The single-chunk assumption died in 1.26832.0.** That release
+dissolved the core: `index.js` went from a 773-byte stub with one
+`require()` to a 195,889-byte file issuing 104 `require()` calls across
+83 distinct chunks, and the 5.2 MB core chunk was replaced by a largest
+chunk of 1.28 MB. Total main-process bytes moved +2.4%, so this was a
+re-split of existing code, not new code — the core-shrink signature.
+`_resolve_main_js`'s multi-chunk guard fired exactly as designed and
+failed the build rather than mispatching, which is the outcome to want,
+but it means the "resolve one file, hand it to every patch" contract is
+finished. Anchors now live in three different places at once: the tray
+ternary in `index.js` itself, quick-window and org-plugins and virtiofsd
+in `index.chunk-*` files, and the cowork evaluator in a second
+`index2.chunk-*` family that did not exist before.
+
+Resolution has to become per-anchor: grep the whole `.vite/build` tree
+for the anchor's stable literal, assert exactly one file carries it,
+patch that file. `cowork-bwrap` already did this for its warm chunk
+(`grep -lF '[warm] ...'`), and that one-off is the shape the rest of the
+suite needs. Two traps the census surfaced:
+
+- **Presence is not the anchor.** `pop-up-menu` appears in two 1.26832.0
+  chunks, but only one carries the `setAlwaysOnTop(!0,...)` call the
+  patch actually rewrites. Resolve on the *full anchor shape*, not on the
+  distinctive string alone, or the exactly-one assertion picks a decoy.
+- **A missing anchor is not always a missing feature.** Of the four
+  1.26832.0 anchors that survived the quote-class fix and still missed,
+  every one was a genuine upstream reshape rather than a deletion: the
+  virtiofsd resolver now returns `await FT(kT)||...` where it returned a
+  bare identifier, and `cowork-bwrap` C1 inverted polarity from
+  ``(x?.status)!=="supported"?!1:`` to ``x?.status===`supported`?(...)``.
+  An inverted guard is the dangerous one — a regex loose enough to match
+  both shapes would install the gate backwards. The fix is to stop the
+  anchor *before* the comparison: C1 matches only the function head and
+  destructure, then injects ahead of upstream's check, which is correct
+  under either polarity because it never has to agree with one.
+
+### A resolution anchor must survive its own patch
+
+Once a patch resolves its own file, the anchor acquires a second job it
+never had as a patch-site anchor: it has to still match *after* the patch
+has run. Six of the first ten anchors written for #820 failed that.
+`org-plugins` resolves on the compound `` `org-plugins`);default:return
+null `` shape and then inserts a `case"linux"` between those two halves;
+`cowork-bwrap` A resolves on a function head it rewrites; the tray patch
+resolves on a ternary condition it replaces. Every one resolved fine on a
+clean tree and failed on a re-run — and failed *at resolution*, so the
+carefully written idempotency guards inside each patch never got to run.
+
+The build normally extracts a fresh asar, so this hides in production and
+surfaces only under a second pass. Test it explicitly: run the whole
+patch stage twice against the same tree and assert the second run is a
+no-op and the repacked archive is byte-identical.
+
+Pick a resolution anchor the patch provably never rewrites, which is
+usually *adjacent* to the patch site rather than at it:
+
+| patch | resolves on | why it survives |
+| --- | --- | --- |
+| `org-plugins` | `Application Support/Claude/org-plugins` | the darwin path; the insert lands elsewhere in the switch |
+| `cowork-bwrap` A | `return process.platform,X()}` | the injected early-return goes in front of it, not through it |
+| `cowork-bwrap` B | the `-socket` literal | re-emitted verbatim in both branches of the swapped call |
+| tray | the two adjacent `TrayIconLinux*.png` literals | the condition is rewritten, the literals are re-emitted |
+
+Where that is impossible, teach the anchor to tolerate the patch's own
+marker — `cowork-bwrap` C1 allows an optional
+`/*cowork-bwrap-dl*/...;` segment between the function head and the
+destructure it anchors on.
+
+One mechanical footnote: resolve with `grep -lPz`, not `grep -lP`. Bare
+`-P` is line-oriented, so a `\s*` in the anchor cannot cross a newline
+and every multi-line beautified bundle reports the anchor missing —
+the beautified false-negative trap again, this time in the resolver
+rather than in the patch.
 
 The corollary for anchor uniqueness: a literal that was unique across
 one 15 MB file can now recur across ~50 chunks (source-map tails,

--- a/scripts/cowork-fallback/tests/cowork-bwrap-patch.bats
+++ b/scripts/cowork-fallback/tests/cowork-bwrap-patch.bats
@@ -23,6 +23,21 @@ async function Vdo(A,e,t){if(!e){log("[warm] Warm download disabled");return}ret
 JS
 }
 
+# The same four anchor shapes as emitted by 1.26832.0: backtick string
+# literals, `let` over const, the bundler indirect-call form for spawn,
+# preserved optional chaining, and a module-binding destructure callee
+# (p.n() rather than sM()). C2's log literal is retained here so the
+# fixture still covers the sub-patch on bundles that carry it.
+fixture_1268320() {
+	cat <<'JS'
+function Ben(){return process.platform,Cen()}
+function Cen(){return{status:`unsupported`}}
+function ygi(A){return (0,ye.spawn)(A,[`-socket`,Vie()],{stdio:[`pipe`,`pipe`,`pipe`]})}
+async function OzA(A,e){let{yukonSilver:t}=p.n();return t?.status===`supported`?doDownload():!1}
+async function Vdo(A,e,t){if(!e){log(`[warm] Warm download disabled`);return}return warmPrefetch()}
+JS
+}
+
 setup() {
 	WORK="$(mktemp -d)"
 	mkdir -p "$WORK/app.asar.contents/.vite/build"
@@ -143,4 +158,53 @@ target() { printf '%s' "$WORK/app.asar.contents/.vite/build/index.js"; }
 	[ "$status" -ne 0 ]
 	[[ "$output" == *"B: FATAL"* ]]
 	[[ "$output" == *"expected exactly 1"* ]]
+}
+
+@test "patch: applies to the 1.26832.0 bundler-swap shape" {
+	# Pins three tolerances at once: the quote class, the indirect-call
+	# spawn callee ((0,ye.spawn)(), and C1's let + property-chain
+	# destructure callee. Reverting any of them leaves this red.
+	cd "$WORK"
+	fixture_1268320 > "$(target)"
+	run patch_cowork_bwrap
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"A: gated yukonSilver"* ]]
+	[[ "$output" == *"B: swapped helper spawn"* ]]
+	[[ "$output" == *"C1: blocked foreground"* ]]
+	[[ "$output" == *"C2: blocked warm"* ]]
+	run node --check "$(target)"
+	[ "$status" -eq 0 ]
+}
+
+@test "patch: 1.26832.0 shape keeps the indirect spawn callee intact" {
+	cd "$WORK"
+	fixture_1268320 > "$(target)"
+	patch_cowork_bwrap
+	# The callee is re-emitted verbatim; rebuilding it as OBJ.spawn(
+	# would drop the (0,...) and change `this` binding.
+	grep -qF '/*cowork-bwrap-spawn*/(0,ye.spawn)(' "$(target)"
+}
+
+@test "patch: 1.26832.0 C1 gate lands ahead of the inverted status check" {
+	# The guard inverted between releases (!== early-false became ===
+	# proceed). The injection must sit before upstream's check so it is
+	# correct under either polarity.
+	cd "$WORK"
+	fixture_1268320 > "$(target)"
+	patch_cowork_bwrap
+	grep -qF 'async function OzA(A,e){/*cowork-bwrap-dl*/if(' "$(target)"
+	grep -qF 'return!1;let{yukonSilver:t}=p.n();return t?.status===`supported`' \
+		"$(target)"
+}
+
+@test "patch: 1.26832.0 shape is idempotent" {
+	cd "$WORK"
+	fixture_1268320 > "$(target)"
+	patch_cowork_bwrap
+	local first; first="$(cat "$(target)")"
+	run patch_cowork_bwrap
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"already"* ]]
+	[ "$(cat "$(target)")" == "$first" ]
 }

--- a/scripts/cowork-fallback/tests/cowork-bwrap-patch.bats
+++ b/scripts/cowork-fallback/tests/cowork-bwrap-patch.bats
@@ -29,6 +29,12 @@ setup() {
 	fixture > "$WORK/app.asar.contents/.vite/build/index.js"
 	# shellcheck source=scripts/patches/cowork-bwrap.sh
 	source "$PATCH_SH"
+	# _resolve_anchor_file lives in the orchestrator; each sub-patch now
+	# resolves its own file instead of reading a main_js global (#820).
+	# This fixture keeps all four anchors in one file, which also covers
+	# the shared-file path of the patch's read/write cache.
+	# shellcheck source=scripts/patches/app-asar.sh
+	source "${SCRIPT_DIR}/../../patches/app-asar.sh"
 }
 
 teardown() {
@@ -119,7 +125,11 @@ target() { printf '%s' "$WORK/app.asar.contents/.vite/build/index.js"; }
 	local before; before="$(cat "$t")"
 	run patch_cowork_bwrap
 	[ "$status" -ne 0 ]
-	[[ "$output" == *"B: FATAL"* ]]
+	# The socket argv is B's resolution anchor, so removing the spawn
+	# line now fails at resolution rather than inside the patch body.
+	# Either way the build stops and nothing is written, which is the
+	# property under test.
+	[[ "$output" == *"B: FATAL"* || "$output" == *"matched no file"* ]]
 	# A load-bearing miss must not write a half-patched file.
 	[ "$(cat "$t")" == "$before" ]
 }

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -8,13 +8,14 @@
 #
 # Each entry is a function sourced from scripts/patches/*.sh that edits
 # the main-process JS relative to CWD; patch_app_asar runs them with
-# CWD = $app_staging_dir/resources and sets $main_js (resolved by
-# _resolve_main_js — see below) as the file every patch operates on.
+# CWD = $app_staging_dir/resources. Each patch resolves the file its own
+# anchor lives in via _resolve_anchor_file — there is no single
+# main-process file to hand them all (see that function's comment).
 #
 # Sourced by: build.sh
 # Sourced globals:
 #   app_staging_dir, asar_exec, work_dir, project_root
-# Modifies globals: main_js, WM_CLASS (derived + exported)
+# Modifies globals: WM_CLASS (derived + exported)
 #===============================================================================
 
 # Survivor candidates per docs/learnings/official-deb-rebase-verification.md:
@@ -148,49 +149,63 @@ _derive_wm_class() {
 	printf '%s\n' "${desktop_name%.desktop}"
 }
 
-# Resolve the main-process JS file inside the extracted asar and echo
-# its path relative to the resources CWD. Pre-3.x bundles kept the whole
-# main process in .vite/build/index.js. Since upstream 1.19367.0 the
-# bundle is code-split: index.js is a ~700-byte stub that require()s the
-# real main chunk (index.chunk-<hash>.js — content-hashed, so the name
-# changes every release). Follow the stub's require to the chunk; fall
-# back to index.js for the pre-split layout. All active patches anchor on
-# literals that live in this one chunk; if a future release spreads them
-# across chunks, the patches need per-anchor resolution (this returns
-# non-zero on a multi-chunk split rather than mispatching silently).
-_resolve_main_js() {
+# Resolve the single .vite/build file whose bytes carry an anchor, and
+# echo its path relative to the resources CWD.
+#
+# There is deliberately no "the main JS file" any more. Pre-3.x bundles
+# kept the whole main process in .vite/build/index.js; 1.19367.0 split it
+# into a stub plus one content-hashed main chunk; 1.26832.0 dissolved
+# that core entirely — index.js became a 190 KB file require()ing 83
+# chunks, across two chunk families (index.chunk-* and index2.chunk-*),
+# with the tray anchor left behind in index.js itself. A single resolved
+# path cannot serve every patch, so each anchor resolves its own file
+# (#820, docs/learnings/patching-minified-js.md).
+#
+# Takes a PCRE for the FULL anchor shape, not just its distinctive
+# string: on 1.26832.0 the literal `pop-up-menu` occurs in two chunks but
+# only one carries the setAlwaysOnTop call quick-window rewrites, so
+# resolving on the string alone picks a decoy. Asserting exactly one
+# match is what replaces the old multi-chunk guard: zero or many is a
+# hard error rather than a silent mispatch.
+#
+# Anchors must be written with a quote class ([`"']) rather than a bare
+# double quote — 1.26832.0 swapped the minifier and re-emitted nearly
+# every string literal as a backtick template.
+_resolve_anchor_file() {
+	local label="$1"
+	local pattern="$2"
 	local build_dir='app.asar.contents/.vite/build'
-	local stub="$build_dir/index.js"
 
-	if [[ ! -f $stub ]]; then
-		echo "No index.js under $build_dir — upstream layout changed?" >&2
+	if [[ ! -d $build_dir ]]; then
+		echo "No $build_dir — upstream layout changed?" >&2
 		return 1
 	fi
 
-	local -a chunks
-	mapfile -t chunks < <(
-		grep -oP 'require\("\./\Kindex\.chunk-[^"]+\.js(?="\))' "$stub"
+	# -z treats each file as one record so an anchor's \s* can span a
+	# newline. Shipped bytes are single-line, but a beautified reference
+	# bundle wraps the same expression across lines and a line-oriented
+	# grep would report it missing (the beautified false-negative trap in
+	# docs/learnings/patching-minified-js.md).
+	local -a hits
+	mapfile -t hits < <(
+		grep -rlPz --include='*.js' -- "$pattern" "$build_dir" 2>/dev/null \
+			| sort
 	)
 
-	if (( ${#chunks[@]} == 0 )); then
-		# Pre-split layout: index.js is the main process itself.
-		printf '%s\n' "$stub"
-		return 0
+	if (( ${#hits[@]} == 0 )); then
+		echo "Anchor '$label' matched no file under $build_dir —" \
+			'upstream reshaped or removed it. Re-derive the anchor' \
+			'before shipping (#820).' >&2
+		return 1
 	fi
-	if (( ${#chunks[@]} > 1 )); then
-		echo "index.js requires ${#chunks[@]} main chunks" \
-			"(${chunks[*]}) — upstream split the main bundle across" \
-			'files; patches need per-anchor resolution. Re-point' \
-			'scripts/patches/*.sh before shipping.' >&2
+	if (( ${#hits[@]} > 1 )); then
+		echo "Anchor '$label' matched ${#hits[@]} files (${hits[*]}) —" \
+			'ambiguous. Tighten the anchor to the full shape so it' \
+			'selects one file (#820).' >&2
 		return 1
 	fi
 
-	local chunk="$build_dir/${chunks[0]}"
-	if [[ ! -f $chunk ]]; then
-		echo "index.js requires ${chunks[0]} but $chunk is missing" >&2
-		return 1
-	fi
-	printf '%s\n' "$chunk"
+	printf '%s\n' "${hits[0]}"
 }
 
 patch_app_asar() {
@@ -241,9 +256,18 @@ patch_app_asar() {
 	cd "$resources_dir" || exit 1
 	"$asar_exec" extract app.asar app.asar.contents || exit 1
 
-	# Resolve the code-split main chunk once; every patch reads $main_js.
-	main_js=$(_resolve_main_js) || exit 1
-	echo "Main-process JS: $main_js"
+	# Layout census, informational only — each patch resolves the file
+	# its own anchor lives in (see _resolve_anchor_file). Printed so a
+	# build log still records when upstream reshapes the bundle.
+	local build_dir='app.asar.contents/.vite/build'
+	# grep -o | wc -l, not grep -c: the bundle is near-single-line, so
+	# grep -c would report matching LINES (a handful) rather than matches.
+	local js_count chunk_count
+	js_count=$(find "$build_dir" -name '*.js' -type f | wc -l)
+	chunk_count=$(grep -oP 'require\("\./index2?\.chunk-[^"]+\.js"\)' \
+		"$build_dir/index.js" 2>/dev/null | wc -l)
+	echo "Bundle layout: $js_count JS files under .vite/build," \
+		"$chunk_count chunk requires from index.js"
 
 	local patch_fn
 	for patch_fn in "${active_patches[@]}"; do

--- a/scripts/patches/cowork-bwrap.sh
+++ b/scripts/patches/cowork-bwrap.sh
@@ -38,38 +38,76 @@
 # only wires all this up when the user sets COWORK_VM_BACKEND=bwrap.
 #
 # Sourced by: build.sh
-# Sourced globals: main_js (optional — the resolved main chunk; set by
-#   patch_app_asar. A/B/C1 patch it; C2 patches the warm chunk, resolved
-#   here by its [warm] log literal. Both fall back to index.js on older
-#   single-file bundles.)
+# Sourced globals: (none — each sub-patch resolves its own file via
+#   _resolve_anchor_file, defined in app-asar.sh)
 # Modifies globals: (none)
+#
+# All four sub-patches shared one file through 1.24012.11. 1.26832.0 put
+# each in a different one: A in an index2.chunk-*, B and C1 in two
+# separate index.chunk-*, and C2's anchor is gone from the bundle
+# entirely (#820). They are resolved independently and may or may not
+# coincide, so the node stage below reads and writes per file.
 #===============================================================================
+
+# Quote class: 1.26832.0 re-emitted nearly every string literal as a
+# backtick template (#820).
+_CB_Q='[`"'"'"']'
 
 patch_cowork_bwrap() {
 	echo 'Patching Cowork bwrap fallback (opt-in COWORK_VM_BACKEND=bwrap)...'
-	local index_js="${main_js:-app.asar.contents/.vite/build/index.js}"
 
-	# A/B/C1 live in the main chunk; C2's warm-prefetch code can sit in a
-	# separate code-split chunk (1.19367.0+). Resolve the file carrying
-	# the warm anchor by its stable log literal; fall back to the main
-	# chunk for older single-file bundles.
-	local build_dir warm_js
-	build_dir=$(dirname "$index_js")
-	warm_js=$(grep -lF '[warm] Warm download disabled' \
-		"$build_dir"/*.js 2>/dev/null | head -1)
-	[[ -z $warm_js ]] && warm_js="$index_js"
+	local a_js b_js c1_js c2_js
+	# Each resolution anchor below is deliberately chosen to survive its
+	# own patch: patch A rewrites the function head, patch B rewrites the
+	# spawn arguments, patch C1 injects after the opening brace. Anchoring
+	# on the rewritten text would make the second run fail to resolve the
+	# file at all, before the idempotency guards could fire.
+	a_js=$(_resolve_anchor_file 'cowork A (platform dispatch)' \
+		'return process\.platform,[\w$]+\(\)\}') || return 1
+	b_js=$(_resolve_anchor_file 'cowork B (helper socket argv)' \
+		"${_CB_Q}-socket${_CB_Q}") || return 1
+	c1_js=$(_resolve_anchor_file 'cowork C1 (foreground download)' \
+		'async function\s+[\w$]+\([\w$]+,[\w$]+\)\{(?:/\*cowork-bwrap-dl\*/[^;]*;)?(?:const|let)\{yukonSilver:') \
+		|| return 1
 
-	if INDEX_JS="$index_js" WARM_JS="$warm_js" node << 'COWORK_BWRAP_PATCH'
+	# C2 is best-effort and its anchor is absent from 1.26832.0, so an
+	# unresolved warm file is a warning rather than a build failure. Not
+	# routed through _resolve_anchor_file: that helper fails loud by
+	# design, which is the wrong contract for an optional sub-patch.
+	c2_js=$(grep -rlF --include='*.js' '[warm] Warm download disabled' \
+		'app.asar.contents/.vite/build' 2>/dev/null | head -1)
+
+	if A_JS="$a_js" B_JS="$b_js" C1_JS="$c1_js" C2_JS="$c2_js" \
+		node << 'COWORK_BWRAP_PATCH'
 const fs = require('fs');
-const indexJs = process.env.INDEX_JS;
-const warmJs = process.env.WARM_JS || indexJs;
-const warmSameFile = warmJs === indexJs;
-let code = fs.readFileSync(indexJs, 'utf8');
+
+// Sub-patches may share a file or not, depending on release. Route every
+// read and write through one cache so a shared file is not read twice
+// (which would drop the earlier sub-patch's edit) and each file is
+// written exactly once at the end.
+const files = new Map();
+const load = p => {
+    if (!files.has(p)) files.set(p, fs.readFileSync(p, 'utf8'));
+    return files.get(p);
+};
+const save = (p, c) => files.set(p, c);
+
+const aJs = process.env.A_JS;
+const bJs = process.env.B_JS;
+const c1Js = process.env.C1_JS;
+const c2Js = process.env.C2_JS;
 
 // The runtime gate shared by every injected branch. Unflagged launches
-// never enter any of them, so the official path ships unchanged.
+// never enter any of them, so the official path ships unchanged. Our own
+// injected JS keeps double quotes: it is valid under either upstream
+// emission style.
 const GATE =
     'process.platform==="linux"&&process.env.COWORK_VM_BACKEND==="bwrap"';
+
+// q(): match an upstream literal under any delimiter. 1.26832.0 swapped
+// the minifier and re-emitted nearly every string as a backtick template
+// (#820).
+const q = s => '[`"\']' + s + '[`"\']';
 
 let loadBearingFailed = false;
 
@@ -85,13 +123,14 @@ let loadBearingFailed = false;
 // ---------------------------------------------------------------------
 const evalRe =
     /function\s+([\w$]+)\(\)\{return process\.platform,([\w$]+)\(\)\}/;
+let codeA = load(aJs);
 if (new RegExp('return\\{status:"supported"\\};return process\\.platform,')
-        .test(code)) {
+        .test(codeA)) {
     console.log('  A: evaluator already gated (supported when flagged)');
 } else {
     // Fail loud if upstream ever grows a second platform-dispatch of
     // this exact shape — a blind first-match swap would be wrong.
-    const evalAll = [...code.matchAll(new RegExp(evalRe, 'g'))];
+    const evalAll = [...codeA.matchAll(new RegExp(evalRe, 'g'))];
     const m = evalAll.length === 1 ? evalAll[0] : null;
     if (evalAll.length > 1) {
         console.log('  A: FATAL — yukonSilver platform-dispatch anchor ' +
@@ -106,7 +145,7 @@ if (new RegExp('return\\{status:"supported"\\};return process\\.platform,')
         // inside a captured name as substitution patterns — silently
         // corrupting the bundle (the $ trap in
         // docs/learnings/patching-minified-js.md, replacement side).
-        code = code.replace(evalRe, () => replacement);
+        save(aJs, codeA.replace(evalRe, () => replacement));
         console.log('  A: gated yukonSilver evaluator -> supported ' +
             'when flagged (' + m[1] + '/' + m[2] + ')');
     } else {
@@ -129,21 +168,31 @@ if (new RegExp('return\\{status:"supported"\\};return process\\.platform,')
 // through the swap too. Identifiers (IE, A, Vie) are captured, not
 // hardcoded.
 // ---------------------------------------------------------------------
-if (code.includes('/*cowork-bwrap-spawn*/')) {
+let codeB = load(bJs);
+if (codeB.includes('/*cowork-bwrap-spawn*/')) {
     console.log('  B: helper spawn swap already applied');
 } else {
-    const spawnRe =
-        /([\w$]+)\.spawn\(([\w$]+),\[\s*"-socket"\s*,\s*([\w$]+)\(\)\s*\]\s*,\s*\{\s*stdio:\s*\[\s*"pipe"\s*,\s*"pipe"\s*,\s*"pipe"\s*\]\s*\}\)/;
+    // The callee is captured whole rather than as an object plus a
+    // literal `.spawn`: 1.24012.11 emitted `IE.spawn(`, 1.26832.0 emits
+    // the bundler's indirect-call form `(0,ye.spawn)(`. Both are valid
+    // call expressions, so re-emitting the captured text verbatim works
+    // for either.
+    const callee = String.raw`((?:\(0,\s*[\w$]+(?:\.[\w$]+)*\)|[\w$]+\.spawn))`;
+    const spawnRe = new RegExp(
+        callee + String.raw`\(([\w$]+),\[\s*` + q('-socket') +
+        String.raw`\s*,\s*([\w$]+)\(\)\s*\]\s*,\s*\{\s*stdio:\s*\[\s*` +
+        q('pipe') + '\\s*,\\s*' + q('pipe') + '\\s*,\\s*' + q('pipe') +
+        String.raw`\s*\]\s*\}\)`);
     // Assert the helper-spawn shape is unique before swapping — a blind
     // first-match replace would half-patch if upstream duplicates it.
-    const spawnAll = [...code.matchAll(new RegExp(spawnRe, 'g'))];
+    const spawnAll = [...codeB.matchAll(new RegExp(spawnRe, 'g'))];
     const m = spawnAll.length === 1 ? spawnAll[0] : null;
     if (spawnAll.length > 1) {
         console.log('  B: FATAL — helper spawn anchor matched ' +
             spawnAll.length + ' sites, expected exactly 1');
         loadBearingFailed = true;
     } else if (m) {
-        const spawnObj = m[1], helperPath = m[2], sockFn = m[3];
+        const spawnCall = m[1], helperPath = m[2], sockFn = m[3];
         const flagged = '(' + GATE + ')';
         const daemon =
             'require("path").join(process.resourcesPath,' +
@@ -153,16 +202,16 @@ if (code.includes('/*cowork-bwrap-spawn*/')) {
         const args = flagged +
             '?[' + daemon + ',"-socket",' + sockFn + '()]' +
             ':["-socket",' + sockFn + '()]';
-        const replacement = '/*cowork-bwrap-spawn*/' + spawnObj +
-            '.spawn(' + cmd + ',' + args +
+        const replacement = '/*cowork-bwrap-spawn*/' + spawnCall +
+            '(' + cmd + ',' + args +
             ',{stdio:["pipe","pipe","pipe"]})';
         // () => replacement: same $-in-identifier trap as Patch A.
-        code = code.replace(spawnRe, () => replacement);
+        save(bJs, codeB.replace(spawnRe, () => replacement));
         console.log('  B: swapped helper spawn -> node daemon when ' +
-            'flagged (' + spawnObj + '/' + helperPath + '/' + sockFn + ')');
+            'flagged (' + spawnCall + '/' + helperPath + '/' + sockFn + ')');
     } else {
         console.log('  B: FATAL — helper spawn anchor ' +
-            '(X.spawn(P,["-socket",S()],{stdio:[...]}))  not found');
+            '(X.spawn(P,[`-socket`,S()],{stdio:[...]}))  not found');
         loadBearingFailed = true;
     }
 }
@@ -174,14 +223,33 @@ if (code.includes('/*cowork-bwrap-spawn*/')) {
 // each at its function head. A miss here only wastes bandwidth/disk, so
 // warn rather than fail.
 // ---------------------------------------------------------------------
-// Foreground: async function OzA(A,e){const{yukonSilver:t}=sM();return...
-const dlRe =
-    /(async function\s+[\w$]+\([\w$]+,[\w$]+\)\{)(const\{yukonSilver:[\w$]+\}=[\w$]+\(\);return\([\w$]+==null\?void 0:[\w$]+\.status\)!=="supported"\?!1:)/;
-if (code.includes('/*cowork-bwrap-dl*/')) {
+// Foreground:
+//   1.24012.11: async function OzA(A,e){const{yukonSilver:t}=sM();
+//               return(A==null?void 0:A.status)!=="supported"?!1:...
+//   1.26832.0:  async function ut(e,n){let{yukonSilver:r}=p.n();
+//               return r?.status===`supported`?(...)
+//
+// The status guard INVERTED between those releases (a !== early-false
+// became a === proceed), so the anchor deliberately stops at the
+// `return` and never spans the comparison. Matching only the function
+// head plus the destructure keeps the injection polarity-agnostic: the
+// gate is inserted before upstream's check runs, so it short-circuits
+// either shape. Widening this regex to cover both comparisons would be
+// the dangerous fix — a pattern loose enough to match both could bind
+// the wrong one and install the gate backwards.
+// The destructure initialiser is a plain call (`=sM()`) on 1.24012.11
+// and a module-binding call (`=p.n()`) on 1.26832.0, so the callee
+// tolerates a property chain.
+const dlRe = new RegExp(
+    String.raw`(async function\s+[\w$]+\([\w$]+,[\w$]+\)\{)` +
+    String.raw`((?:const|let)\{yukonSilver:[\w$]+\}=` +
+    String.raw`[\w$]+(?:\.[\w$]+)*\(\);return)`);
+let codeC1 = load(c1Js);
+if (codeC1.includes('/*cowork-bwrap-dl*/')) {
     console.log('  C1: foreground download block already applied');
-} else if (dlRe.test(code)) {
-    code = code.replace(dlRe,
-        '$1/*cowork-bwrap-dl*/if(' + GATE + ')return!1;$2');
+} else if (dlRe.test(codeC1)) {
+    save(c1Js, codeC1.replace(dlRe,
+        '$1/*cowork-bwrap-dl*/if(' + GATE + ')return!1;$2'));
     console.log('  C1: blocked foreground VM download when flagged');
 } else {
     console.log('  C1: WARNING — foreground download anchor not found; ' +
@@ -189,23 +257,29 @@ if (code.includes('/*cowork-bwrap-dl*/')) {
 }
 
 // Warm prefetch: async function Vdo(A,e,t){if(!e){..."[warm] Warm download
-// This function moved to its own code-split chunk in 1.19367.0, so C2
-// operates on warmCode (the warm chunk), which is the same string as
-// `code` only in the older single-file layout.
-let warmCode = warmSameFile ? code : fs.readFileSync(warmJs, 'utf8');
+// Absent from 1.26832.0: that release dropped the log line this anchors
+// on, and with it VM_BUNDLE_SPEC and every warm-file identifier, so the
+// prefetch subsystem looks restructured rather than merely re-minified.
+// No replacement anchor is asserted here on purpose — inventing one
+// risks gating unrelated code. C2 only saves bandwidth, so it warns.
 const warmRe =
     /(async function\s+[\w$]+\([\w$]+,[\w$]+,[\w$]+\)\{)(if\(![\w$]+\)\{[\s\S]{0,120}?\[warm\] Warm download disabled)/;
-if (warmCode.includes('/*cowork-bwrap-warm*/')) {
-    console.log('  C2: warm download block already applied');
-} else if (warmRe.test(warmCode)) {
-    warmCode = warmCode.replace(warmRe,
-        '$1/*cowork-bwrap-warm*/if(' + GATE + ')return;$2');
-    console.log('  C2: blocked warm VM prefetch when flagged');
+if (!c2Js) {
+    console.log('  C2: WARNING — warm download anchor not present in this ' +
+        'bundle; flagged runs may prefetch an unused VM image');
 } else {
-    console.log('  C2: WARNING — warm download anchor not found; flagged ' +
-        'runs may prefetch an unused VM image');
+    const codeC2 = load(c2Js);
+    if (codeC2.includes('/*cowork-bwrap-warm*/')) {
+        console.log('  C2: warm download block already applied');
+    } else if (warmRe.test(codeC2)) {
+        save(c2Js, codeC2.replace(warmRe,
+            '$1/*cowork-bwrap-warm*/if(' + GATE + ')return;$2'));
+        console.log('  C2: blocked warm VM prefetch when flagged');
+    } else {
+        console.log('  C2: WARNING — warm download anchor not found; ' +
+            'flagged runs may prefetch an unused VM image');
+    }
 }
-if (warmSameFile) code = warmCode;
 
 if (loadBearingFailed) {
     console.log('  One or more load-bearing anchors (A/B) missed — ' +
@@ -213,8 +287,7 @@ if (loadBearingFailed) {
     process.exit(1);
 }
 
-fs.writeFileSync(indexJs, code);
-if (!warmSameFile) fs.writeFileSync(warmJs, warmCode);
+for (const [path, contents] of files) fs.writeFileSync(path, contents);
 COWORK_BWRAP_PATCH
 	then
 		echo 'Cowork bwrap fallback patch applied'

--- a/scripts/patches/org-plugins.sh
+++ b/scripts/patches/org-plugins.sh
@@ -10,49 +10,55 @@
 # consistent with Claude Code's /etc/claude-code/ path.
 #
 # Sourced by: build.sh
-# Sourced globals: main_js (optional — the resolved main chunk; set by
-#   patch_app_asar. Falls back to .vite/build/index.js for older bundles.)
+# Sourced globals: (none — resolves its own file via _resolve_anchor_file,
+#   defined in app-asar.sh)
 # Modifies globals: (none)
 #===============================================================================
 
+# Quote class: 1.26832.0 swapped the minifier and re-emitted nearly every
+# string literal as a backtick template, so a bare " in an anchor matches
+# nothing (#820). The injected case keeps double quotes on purpose — it
+# is our own JS and is valid under either emission style.
+_ORG_Q='[`"'"'"']'
+
 patch_org_plugins_path() {
-	local index_js="${main_js:-app.asar.contents/.vite/build/index.js}"
+	# Resolve on the darwin path string, which is unique in the bundle
+	# and — unlike the compound switch anchor below — is not disturbed by
+	# this patch's own insertion. A resolution anchor has to be invariant
+	# under its patch, or the second run fails to find the file at all,
+	# before any idempotency guard can fire.
+	local index_js
+	index_js=$(_resolve_anchor_file 'org-plugins resolver' \
+		'Application Support/Claude/org-plugins') || return 1
 
 	# Idempotency: skip if a Linux case already exists near the
 	# org-plugins path resolver (upstream may add one in the future).
-	if grep -q 'case"linux":return"/etc/claude/org-plugins"' \
+	if grep -qP "case\\s*${_ORG_Q}linux${_ORG_Q}\\s*:\\s*return\\s*${_ORG_Q}/etc/claude/org-plugins" \
 		"$index_js"; then
 		echo 'Linux org-plugins path already present'
 		return
 	fi
 
 	# Anchor: the darwin path string is unique in the entire bundle.
-	# Verify it exists before attempting the patch.
+	# Verify it exists before attempting the patch. No quote class needed
+	# — the match is on the path's interior, away from either delimiter.
 	local anchor='Application Support/Claude/org-plugins'
-	if ! grep -q "$anchor" "$index_js"; then
+	if ! grep -qF "$anchor" "$index_js"; then
 		echo 'Warning: org-plugins path resolver not found' \
 			'in this version, skipping' >&2
 		return
 	fi
 
 	# Pattern (minified):
-	#   ..."org-plugins");default:return null}
+	#   ...`org-plugins`);default:return null}
 	#
-	# The compound anchor — "org-plugins") immediately before
-	# default:return null — is unique to this switch statement.
 	# Insert case"linux":return"/etc/claude/org-plugins"; between
 	# the end of the win32 case and the default case.
 	#
 	# \s* between tokens handles any future whitespace variation,
 	# though the target file is always minified in practice.
-	if grep -qP '"org-plugins"\)\s*;\s*default\s*:\s*return\s+null' \
-		"$index_js"; then
-		sed -i -E \
-			's/("org-plugins"\)\s*;\s*)(default\s*:\s*return\s+null)/\1case"linux":return"\/etc\/claude\/org-plugins";\2/' \
-			"$index_js"
-		echo 'Added Linux org-plugins path (/etc/claude/org-plugins)'
-	else
-		echo 'Warning: org-plugins switch pattern not matched,' \
-			'skipping' >&2
-	fi
+	sed -i -E \
+		"s/(${_ORG_Q}org-plugins${_ORG_Q}\\)\\s*;\\s*)(default\\s*:\\s*return\\s+null)/\\1case\"linux\":return\"\\/etc\\/claude\\/org-plugins\";\\2/" \
+		"$index_js"
+	echo 'Added Linux org-plugins path (/etc/claude/org-plugins)'
 }

--- a/scripts/patches/quick-window.sh
+++ b/scripts/patches/quick-window.sh
@@ -3,19 +3,36 @@
 # so the main window reappears after quick-entry submit.
 #
 # Sourced by: build.sh
-# Sourced globals: main_js (optional — the resolved main chunk; set by
-#   patch_app_asar. Falls back to .vite/build/index.js for older bundles.)
+# Sourced globals: (none — each part resolves its own file via
+#   _resolve_anchor_file, defined in app-asar.sh)
 # Modifies globals: (none)
+#
+# The two parts resolve independently: on 1.26832.0 both happen to land
+# in the same chunk, but part 1's setAlwaysOnTop call and part 2's
+# QuickEntry submit path are separate subsystems and upstream is free to
+# split them apart again.
 #===============================================================================
+
+# Quote class: 1.26832.0 swapped the minifier and re-emitted nearly every
+# string literal as a backtick template, so a bare " in an anchor matches
+# nothing (#820).
+_QW_Q='[`"'"'"']'
 
 patch_quick_window() {
 	echo 'Patching quick window for Linux...'
-	local index_js="${main_js:-app.asar.contents/.vite/build/index.js}"
+
+	# Resolve on the full setAlwaysOnTop shape, not on "pop-up-menu"
+	# alone — the bare literal also occurs in a sibling chunk that has no
+	# call to rewrite.
+	local index_js
+	index_js=$(_resolve_anchor_file 'quick-window setAlwaysOnTop' \
+		"[\$\\w]+\\.setAlwaysOnTop\\(\\s*!0\\s*,\\s*${_QW_Q}pop-up-menu${_QW_Q}\\)") \
+		|| return 1
 
 	# Extract the quick window variable name from the unique "pop-up-menu"
-	# setAlwaysOnTop call, e.g.: Sa.setAlwaysOnTop(!0,"pop-up-menu")
+	# setAlwaysOnTop call, e.g.: Sa.setAlwaysOnTop(!0,`pop-up-menu`)
 	local quick_var
-	quick_var=$(grep -oP '[$\w]+(?=\.setAlwaysOnTop\(\s*!0\s*,\s*"pop-up-menu"\))' \
+	quick_var=$(grep -oP "[\$\\w]+(?=\\.setAlwaysOnTop\\(\\s*!0\\s*,\\s*${_QW_Q}pop-up-menu${_QW_Q}\\))" \
 		"$index_js" | head -1)
 	if [[ -z $quick_var ]]; then
 		echo 'WARNING: Could not extract quick window variable name'
@@ -50,58 +67,46 @@ patch_quick_window() {
 	# FOCUS_CHECK()||Lt.show() to skip the show. Gate the visibility-check
 	# replacement to KDE only: on GNOME, the original focus check works
 	# and replacing it regresses quick entry (see #393).
-	if INDEX_JS="$index_js" node << 'QUICK_WINDOW_PATCH'
+	#
+	# Resolved separately from part 1: the QuickEntry submit path is its
+	# own subsystem and upstream may split it into another chunk.
+	local submit_js
+	submit_js=$(_resolve_anchor_file 'quick-entry submit' \
+		'\[QuickEntry\] Creating new chat with submit_quick_entry') \
+		|| return 1
+
+	if INDEX_JS="$submit_js" node << 'QUICK_WINDOW_PATCH'
 const fs = require('fs');
 const indexJs = process.env.INDEX_JS;
 let code = fs.readFileSync(indexJs, 'utf8');
 let patchCount = 0;
 
-// Find the minified isWindowFocused function via its named property
-// export: isWindowFocused: () => !!NAME()
-const focusedPropRe = /isWindowFocused:\s*\(\)\s*=>\s*!!([\w$]+)\(\)/;
-const focusedMatch = code.match(focusedPropRe);
-if (!focusedMatch) {
-    console.log('  WARNING: Could not find isWindowFocused function');
-    process.exit(1);
-}
-const focusFn = focusedMatch[1];
-console.log('  Found focus check function: ' + focusFn);
-
-// Find the sibling isVisible function defined near the focus function.
-// Tolerate the optional `var <name>(,<name>)*;` declaration the
-// minifier hoists when the function body uses optional chaining
-// (1.3883.0+ shape: `function aZA(){var e;return!Qt...}`). Older
-// builds don't declare anything before `return!`. The non-capturing
-// group keeps the prefix optional in either case.
+// Both the focus check and the window handle are captured from the call
+// site itself.
 //
-// The window handle churns: a bare minified local (`Qt`, `it`) through
-// 1.18286.0, a property access (`exports.mainWindow`) from 1.19367.0.
-// [\w$]+(?:\.[\w$]+)* covers both; the fn-name capture is [\w$]+ (not
-// \w+) so a `$`-prefixed name isn't silently truncated
-// (docs/learnings/patching-minified-js.md).
-const focusFnIdx = code.indexOf('function ' + focusFn + '(');
-const nearbyCode = code.substring(focusFnIdx, focusFnIdx + 500);
+// Earlier revisions resolved them definition-side: find
+// `isWindowFocused:()=>!!X()`, then hunt for a sibling visibility helper
+// near X's definition. 1.26832.0 moved that pair into a shared module,
+// so the call site now sees them only as import bindings (`i.s`, `i.f`)
+// whose names have nothing to do with the definitions, and the
+// definitions live in a different file from the call site. A
+// definition-side lookup can no longer name what the call site calls;
+// the call site is the only place both are spelled the way they are
+// used. Capturing there also drops two fragile lookups.
 const win = String.raw`[\w$]+(?:\.[\w$]+)*`;
-const visFnRe = new RegExp(
-    String.raw`function ([\w$]+)\(\)\{(?:var [\w$]+(?:,[\w$]+)*;)?` +
-    `return!${win}\\|\\|${win}\\.isDestroyed\\(\\)\\?!1:` +
-    `${win}\\.isVisible\\(\\)`
-);
-const visMatch = nearbyCode.match(visFnRe);
-if (!visMatch) {
-    console.log('  WARNING: Could not find visibility function near ' +
-        focusFn);
-    process.exit(1);
-}
-const visFn = visMatch[1];
-console.log('  Found visibility check function: ' + visFn);
 
-// Anchor on unique QuickEntry log strings to patch only the right sites
+// Anchor on unique QuickEntry log strings to patch only the right sites.
+// A second anchor, 'Navigating to existing chat', was dropped: it is
+// absent from both 1.24012.11 and 1.26832.0, so it only ever produced a
+// standing WARNING that trained the eye to ignore real ones.
 const anchors = [
-    'Navigating to existing chat',
     'Creating new chat with submit_quick_entry',
 ];
-const escapeRegExp = s => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// Sites already carrying the gate from a previous run. Counted
+// separately from patchCount so a re-run over a fully patched bundle
+// stays silent instead of emitting a WARNING that nothing was patched —
+// there was nothing left to patch, which is success, not a miss.
+let alreadyCount = 0;
 for (const anchor of anchors) {
     const anchorIdx = code.indexOf(anchor);
     if (anchorIdx === -1) {
@@ -114,31 +119,49 @@ for (const anchor of anchors) {
     if (region.indexOf('XDG_CURRENT_DESKTOP') !== -1) {
         console.log('  Quick entry show() already patched near "' +
             anchor.substring(0, 30) + '..."');
+        alreadyCount++;
         continue;
     }
-    // matches: <focusFn>()||<win>.show(), where <win> is a bare local
-    // (older builds) or a property access like exports.mainWindow
-    // (1.19367.0+). Capturing the whole handle keeps the .show() call
+    // matches: <focusCall>()||<win>.show(). Both sides are captured:
+    // <focusCall> is a bare minified local (`n1`) on older builds and an
+    // import binding (`i.s`) from 1.26832.0; <win> is a bare local
+    // through 1.18286.0, `exports.mainWindow` from 1.19367.0, and `i.f`
+    // from 1.26832.0. Capturing the whole handle keeps the .show() call
     // pointed at the real window after the rewrite.
     const showRe = new RegExp(
-        escapeRegExp(focusFn) + String.raw`\(\)\|\|(${win})\.show\(\)`
+        `(${win})\\(\\)\\|\\|(${win})\\.show\\(\\)`
     );
     const showMatch = region.match(showRe);
     if (showMatch) {
         const oldStr = showMatch[0];
-        const mainWin = showMatch[1];
+        const focusCall = showMatch[1];
+        const mainWin = showMatch[2];
         // Gate the visibility check to KDE only; fall back to original
         // focus check on GNOME/other so #390 doesn't regress them (#393).
         const deCheck = '(process.env.XDG_CURRENT_DESKTOP||"")' +
             '.toLowerCase().includes("kde")';
-        const newStr = '(' + deCheck + '?' + visFn + '():' +
-            focusFn + '())||' + mainWin + '.show()';
+        // Inline the visibility test from the captured handle rather
+        // than calling upstream's helper, which is no longer nameable
+        // from here. Upstream's version ORs in
+        // `mainView?.webContents?.isFocused()`; this drops that clause,
+        // so a hidden window whose webContents still reports focus now
+        // gets show() called instead of skipped. That is the safe
+        // direction for #390, whose whole symptom is show() being
+        // skipped, and the state itself is not reachable in practice.
+        const visible = '(!' + mainWin + '||' + mainWin +
+            '.isDestroyed()?!1:' + mainWin + '.isVisible())';
+        // Built by concatenation, never through replace(): a captured
+        // handle can contain `$`, which replace() would reinterpret as a
+        // substitution pattern (docs/learnings/patching-minified-js.md).
+        const newStr = '(' + deCheck + '?' + visible + ':' +
+            focusCall + '())||' + mainWin + '.show()';
         if (oldStr !== newStr) {
             const absIdx = anchorIdx + region.indexOf(oldStr);
             code = code.substring(0, absIdx) + newStr +
                 code.substring(absIdx + oldStr.length);
-            console.log('  KDE-gated ' + focusFn + '()/' + visFn +
-                '() for show() near "' + anchor.substring(0, 30) + '..."');
+            console.log('  KDE-gated ' + focusCall + '()/' + mainWin +
+                '.isVisible() for show() near "' +
+                anchor.substring(0, 30) + '..."');
             patchCount++;
         }
     } else {
@@ -151,6 +174,9 @@ if (patchCount > 0) {
     fs.writeFileSync(indexJs, code);
     console.log('  Patched ' + patchCount +
         ' quick entry show() calls to use visibility check');
+} else if (alreadyCount === anchors.length) {
+    console.log('  Quick entry show() calls already patched (' +
+        alreadyCount + '/' + anchors.length + ')');
 } else {
     console.log('  WARNING: No quick entry show() calls patched');
 }

--- a/scripts/patches/tray-icon-selection.sh
+++ b/scripts/patches/tray-icon-selection.sh
@@ -28,14 +28,25 @@
 # Interim fix pending upstream; this is not a net-new feature.
 #
 # Sourced by: build.sh
-# Sourced globals: main_js (optional — the resolved main chunk; set by
-#   patch_app_asar. Falls back to .vite/build/index.js for older bundles.)
+# Sourced globals: (none — resolves its own file via _resolve_anchor_file,
+#   defined in app-asar.sh)
 # Modifies globals: (none)
 #===============================================================================
 
 patch_tray_icon_env_override() {
 	echo 'Patching Linux tray icon selection (CLAUDE_TRAY_USE_DARK_ICON)...'
-	local index_js="${main_js:-app.asar.contents/.vite/build/index.js}"
+
+	# On 1.26832.0 this anchor sits in index.js itself rather than in any
+	# chunk — the entry file stopped being a stub and now carries real
+	# code (#820). Resolving by anchor rather than by filename is what
+	# makes that a non-event.
+	local index_js
+	# Anchored on the adjacent icon-literal pair rather than on the
+	# ternary condition: the patch rewrites the condition but re-emits
+	# these two literals verbatim, so resolution still works on a re-run.
+	index_js=$(_resolve_anchor_file 'tray icon literals' \
+		'[`"'"'"']TrayIconLinux-Dark\.png[`"'"'"']\s*:\s*[`"'"'"']TrayIconLinux\.png[`"'"'"']') \
+		|| return 1
 
 	# Anchored on the two stable icon literals (developer strings
 	# survive minification); the DE-detector and electron identifiers
@@ -71,11 +82,16 @@ if (code.includes(applied)) {
 // ((0,i.oPe)()) and the electron handle tolerates a property chain —
 // both are real minifier artifacts post-code-split (the quick-window
 // patch hit the exports.mainWindow rename the same way).
+// q(): match a literal under any delimiter. 1.26832.0 swapped the
+// minifier and re-emitted nearly every string as a backtick template, so
+// a bare " here matches nothing (#820).
+const q = s => '[`"\']' + s + '[`"\']';
 const ternRe = new RegExp(
     String.raw`((?:\(0,\s*[\w$]+(?:\.[\w$]+)*\)|[\w$]+))` +
-    String.raw`\(\)\s*===\s*"gnome"\s*\|\|\s*` +
+    `\\(\\)\\s*===\\s*${q('gnome')}\\s*\\|\\|\\s*` +
     String.raw`([\w$]+(?:\.[\w$]+)*)\.nativeTheme\.shouldUseDarkColors` +
-    String.raw`\s*\?\s*"TrayIconLinux-Dark\.png"\s*:\s*"TrayIconLinux\.png"`,
+    `\\s*\\?\\s*${q('TrayIconLinux-Dark\\.png')}` +
+    `\\s*:\\s*${q('TrayIconLinux\\.png')}`,
     'g');
 const matches = [...code.matchAll(ternRe)];
 if (matches.length !== 1) {

--- a/scripts/patches/virtiofsd-probe.sh
+++ b/scripts/patches/virtiofsd-probe.sh
@@ -23,14 +23,20 @@
 # list this tightly).
 #
 # Sourced by: build.sh
-# Sourced globals: main_js (optional — the resolved main chunk; set by
-#   patch_app_asar. Falls back to .vite/build/index.js for older bundles.)
+# Sourced globals: (none — resolves its own file via _resolve_anchor_file,
+#   defined in app-asar.sh)
 # Modifies globals: (none)
 #===============================================================================
 
 patch_virtiofsd_probe() {
 	echo 'Patching virtiofsd resolution (bundled fallback un-gate)...'
-	local index_js="${main_js:-app.asar.contents/.vite/build/index.js}"
+
+	# Resolve on the probe-path array itself: `virtiofsd` alone also
+	# appears in a second 1.26832.0 chunk that has no array to rewrite.
+	local index_js
+	index_js=$(_resolve_anchor_file 'virtiofsd probe array' \
+		'\[\s*[`"'"'"']/usr/libexec/virtiofsd[`"'"'"']\s*,\s*[`"'"'"']/usr/bin/virtiofsd[`"'"'"']\s*\]') \
+		|| return 1
 
 	# Anchored on the probe-path array literal (path strings survive
 	# minification); the gate rewrite happens in a bounded window after
@@ -42,11 +48,17 @@ const fs = require('fs');
 const indexJs = process.env.INDEX_JS;
 let code = fs.readFileSync(indexJs, 'utf8');
 
+// q(): match a literal under any delimiter. 1.26832.0 swapped the
+// minifier and re-emitted nearly every string as a backtick template, so
+// a bare " here matches nothing (#820).
+const q = s => '[`"\']' + s + '[`"\']';
+
 // The client's virtiofsd probe-path array, whitespace-tolerant for
 // beautified bundles:
-//   ["/usr/libexec/virtiofsd","/usr/bin/virtiofsd"]
-const arrRe =
-    /\[\s*"\/usr\/libexec\/virtiofsd"\s*,\s*"\/usr\/bin\/virtiofsd"\s*\]/g;
+//   [`/usr/libexec/virtiofsd`,`/usr/bin/virtiofsd`]
+const arrRe = new RegExp(
+    '\\[\\s*' + q('\\/usr\\/libexec\\/virtiofsd') + '\\s*,\\s*' +
+    q('\\/usr\\/bin\\/virtiofsd') + '\\s*\\]', 'g');
 const arrMatches = [...code.matchAll(arrRe)];
 if (arrMatches.length !== 1) {
     console.log('  WARNING: expected exactly 1 virtiofsd probe-path ' +
@@ -60,15 +72,25 @@ const start = arrMatches[0].index + arrMatches[0][0].length;
 const region = code.substring(start, start + 1200);
 
 // Gated resolver tail (minified):
-//   return e||(A?d3A(igi,bA.constants.X_OK):null)
-// e = system-path hit, A = "is Ubuntu 22.x", d3A(igi,...) = bundled
-// copy at process.resourcesPath. Identifiers are captured, not
-// hardcoded — they change every release.
-const gatedRe =
-    /return\s+([\w$]+)\s*\|\|\s*\(\s*[\w$]+\s*\?\s*([\w$]+\(\s*[\w$]+\s*,\s*[\w$]+\.constants\.X_OK\s*\))\s*:\s*null\s*\)/;
+//   1.24012.11: return e||(A?d3A(igi,bA.constants.X_OK):null)
+//   1.26832.0:  return await FT(kT)||(e?IT(TT,N.constants.X_OK):null)
+// The left operand is the system-path hit. It used to be a bare
+// identifier holding an already-awaited result; 1.26832.0 inlined the
+// call, so it is now an `await F(x)` expression. Accept either shape --
+// anything else here would be a different code path, not a re-minified
+// one. The middle operand is "is Ubuntu 22.x" and the captured call is
+// the bundled copy at process.resourcesPath. Identifiers are captured,
+// not hardcoded, since they change every release.
+const lhs = String.raw`(await\s+[\w$]+\(\s*[\w$]*\s*\)|[\w$]+)`;
+const bundled =
+    String.raw`([\w$]+\(\s*[\w$]+\s*,\s*[\w$]+\.constants\.X_OK\s*\))`;
+const gatedRe = new RegExp(
+    `return\\s+${lhs}\\s*\\|\\|\\s*\\(\\s*[\\w$]+\\s*\\?\\s*` +
+    `${bundled}\\s*:\\s*null\\s*\\)`);
 // Already-ungated form, for idempotency (re-run, or upstream fix):
-const ungatedRe =
-    /return\s+([\w$]+)\s*\|\|\s*[\w$]+\(\s*[\w$]+\s*,\s*[\w$]+\.constants\.X_OK\s*\)/;
+const ungatedRe = new RegExp(
+    `return\\s+${lhs}\\s*\\|\\|\\s*` +
+    String.raw`[\w$]+\(\s*[\w$]+\s*,\s*[\w$]+\.constants\.X_OK\s*\)`);
 
 const gated = region.match(gatedRe);
 if (gated) {

--- a/tests/app-asar.bats
+++ b/tests/app-asar.bats
@@ -7,18 +7,20 @@
 # deleted 2.x patches used to WARN when those anchors moved, and the
 # tripwires replace that signal.
 #
-# _resolve_main_js: since 1.19367.0 the main process is code-split, so
-# index.js is a stub that require()s a content-hashed main chunk. The
-# resolver follows that require, falls back to index.js on the older
-# single-file layout, and fails loud on anything ambiguous.
+# _resolve_anchor_file: there is no single main-process file any more.
+# 1.19367.0 split it into a stub plus one content-hashed chunk; 1.26832.0
+# dissolved that core into 83 chunks across two families and left some
+# anchors in index.js itself (#820). Each patch resolves the file its own
+# anchor lives in, and the exactly-one assertion is what replaces the old
+# multi-chunk guard.
 
 setup() {
 	source "$BATS_TEST_DIRNAME/../scripts/patches/app-asar.sh"
 }
 
-# Build the .vite/build tree _resolve_main_js reads (relative to CWD) and
-# cd into its parent so the resolver's relative paths resolve. $1 = the
-# index.js body; remaining args = "chunk-name:body" files to also create.
+# Build the .vite/build tree _resolve_anchor_file reads (relative to CWD)
+# and cd into its parent so the resolver's relative paths resolve. $1 =
+# the index.js body; remaining args = "chunk-name:body" files to create.
 _make_build_tree() {
 	local index_body="$1"
 	shift
@@ -87,58 +89,98 @@ _write_bundle() {
 	[[ $output == *'MB-1'* ]]
 }
 
-@test "resolve: follows the stub require to the code-split main chunk" {
+@test "resolve: finds the single chunk carrying the anchor" {
 	_make_build_tree \
 		'"use strict";require("./index.chunk-CNXUb5h4.js");' \
-		'index.chunk-CNXUb5h4.js:/* main process */'
-	run _resolve_main_js
+		'index.chunk-CNXUb5h4.js:var a=`TrayIconLinux-Dark.png`;'
+	run _resolve_anchor_file 'tray' 'TrayIconLinux-Dark\.png'
 	[[ $status -eq 0 ]]
 	[[ $output == 'app.asar.contents/.vite/build/index.chunk-CNXUb5h4.js' ]]
 }
 
-@test "resolve: falls back to index.js on the old single-file layout" {
-	_make_build_tree 'var x=1;/* whole main process, no chunk require */'
-	run _resolve_main_js
+@test "resolve: finds an anchor left in index.js itself (1.26832.0)" {
+	# The entry file stopped being a stub: the tray anchor lives there.
+	_make_build_tree \
+		'var a=`TrayIconLinux-Dark.png`;require("./index.chunk-AAAA1111.js");' \
+		'index.chunk-AAAA1111.js:/* unrelated */'
+	run _resolve_anchor_file 'tray' 'TrayIconLinux-Dark\.png'
 	[[ $status -eq 0 ]]
 	[[ $output == 'app.asar.contents/.vite/build/index.js' ]]
 }
 
-@test "resolve: ignores non-chunk requires when falling back" {
-	# electron/node requires in the stub must not be mistaken for a chunk
+@test "resolve: finds an anchor in the index2 chunk family" {
 	_make_build_tree \
-		'require("node:path");require("electron");require("./preload.js");'
-	run _resolve_main_js
+		'require("./index2.chunk-ZZZZ9999.js");' \
+		'index2.chunk-ZZZZ9999.js:function q(){return process.platform,r()}'
+	run _resolve_anchor_file 'cowork A' 'return process\.platform,[\w$]+\(\)\}'
 	[[ $status -eq 0 ]]
-	[[ $output == 'app.asar.contents/.vite/build/index.js' ]]
+	[[ $output == 'app.asar.contents/.vite/build/index2.chunk-ZZZZ9999.js' ]]
 }
 
-@test "resolve: fails loud when the stub requires two main chunks" {
+@test "resolve: matches a backtick literal via the quote class" {
+	# 1.26832.0 re-emitted nearly every string as a backtick template; an
+	# anchor pinned to a bare double quote would find nothing.
 	_make_build_tree \
-		'require("./index.chunk-AAAA1111.js");require("./index.chunk-BBBB2222.js");' \
-		'index.chunk-AAAA1111.js:/* a */' \
-		'index.chunk-BBBB2222.js:/* b */'
-	run _resolve_main_js
-	[[ $status -eq 1 ]]
-	[[ $output == *'2 main chunks'* ]]
-	[[ $output == *'per-anchor resolution'* ]]
+		'var x=1;' \
+		'index.chunk-AAAA1111.js:e.setAlwaysOnTop(!0,`pop-up-menu`)'
+	run _resolve_anchor_file 'quick-window' \
+		'\.setAlwaysOnTop\(\s*!0\s*,\s*[`"'"'"']pop-up-menu[`"'"'"']\)'
+	[[ $status -eq 0 ]]
+	[[ $output == 'app.asar.contents/.vite/build/index.chunk-AAAA1111.js' ]]
 }
 
-@test "resolve: fails loud when the required chunk file is missing" {
-	# stub names a chunk, but the bundler output doesn't contain it
+@test "resolve: the same anchor still matches the old double-quoted shape" {
 	_make_build_tree \
-		'require("./index.chunk-CNXUb5h4.js");'
-	run _resolve_main_js
-	[[ $status -eq 1 ]]
-	[[ $output == *'missing'* ]]
+		'var x=1;' \
+		'index.chunk-AAAA1111.js:e.setAlwaysOnTop(!0,"pop-up-menu")'
+	run _resolve_anchor_file 'quick-window' \
+		'\.setAlwaysOnTop\(\s*!0\s*,\s*[`"'"'"']pop-up-menu[`"'"'"']\)'
+	[[ $status -eq 0 ]]
+	[[ $output == 'app.asar.contents/.vite/build/index.chunk-AAAA1111.js' ]]
 }
 
-@test "resolve: fails loud when index.js is absent" {
+@test "resolve: fails loud when the anchor matches nothing" {
+	_make_build_tree 'var x=1;' 'index.chunk-AAAA1111.js:/* nothing */'
+	run _resolve_anchor_file 'tray' 'TrayIconLinux-Dark\.png'
+	[[ $status -eq 1 ]]
+	[[ $output == *'matched no file'* ]]
+	[[ $output == *'Re-derive'* ]]
+}
+
+@test "resolve: fails loud when the anchor is ambiguous across chunks" {
+	# The decoy case: a distinctive string can recur in a sibling chunk
+	# that carries no call to rewrite, so resolving on it must not pick
+	# one at random.
+	_make_build_tree \
+		'var x=1;' \
+		'index.chunk-AAAA1111.js:log(`pop-up-menu`)' \
+		'index.chunk-BBBB2222.js:e.setAlwaysOnTop(!0,`pop-up-menu`)'
+	run _resolve_anchor_file 'quick-window' 'pop-up-menu'
+	[[ $status -eq 1 ]]
+	[[ $output == *'matched 2 files'* ]]
+	[[ $output == *'ambiguous'* ]]
+}
+
+@test "resolve: the full anchor shape disambiguates where the string cannot" {
+	# Same tree as above; anchoring on the call shape rather than the
+	# bare literal selects the one file that actually has a patch site.
+	_make_build_tree \
+		'var x=1;' \
+		'index.chunk-AAAA1111.js:log(`pop-up-menu`)' \
+		'index.chunk-BBBB2222.js:e.setAlwaysOnTop(!0,`pop-up-menu`)'
+	run _resolve_anchor_file 'quick-window' \
+		'\.setAlwaysOnTop\(\s*!0\s*,\s*[`"'"'"']pop-up-menu[`"'"'"']\)'
+	[[ $status -eq 0 ]]
+	[[ $output == 'app.asar.contents/.vite/build/index.chunk-BBBB2222.js' ]]
+}
+
+@test "resolve: fails loud when the build dir is absent" {
 	rm -rf "$BATS_TEST_TMPDIR/app.asar.contents"
-	mkdir -p "$BATS_TEST_TMPDIR/app.asar.contents/.vite/build"
+	mkdir -p "$BATS_TEST_TMPDIR"
 	cd "$BATS_TEST_TMPDIR" || return 1
-	run _resolve_main_js
+	run _resolve_anchor_file 'tray' 'TrayIconLinux-Dark\.png'
 	[[ $status -eq 1 ]]
-	[[ $output == *'No index.js'* ]]
+	[[ $output == *'upstream layout changed'* ]]
 }
 
 # =============================================================================

--- a/tests/patch-anchors.bats
+++ b/tests/patch-anchors.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+#
+# patch_quick_window / patch_org_plugins_path / patch_virtiofsd_probe:
+# the three asar patches that had no BATS coverage until #820. Each is
+# exercised against BOTH shipped shapes, because 1.26832.0 swapped the
+# bundler and re-emitted the same code differently:
+#
+#   1.24012.11 — double-quoted literals, const, bare identifiers,
+#                downleveled optional chaining
+#   1.26832.0  — backtick templates, let, module-binding callees
+#                (`p.n()`, `i.s()`), preserved optional chaining
+#
+# Every fixture below is copied from the shipped minified bytes of the
+# release named in its comment, not hand-written, so a passing test means
+# the anchor matches what upstream actually emits. The near-miss fixtures
+# sit one edit from the anchor on purpose: loosening a regex turns their
+# expected failure into a pass and goes red
+# (docs/learnings/test-methodology-and-coverage.md).
+
+setup() {
+	for p in quick-window org-plugins virtiofsd-probe; do
+		# shellcheck source=/dev/null
+		source "$BATS_TEST_DIRNAME/../scripts/patches/$p.sh"
+	done
+	# _resolve_anchor_file: each patch resolves its own file (#820).
+	# shellcheck source=scripts/patches/app-asar.sh
+	source "$BATS_TEST_DIRNAME/../scripts/patches/app-asar.sh"
+
+	BUILD="$BATS_TEST_TMPDIR/app.asar.contents/.vite/build"
+	mkdir -p "$BUILD"
+}
+
+# $1 = chunk basename, $2 = contents
+_chunk() {
+	printf '%s\n' "$2" > "$BUILD/$1"
+	cd "$BATS_TEST_TMPDIR" || return 1
+}
+
+# =============================================================================
+# quick-window
+# =============================================================================
+
+# 1.24012.11 shipped bytes: quick var `er`, double-quoted "pop-up-menu",
+# the `N6()||er.hide()` site, and the QuickEntry submit path whose show()
+# call reads `n1()||exports.mainWindow.show()`.
+QW_OLD='function N6(){return!er||er.isDestroyed()}function nce(){N6()||er.hide()}
+Il.QUICK_ENTRY),er.setAlwaysOnTop(!0,"pop-up-menu"),er.webContents;
+_.info("[QuickEntry] Creating new chat with submit_quick_entry");n1()||exports.mainWindow.show()'
+
+# 1.26832.0 shipped bytes: quick var `R`, backticked `pop-up-menu`, and a
+# show() site whose focus check is the module binding `i.s`.
+QW_NEW='function N6(){return!R||R.isDestroyed()}function nce(){N6()||R.hide()}
+n.n.QUICK_ENTRY),R.setAlwaysOnTop(!0,`pop-up-menu`),R.webContents;
+n.o.info(`[QuickEntry] Creating new chat with submit_quick_entry`);i.s()||i.f.show()'
+
+@test "quick-window: applies to the 1.24012.11 double-quoted shape" {
+	_chunk 'index.chunk-test.js' "$QW_OLD"
+	run patch_quick_window
+	[[ $status -eq 0 ]]
+	[[ $output == *'Found quick window variable: er'* ]]
+	grep -qF 'er.blur(),er.hide()' "$BUILD/index.chunk-test.js"
+	grep -qF 'n1())||exports.mainWindow.show()' "$BUILD/index.chunk-test.js"
+}
+
+@test "quick-window: applies to the 1.26832.0 backticked shape" {
+	# The delimiter flip alone took this anchor to zero matches (#820).
+	_chunk 'index.chunk-test.js' "$QW_NEW"
+	run patch_quick_window
+	[[ $status -eq 0 ]]
+	[[ $output == *'Found quick window variable: R'* ]]
+	grep -qF 'R.blur(),R.hide()' "$BUILD/index.chunk-test.js"
+}
+
+@test "quick-window: captures a module-binding focus check (i.s)" {
+	# 1.26832.0 moved the focus/visibility pair into a shared module, so
+	# the call site sees `i.s()`, not a bare identifier. A capture
+	# restricted to [\w$]+ silently fails to rewrite the show() call.
+	_chunk 'index.chunk-test.js' "$QW_NEW"
+	patch_quick_window
+	grep -qF 'i.s())||i.f.show()' "$BUILD/index.chunk-test.js"
+	# The KDE branch must test visibility on the captured handle.
+	grep -qF 'i.f.isVisible()' "$BUILD/index.chunk-test.js"
+}
+
+@test "quick-window: re-run is a no-op and warns about nothing" {
+	_chunk 'index.chunk-test.js' "$QW_NEW"
+	patch_quick_window
+	local first; first="$(cat "$BUILD/index.chunk-test.js")"
+	run patch_quick_window
+	[[ $status -eq 0 ]]
+	[[ $output == *'already patched'* ]]
+	# A fully patched bundle must not emit a WARNING; a standing warning
+	# on every rebuild trains the eye to ignore real ones.
+	[[ $output != *'WARNING'* ]]
+	[[ "$(cat "$BUILD/index.chunk-test.js")" == "$first" ]]
+}
+
+@test "quick-window: decoy chunk without the call site is not selected" {
+	# `pop-up-menu` occurs in two 1.26832.0 chunks; only one has the
+	# setAlwaysOnTop call. Resolving on the bare string picks a decoy.
+	_chunk 'index.chunk-decoy.js' 'n.o.info(`pop-up-menu opened`)'
+	_chunk 'index.chunk-real.js' "$QW_NEW"
+	run patch_quick_window
+	[[ $status -eq 0 ]]
+	grep -qF 'R.blur(),R.hide()' "$BUILD/index.chunk-real.js"
+	run grep -qF 'blur()' "$BUILD/index.chunk-decoy.js"
+	[[ $status -ne 0 ]]
+}
+
+# =============================================================================
+# org-plugins
+# =============================================================================
+
+# 1.24012.11 shipped bytes.
+ORG_OLD='return"/Library/Application Support/Claude/org-plugins";case"win32":return C.join("C:\\Program Files","Claude","org-plugins");default:return null}}'
+
+# 1.26832.0 shipped bytes: backticks throughout, indirect join callee.
+ORG_NEW='return`/Library/Application Support/Claude/org-plugins`;case`win32`:return(0,j.join)(`C:\\Program Files`,`Claude`,`org-plugins`);default:return null}}'
+
+@test "org-plugins: injects the linux case on the 1.24012.11 shape" {
+	_chunk 'index.chunk-test.js' "$ORG_OLD"
+	run patch_org_plugins_path
+	[[ $status -eq 0 ]]
+	grep -qF 'case"linux":return"/etc/claude/org-plugins";default:return null' \
+		"$BUILD/index.chunk-test.js"
+}
+
+@test "org-plugins: injects the linux case on the 1.26832.0 shape" {
+	_chunk 'index.chunk-test.js' "$ORG_NEW"
+	run patch_org_plugins_path
+	[[ $status -eq 0 ]]
+	# Injected ahead of default:, and our own JS stays double-quoted.
+	grep -qF 'case"linux":return"/etc/claude/org-plugins";default:return null' \
+		"$BUILD/index.chunk-test.js"
+}
+
+@test "org-plugins: idempotent and byte-identical on re-run" {
+	# The insertion splits the compound switch anchor, so a resolution
+	# anchor keyed on that shape would fail to find the file at all on
+	# the second pass, before the idempotency guard could fire (#820).
+	_chunk 'index.chunk-test.js' "$ORG_NEW"
+	patch_org_plugins_path
+	local first; first="$(cat "$BUILD/index.chunk-test.js")"
+	run patch_org_plugins_path
+	[[ $status -eq 0 ]]
+	[[ $output == *'already present'* ]]
+	[[ "$(cat "$BUILD/index.chunk-test.js")" == "$first" ]]
+}
+
+@test "org-plugins: switch without the default arm is left alone" {
+	# One edit short: the resolver still finds the file via the darwin
+	# path, but the compound switch anchor must not match.
+	_chunk 'index.chunk-test.js' \
+		'return`/Library/Application Support/Claude/org-plugins`;case`win32`:return`x`}}'
+	run patch_org_plugins_path
+	[[ $status -eq 0 ]]
+	run grep -qF '/etc/claude/org-plugins' "$BUILD/index.chunk-test.js"
+	[[ $status -ne 0 ]]
+}
+
+# =============================================================================
+# virtiofsd-probe
+# =============================================================================
+
+# 1.24012.11 shipped bytes: double-quoted probe array, and a resolver
+# whose left operand is a bare identifier holding an awaited result.
+VFSD_OLD='Gon=["/usr/libexec/virtiofsd","/usr/bin/virtiofsd"];async function Zon(){try{const e=await Ome();return(e==null?void 0:e.id)==="ubuntu"&&(e.versionId??"").startsWith("22.")}catch{return!1}}async function Kon(e){const t=await Qot(Gon);return t||(e?loe(Won,Y.constants.X_OK):null)}'
+
+# 1.26832.0 shipped bytes: backticked array, preserved optional chaining,
+# and the await inlined into the left operand of the ||.
+VFSD_NEW='kT=[`/usr/libexec/virtiofsd`,`/usr/bin/virtiofsd`];async function AT(){try{let e=await fT();return e?.id===`ubuntu`&&(e.versionId??``).startsWith(`22.`)}catch{return!1}}async function jT(e){return await FT(kT)||(e?IT(TT,N.constants.X_OK):null)}'
+
+@test "virtiofsd: un-gates the fallback on the 1.24012.11 shape" {
+	_chunk 'index.chunk-test.js' "$VFSD_OLD"
+	run patch_virtiofsd_probe
+	[[ $status -eq 0 ]]
+	grep -qF 'return t||loe(Won,Y.constants.X_OK)' \
+		"$BUILD/index.chunk-test.js"
+}
+
+@test "virtiofsd: un-gates the fallback on the 1.26832.0 shape" {
+	# The left operand became `await FT(kT)`; an anchor expecting a bare
+	# identifier there leaves the Ubuntu-22 gate in place and re-opens
+	# #771 on every other distro.
+	_chunk 'index.chunk-test.js' "$VFSD_NEW"
+	run patch_virtiofsd_probe
+	[[ $status -eq 0 ]]
+	grep -qF 'return await FT(kT)||IT(TT,N.constants.X_OK)' \
+		"$BUILD/index.chunk-test.js"
+	# The Ubuntu-only ternary must be gone, not merely bypassed.
+	run grep -qF '(e?IT(TT,N.constants.X_OK):null)' \
+		"$BUILD/index.chunk-test.js"
+	[[ $status -ne 0 ]]
+}
+
+@test "virtiofsd: idempotent and byte-identical on re-run" {
+	_chunk 'index.chunk-test.js' "$VFSD_NEW"
+	patch_virtiofsd_probe
+	local first; first="$(cat "$BUILD/index.chunk-test.js")"
+	run patch_virtiofsd_probe
+	[[ $status -eq 0 ]]
+	[[ $output == *'already un-gated'* ]]
+	[[ "$(cat "$BUILD/index.chunk-test.js")" == "$first" ]]
+}
+
+@test "virtiofsd: missing probe array fails the build" {
+	# An anchor miss here must stop the build, not warn: shipping without
+	# the patch silently re-opens #771.
+	_chunk 'index.chunk-test.js' 'var x=[`/usr/bin/qemu-system-x86_64`];'
+	run patch_virtiofsd_probe
+	[[ $status -ne 0 ]]
+	[[ $output == *'matched no file'* ]]
+}
+
+@test "virtiofsd: duplicated probe array fails the exactly-1 guard" {
+	_chunk 'index.chunk-test.js' "$VFSD_NEW$VFSD_NEW"
+	run patch_virtiofsd_probe
+	[[ $status -ne 0 ]]
+	[[ $output == *'found 2'* ]]
+}

--- a/tests/test-patch-stage.sh
+++ b/tests/test-patch-stage.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+#===============================================================================
+# Patch-stage integration test against a real official .deb.
+#
+# The BATS suites pin each patch against fixtures copied from shipped
+# bytes, which is fast and runs everywhere. This closes the gap those
+# leave: fixtures can drift from the real bundle, and a fixture cannot
+# tell you whether the *repacked asar* still parses. #666 shipped a
+# Fedora SyntaxError from a bad anchor while every structural test stayed
+# green, so this runs the actual patch stage over the actual archive and
+# then parses every emitted file.
+#
+# Asserts, in order:
+#   1. the patch stage exits 0
+#   2. every JS file in the repacked asar parses (node --check)
+#   3. each injected marker survives the repack
+#   4. a second pass is a no-op and leaves the asar byte-identical
+#
+# (4) is not decoration: through 1.24012.11 the patches resolved a single
+# main file handed to them, and the move to per-anchor resolution (#820)
+# introduced a class of bug where a patch destroys the very anchor it
+# resolves on, so the second run fails to find its file at all — before
+# any idempotency guard can fire. Only a second pass catches that.
+#
+# Usage:
+#   tests/test-patch-stage.sh                 # pinned version, amd64
+#   tests/test-patch-stage.sh <dir>           # pre-extracted resources dir
+#                                             # (holding app.asar +
+#                                             #  app.asar.unpacked)
+#
+# Not wired into tests.yml: it downloads a ~170 MB archive. Run it before
+# shipping a patch change, and on every upstream bump.
+#===============================================================================
+
+project_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+# shellcheck source=scripts/_common.sh
+source "$project_root/scripts/_common.sh"
+# shellcheck source=scripts/setup/official-deb.sh
+source "$project_root/scripts/setup/official-deb.sh"
+
+_fail_count=0
+
+_check() {
+	local label="$1"
+	shift
+	if "$@"; then
+		echo "  [PASS] $label"
+	else
+		echo "  [FAIL] $label"
+		_fail_count=$((_fail_count + 1))
+	fi
+}
+
+# Fetch and unpack the pinned official .deb into $1/resources.
+_stage_official() {
+	local dest="$1"
+	local url_base='https://downloads.claude.ai/claude-desktop/apt/stable'
+	local deb="$dest/official.deb"
+
+	mkdir -p "$dest" || return 1
+	echo "Downloading official .deb $OFFICIAL_DEB_VERSION (amd64)..."
+	if ! curl -fsSL -o "$deb" "$url_base/$OFFICIAL_DEB_POOL_AMD64"; then
+		echo 'Download failed' >&2
+		return 1
+	fi
+	if ! echo "$OFFICIAL_DEB_SHA256_AMD64  $deb" | sha256sum -c - \
+		> /dev/null; then
+		echo 'SHA-256 mismatch on the official .deb' >&2
+		return 1
+	fi
+
+	# _extract_deb_member handles the zst/xz/gz variance upstream has
+	# shipped over time, so the member name is never hardcoded here.
+	_extract_deb_member "$deb" 'data' "$dest" || return 1
+
+	mkdir -p "$dest/resources"
+	cp "$dest/usr/lib/claude-desktop/resources/app.asar" \
+		"$dest/resources/" || return 1
+	cp -a "$dest/usr/lib/claude-desktop/resources/app.asar.unpacked" \
+		"$dest/resources/" || return 1
+}
+
+main() {
+	local src="${1:-}"
+	local tmp
+	tmp=$(mktemp -d) || exit 1
+	# shellcheck disable=SC2064  # $tmp must expand now, not at trap time
+	trap "rm -rf '$tmp'" EXIT
+
+	# Globals the patch stage reads.
+	work_dir="$tmp/work"
+	app_staging_dir="$tmp/staging"
+	asar_exec=$(command -v asar || command -v npx)
+	export work_dir app_staging_dir project_root asar_exec
+	mkdir -p "$work_dir" "$app_staging_dir/resources"
+
+	if [[ -n $src ]]; then
+		cp "$src/app.asar" "$app_staging_dir/resources/" || exit 1
+		cp -a "$src/app.asar.unpacked" "$app_staging_dir/resources/" \
+			|| exit 1
+	else
+		_stage_official "$tmp/official" || exit 1
+		cp "$tmp/official/resources/app.asar" \
+			"$app_staging_dir/resources/" || exit 1
+		cp -a "$tmp/official/resources/app.asar.unpacked" \
+			"$app_staging_dir/resources/" || exit 1
+	fi
+
+	local patch_sh
+	for patch_sh in quick-window org-plugins virtiofsd-probe \
+		cowork-bwrap tray-icon-selection; do
+		# shellcheck source=/dev/null
+		source "$project_root/scripts/patches/$patch_sh.sh"
+	done
+	# shellcheck source=scripts/patches/app-asar.sh
+	source "$project_root/scripts/patches/app-asar.sh"
+
+	# --- pass 1 ----------------------------------------------------------
+	echo '=== pass 1: patch stage ==='
+	# Subshell: patch_app_asar exits on failure, which would take this
+	# harness with it and skip every remaining assertion.
+	( patch_app_asar ) > "$tmp/pass1.log" 2>&1
+	local rc1=$?
+	sed 's/^/  | /' "$tmp/pass1.log"
+	_check 'patch stage exits 0' test "$rc1" -eq 0
+
+	# --- every emitted file must parse ------------------------------------
+	echo '=== parse check ==='
+	"$asar_exec" extract "$app_staging_dir/resources/app.asar" \
+		"$tmp/verify" > /dev/null || exit 1
+	local broken=0 total=0 f
+	while IFS= read -r f; do
+		total=$((total + 1))
+		if ! node --check "$f" > /dev/null 2>&1; then
+			broken=$((broken + 1))
+			echo "  SyntaxError in ${f#"$tmp"/verify/}"
+		fi
+	done < <(find "$tmp/verify/.vite/build" -name '*.js' -type f)
+	echo "  parsed $total JS files"
+	_check "all $total JS files parse" test "$broken" -eq 0
+
+	# --- injected markers must survive the repack -------------------------
+	echo '=== marker check ==='
+	local marker
+	for marker in '/*cowork-bwrap-spawn*/' '/*cowork-bwrap-dl*/' \
+		'CLAUDE_TRAY_USE_DARK_ICON' '/etc/claude/org-plugins' \
+		'XDG_CURRENT_DESKTOP'; do
+		_check "marker present: $marker" \
+			grep -rqF -- "$marker" "$tmp/verify/.vite/build"
+	done
+
+	# --- pass 2: idempotency ----------------------------------------------
+	echo '=== pass 2: idempotency ==='
+	local before after
+	before=$(sha256sum "$app_staging_dir/resources/app.asar" | cut -d' ' -f1)
+	( patch_app_asar ) > "$tmp/pass2.log" 2>&1
+	local rc2=$?
+	sed 's/^/  | /' "$tmp/pass2.log"
+	after=$(sha256sum "$app_staging_dir/resources/app.asar" | cut -d' ' -f1)
+	_check 'second pass exits 0' test "$rc2" -eq 0
+	_check 'asar byte-identical after re-run' test "$before" = "$after"
+
+	echo
+	if (( _fail_count > 0 )); then
+		echo "FAILED: $_fail_count check(s)"
+		return 1
+	fi
+	echo 'All patch-stage checks passed'
+}
+
+main "$@"

--- a/tests/tray-icon-selection.bats
+++ b/tests/tray-icon-selection.bats
@@ -25,6 +25,11 @@ setup() {
 	# literals pins placement inside the ternary, not just marker
 	# presence.
 	patched_expr='process.env.CLAUDE_TRAY_USE_DARK_ICON==="1"||process.env.CLAUDE_TRAY_USE_DARK_ICON!=="0"&&(oPe()==="gnome"||G.nativeTheme.shouldUseDarkColors)?"TrayIconLinux-Dark.png":"TrayIconLinux.png"'
+
+	# Real 1.26832.0 minified bytes: the bundler swap re-emitted every
+	# string literal as a backtick template, which took this anchor to
+	# zero matches (#820).
+	upstream_ternary_bt='case`png`:t=lt()===`gnome`||R.nativeTheme.shouldUseDarkColors?`TrayIconLinux-Dark.png`:`TrayIconLinux.png`;break'
 }
 
 _make_chunk() {
@@ -126,4 +131,26 @@ EOF
 	run patch_tray_icon_env_override
 	[[ $status -eq 1 ]]
 	[[ $output == *'found 2'* ]]
+}
+
+@test "tray icon override: applies to the 1.26832.0 backticked shape" {
+	# Pins the quote class: an anchor keyed to a bare double quote finds
+	# nothing in a 1.26832.0 bundle and hard-fails the release.
+	_make_chunk "$upstream_ternary_bt"
+	run patch_tray_icon_env_override
+	[[ $status -eq 0 ]]
+	grep -qF 'CLAUDE_TRAY_USE_DARK_ICON!=="0"&&(lt()==="gnome"||R.nativeTheme.shouldUseDarkColors)?"TrayIconLinux-Dark.png":"TrayIconLinux.png"' \
+		"$BATS_TEST_TMPDIR/app.asar.contents/.vite/build/index.chunk-test.js"
+}
+
+@test "tray icon override: backticked shape is idempotent" {
+	_make_chunk "$upstream_ternary_bt"
+	patch_tray_icon_env_override
+	local chunk="$BATS_TEST_TMPDIR/app.asar.contents/.vite/build"
+	chunk+='/index.chunk-test.js'
+	local first; first="$(cat "$chunk")"
+	run patch_tray_icon_env_override
+	[[ $status -eq 0 ]]
+	[[ $output == *'already applied'* ]]
+	[[ "$(cat "$chunk")" == "$first" ]]
 }

--- a/tests/tray-icon-selection.bats
+++ b/tests/tray-icon-selection.bats
@@ -12,6 +12,10 @@
 setup() {
 	# shellcheck source=scripts/patches/tray-icon-selection.sh
 	source "$BATS_TEST_DIRNAME/../scripts/patches/tray-icon-selection.sh"
+	# _resolve_anchor_file lives here; the patch resolves its own file
+	# rather than reading a main_js global (#820).
+	# shellcheck source=scripts/patches/app-asar.sh
+	source "$BATS_TEST_DIRNAME/../scripts/patches/app-asar.sh"
 
 	# Real 1.19367.0 minified bytes around the anchor (identifiers
 	# oPe/G as shipped; verified against the pinned official .deb).
@@ -27,7 +31,6 @@ _make_chunk() {
 	local build="$BATS_TEST_TMPDIR/app.asar.contents/.vite/build"
 	mkdir -p "$build"
 	printf '%s\n' "$1" > "$build/index.chunk-test.js"
-	main_js='app.asar.contents/.vite/build/index.chunk-test.js'
 	cd "$BATS_TEST_TMPDIR" || return 1
 }
 
@@ -47,7 +50,6 @@ _make_chunk() {
             ? "TrayIconLinux-Dark.png"
             : "TrayIconLinux.png";
 EOF
-	main_js='app.asar.contents/.vite/build/index.chunk-test.js'
 	cd "$BATS_TEST_TMPDIR" || return 1
 	patch_tray_icon_env_override
 	grep -qF 'CLAUDE_TRAY_USE_DARK_ICON==="1"' "$build/index.chunk-test.js"
@@ -68,11 +70,14 @@ EOF
 }
 
 @test "tray icon override: missing anchor fails the build" {
+	# The icon-literal pair is now the resolution anchor, so a bundle
+	# without it fails before the patch body runs. The build still stops,
+	# which is the property under test; only the message moved.
 	_make_chunk 'case"png":t="TrayIconLinux.png";break'
 	run patch_tray_icon_env_override
 	[[ $status -eq 1 ]]
-	[[ $output == *'WARNING'* ]]
-	[[ $output == *'ERROR'* ]]
+	[[ $output == *'matched no file'* ]]
+	[[ $output == *'Re-derive'* ]]
 }
 
 @test "tray icon override: near-miss without the GNOME half fails" {
@@ -90,11 +95,15 @@ EOF
 @test "tray icon override: Win32 ico lookalike ternary fails" {
 	# Upstream's sibling "ico" case — same shape, different literals. A
 	# patch weakened to ignore the TrayIconLinux literals would pass.
+	# The TrayIconLinux literals guard this from the resolver now rather
+	# than from the ternary count: weakening the resolution anchor to
+	# ignore them lets resolution succeed, and the ternary count then
+	# reports 0 and still fails. Either way this fixture stays red.
 	_make_chunk \
 		'case"ico":t=oPe()==="gnome"||G.nativeTheme.shouldUseDarkColors?"Tray-Win32-Dark.ico":"Tray-Win32.ico";break'
 	run patch_tray_icon_env_override
 	[[ $status -eq 1 ]]
-	[[ $output == *'found 0'* ]]
+	[[ $output == *'matched no file'* ]]
 }
 
 @test "tray icon override: matches the bundler indirect-call shape" {


### PR DESCRIPTION
Refs #820. Deliberately not a closing keyword: nothing here is runtime-verified, so #820 stays open until Cowork, the tray icon and Quick Entry get a fleet pass on 1.26832.0.

Upstream 1.26832.0 failed all six build legs at the patch stage. Two independent changes shipped in the same release, and either one alone would have been enough to break us.

## What broke

**1. The main chunk dissolved.** `index.js` used to be a 773-byte stub with a single `require()`. It's now 195,889 bytes requiring 83 unique chunks across two families, including a new `index2.chunk-*` family with 130 files. The 5.2 MB core is gone and the largest chunk is 1.28 MB.

| | 1.24012.11 | 1.26832.0 |
|---|---|---|
| `index.js` size | 773 B | 195,889 B |
| chunks required by `index.js` | 1 | 83 |
| chunk families | 1 | 2 (`index.chunk-*`, `index2.chunk-*`) |
| largest chunk | 5.2 MB (the core) | 1.28 MB |
| total `.vite/build` bytes | baseline | +2.4% |

Total bytes moved 2.4%, so this is a re-split of code that was already there. That tripped the `_resolve_main_js` multi-chunk guard, which failed the build exactly as designed.

**2. The bundler swapped string emission.** Nearly every literal was re-emitted as a backtick template. Any anchor written with a bare double quote matched nothing.

| Literal form | 1.24012.11 | 1.26832.0 |
|---|---|---|
| double-quoted (short) | 46,526 | 3,050 |
| backticked | 429 | 44,701 |

Three smaller shape changes came with it: optional chaining is preserved instead of downleveled, `let` replaced most `const`/`var`, and callee indirection appeared, so `X.spawn(` is now `(0,ye.spawn)(`.

The second one is the expensive half. "Anchor not found" reads as "upstream deleted the feature" when the feature is sitting right there untouched.

## The fix

`_resolve_main_js` is gone, replaced by `_resolve_anchor_file`. Each patch now resolves the file its own anchor lives in and asserts exactly one match. That assertion is what provides the safety the multi-chunk guard used to give. Anchors carry a quote class so they match either emission shape.

Resolution uses `grep -lPz`, not `-lP`. Bare `-P` is line-oriented, so a `\s*` in an anchor can't cross a newline. Every multi-line beautified bundle would report its anchor missing.

Four anchors needed genuine re-derivation. All four are upstream reshapes, not deletions:

1. **virtiofsd** resolver now returns `await FT(kT)||...` where it returned a bare identifier.
2. **cowork B** spawn callee moved to the indirect-call form.
3. **cowork C1** status guard inverted. It was `(x?.status)!=="supported"?!1:` and is now:
   ```js
   x?.status===`supported`?(...)
   ```
   I could have written a regex matching both polarities, but that risks binding the wrong one and installing the gate backwards. The anchor now stops before the comparison and injects ahead of it. That's correct under either polarity because it never has to agree with one.
4. **quick-window part 2** focus/visibility pair moved into a shared module. The call site only sees `i.s`/`i.f` import bindings, in a different file from the definitions. Both are captured from the call site now instead of looked up definition-side, which also deletes two fragile lookups.

## The design trap

Once a patch resolves its own file, the anchor has to survive its own patch. Six of the first ten anchors did not. org-plugins splits its own compound anchor by inserting into it, cowork A rewrites the function head it anchors on, tray rewrites the ternary condition it matches. All of them resolved fine on a clean tree and failed on a re-run, at resolution, before the idempotency guards ever got a chance to run.

Each now anchors on something adjacent that the patch never rewrites: the darwin path, the `-socket` literal, the two icon literals. Where that wasn't possible, the anchor tolerates the patch's own marker.

## Known gap, deliberate

cowork C2 warns instead of applying. Its `[warm] Warm download disabled` literal, `VM_BUNDLE_SPEC`, and every warm-file identifier are absent from 1.26832.0, so the prefetch subsystem looks restructured rather than re-minified. I'm not asserting a replacement anchor, because inventing one risks gating unrelated code. C2 only saves bandwidth on flagged runs.

## Testing

The second commit exists because the first commit's tests were decoration. A mutation check against [`docs/learnings/test-methodology-and-coverage.md`](docs/learnings/test-methodology-and-coverage.md) found 8 of 11 changes unpinned. Every fixture in the suite was in the 1.24012.11 shape, so reverting the quote class or any shape tolerance left the suite green. quick-window, org-plugins and virtiofsd-probe had no BATS coverage at all.

- New `tests/patch-anchors.bats`, 14 tests, covering those three patches against **both** emission shapes. Every fixture is copied from shipped minified bytes of the release it names. None are hand-written.
- 1.26832.0-shape fixtures added to the tray and cowork suites.
- Near-miss fixtures: a decoy chunk carrying `pop-up-menu` with no call site, a switch missing its default arm, a duplicated probe array.
- All 14 mutations go red. 466/466 bats tests pass. shellcheck clean.

New `tests/test-patch-stage.sh` runs the real patch stage over a real official `.deb`, parses every JS file in the repacked asar, asserts the injected markers survive the repack, then re-runs to prove idempotency. The first commit cited this as methodology without shipping it, which is CHANGES_REQUESTED by our own standard. It's mutation-checked by making the tray patch emit unbalanced parens and watching the parse check go red, which is the #666 class that fixture tests structurally can't catch. Not wired into `tests.yml` because it downloads ~170 MB. It's a pre-ship and upstream-bump gate.

## Validation

Both official debs:

| Check | 1.24012.11 | 1.26832.0 |
|---|---|---|
| patch stage rc | 0 | 0 |
| JS files parsing in repacked asar | 107/107 | 347/347 |
| injected markers survive repack | yes | yes |
| second pass is a no-op (byte-identical asar) | yes | yes |

## Remaining gaps

- **Nothing here is runtime-verified.** This proves the patches apply and the output parses. It does not prove Cowork, the tray icon or Quick Entry actually behave correctly on 1.26832.0. That needs the VM fleet.
- `test-patch-stage.sh` is not in CI, so a patch regression can still reach a green CI.
- cowork C2 has no coverage for the absent-anchor case beyond the warning path.
- quick-window's KDE visibility check is now inlined from the captured window handle and drops upstream's `|| mainView?.webContents?.isFocused()` clause. A hidden window whose webContents reports focus gets `show()` called instead of skipped. That's the safe direction for #390, whose symptom is `show()` being skipped, and I don't think the state is reachable in practice, but it is a real behavioural delta.
- A dead anchor was dropped from quick-window. `Navigating to existing chat` is absent from both 1.24012.11 and 1.26832.0, so it only ever produced a standing WARNING.

## Docs

[`docs/learnings/patching-minified-js.md`](docs/learnings/patching-minified-js.md) gets a new "Quote style" section, a refreshed code-split section (three of its factual claims were falsified by this release), and the resolution-anchor-must-survive-its-own-patch lesson.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
90% AI / 10% Human
Claude: bundle census across both official debs, root-caused the bundler swap, rewrote the patch resolution and the five patch scripts, wrote the test coverage and the patch-stage harness, ran the mutation and validation passes
Human: directed scope and priorities, called for the testing-doc audit that exposed the unpinned tests, reviewed and approved
