### PR TITLE
fix(deb): remove legacy bwrap AppArmor profile on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- `postinst` now removes the legacy `claude-desktop-bwrap` AppArmor profile that 2.x installs left behind, so it no longer survives an upgrade. The profile attaches `flags=(unconfined)` to the shared `/usr/bin/bwrap`, a path Ubuntu's own `bwrap-userns-restrict` also claims; AppArmor resolves neither attachment, logs `conflicting profile attachments`, and bwrap falls through to `unprivileged_userns`, which denies `setpcap` and `net_admin`. On Ubuntu 26.04 that takes out glycin — the sandboxed decoder GNOME 47+ routes *every* image through — so the symptoms are a GDM greeter with no user list and no background that cannot be logged into at all, `gnome-terminal-server` aborting with a GTK assertion at `gtkiconhelper.c` while loading the fallback `image-missing.png`, blank icons across the shell, and `gcr-prompter` failing to render so gnome-keyring stops prompting for ssh key passphrases. The profile is inert on 24.04 (no glycin), which makes this present as "the release upgrade broke my desktop" with nothing pointing at this package — and the 24.04 → 26.04 LTS upgrade path is exactly the population carrying it. `postrm` already handled the legacy names, but its case arm only matches `remove|purge|abort-install` and dpkg invokes the *old* package's `postrm` with `upgrade`, so the file survived every package upgrade; both profiles were confirmed coexisting on `claude-desktop-unofficial 1.30096.1-3.2.2`. Removal is gated on the marker header so admin-authored files of the same name are preserved, and `apparmor_parser -R` runs alongside the delete because the profile otherwise stays loaded in the kernel until the next reload. ([#542](https://github.com/aaddrick/claude-desktop-debian/issues/542), [#825](https://github.com/aaddrick/claude-desktop-debian/pull/825))
+
 ## [v3.2.4] — 2026-09-06
 
 ### Fixed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -423,9 +423,15 @@ run with `--no-sandbox`, see
 ["AppImage Sandbox Warning"](#appimage-sandbox-warning) — so there's
 nothing AppImage-specific to add there either.)
 
-No package ships a bwrap profile as of v3.0.0+; the deb's `postrm` still
-removes the 2.x-era `/etc/apparmor.d/claude-desktop-bwrap` leftover (and a
-`claude-desktop-unofficial-bwrap` sibling, if one exists) on purge.
+No package ships a bwrap profile as of v3.0.0+. The deb's `postrm` removes
+the 2.x-era `/etc/apparmor.d/claude-desktop-bwrap` leftover (and a
+`claude-desktop-unofficial-bwrap` sibling, if one exists) on purge, and
+since [#825](https://github.com/aaddrick/claude-desktop-debian/pull/825)
+`postinst` also clears it on upgrade — `postrm` alone never fired on that
+path, so the leftover used to survive indefinitely. See
+["Blank icons / unloggable GDM greeter after upgrading to Ubuntu
+26.04"](#blank-icons--unloggable-gdm-greeter-after-upgrading-to-ubuntu-2604)
+if you are already in that state.
 
 **Credit:** [@hfyeh](https://github.com/hfyeh)
 ([#351](https://github.com/aaddrick/claude-desktop-debian/issues/351)) for
@@ -434,6 +440,56 @@ the original profile workaround;
 over-scope and the opam/Apptainer precedent, in
 [PR #434](https://github.com/aaddrick/claude-desktop-debian/pull/434#issuecomment-4352273336)
 (tracked in [#542](https://github.com/aaddrick/claude-desktop-debian/issues/542)).
+
+### Blank icons / unloggable GDM greeter after upgrading to Ubuntu 26.04
+
+Tracked in
+[#542](https://github.com/aaddrick/claude-desktop-debian/issues/542).
+
+**Symptoms, all at once, immediately after an Ubuntu release upgrade:**
+
+- the GDM greeter shows text and buttons but **no user list, no
+  background, and no icons**, so there is no way to log in graphically;
+- `gnome-terminal` does not open — `gnome-terminal-server` aborts with a
+  GTK assertion at `gtkiconhelper.c` while loading `image-missing.png`;
+- icons are blank across the shell and in GTK apps;
+- gnome-keyring never shows its password prompt, so passphrase-protected
+  ssh keys stop working (`agent refused operation`).
+
+**Cause.** A 2.x-era install of this package left
+`/etc/apparmor.d/claude-desktop-bwrap` behind, which attaches a profile to
+the shared `/usr/bin/bwrap`. Ubuntu's own `bwrap-userns-restrict` claims
+the same path, so AppArmor resolves neither and bwrap falls through to
+`unprivileged_userns`. GNOME 47+ decodes every image through glycin inside
+a bwrap sandbox, so nothing that is an image can load. The profile is inert
+on Ubuntu 24.04 (no glycin), which is why it only breaks at upgrade time
+and why nothing points at Claude Desktop.
+
+**Confirm it** from a TTY (`Ctrl+Alt+F3`):
+
+```bash
+journalctl -b | grep -c 'conflicting profile attachments'   # non-zero
+ls /etc/apparmor.d/claude-desktop-bwrap                     # exists
+```
+
+**Fix:**
+
+```bash
+sudo apparmor_parser -R /etc/apparmor.d/claude-desktop-bwrap
+sudo rm /etc/apparmor.d/claude-desktop-bwrap
+sudo systemctl restart gdm
+```
+
+`apparmor_parser -R` is required in addition to the delete. Removing the
+file alone leaves the profile loaded in the kernel, so the conflict —
+and the broken desktop — survives until the next reboot.
+
+Upgrading the package fixes this going forward: `postinst` clears the
+leftover as of
+[#825](https://github.com/aaddrick/claude-desktop-debian/pull/825). Keep
+`/etc/apparmor.d/claude-desktop` (and
+`/etc/apparmor.d/claude-desktop-unofficial`) — those attach to this
+application's own binary and are correct.
 
 ### Cowork: ENAMETOOLONG on encrypted home (eCryptfs)
 

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -234,6 +234,31 @@ else
     echo "Warning: chrome-sandbox binary not found in local package at \$LOCAL_SANDBOX_PATH. Sandbox may not function correctly."
 fi
 
+# --- Remove legacy bwrap-attached AppArmor profiles (#542) ---
+# 2.x installs shipped a profile attached to the shared /usr/bin/bwrap. It is
+# no longer installed, but an upgrade never removes it: dpkg runs the *old*
+# package's postrm with "upgrade", and that cleanup arm only matches
+# remove|purge|abort-install. The stale file then collides with the distro's
+# own profile (Ubuntu ships bwrap-userns-restrict, also attached to
+# /usr/bin/bwrap); AppArmor resolves neither, bwrap falls through to
+# unprivileged_userns, and glycin's sandboxed image decoding dies -- unusable
+# GDM greeter, GTK apps aborting on icon loads, gnome-keyring unable to
+# prompt. Same marker-header rule as below: files without it were written by
+# the admin (or another package) and are preserved. apparmor_parser -R is
+# needed as well as rm -- deleting the file leaves the profile loaded in the
+# kernel, so the conflict survives until the next reboot.
+for _legacy_profile in "/etc/apparmor.d/claude-desktop-bwrap" \
+    "/etc/apparmor.d/${package_name}-bwrap"; do
+    if [ -e "\$_legacy_profile" ] \
+        && grep -q "managed by the claude-desktop" "\$_legacy_profile" 2>/dev/null; then
+        if command -v apparmor_parser >/dev/null 2>&1; then
+            apparmor_parser -R "\$_legacy_profile" >/dev/null 2>&1 || true
+        fi
+        rm -f "\$_legacy_profile" 2>/dev/null || true
+        echo "Removed legacy AppArmor profile \$_legacy_profile"
+    fi
+done
+
 # --- AppArmor profile for Chromium's user-namespace sandbox ---
 # Ubuntu 24.04+ sets kernel.apparmor_restrict_unprivileged_userns=1, which
 # blocks the unprivileged user namespaces Chromium's sandbox relies on,

--- a/tests/test-artifact-deb.sh
+++ b/tests/test-artifact-deb.sh
@@ -62,6 +62,45 @@ else
 	fail 'Control lacks Replaces: claude-desktop (<< 1.16000)'
 fi
 
+# --- Control scripts: legacy bwrap profile cleanup (#542) ---
+# 2.x installs shipped an AppArmor profile attached to the shared
+# /usr/bin/bwrap. Nothing removed it on upgrade: dpkg runs the *old*
+# package's postrm with 'upgrade', and that cleanup arm only matches
+# remove|purge|abort-install. postinst therefore has to clear it, or the
+# stale profile keeps colliding with the distro's bwrap-userns-restrict
+# and breaks glycin image decoding on Ubuntu 26.04 (unloggable greeter).
+# Presence and syntax are asserted on every build; the behavioural test
+# can't run here, since the 24.04 runner blocks the user namespace bwrap
+# needs.
+control_dir=$(mktemp -d)
+if dpkg-deb -e "$deb_file" "$control_dir" 2>/dev/null; then
+	pass 'Control archive extracted with dpkg-deb -e'
+
+	if grep -q 'claude-desktop-bwrap' "$control_dir/postinst"; then
+		pass 'postinst clears the legacy bwrap profile (#542)'
+	else
+		fail 'postinst lacks the legacy bwrap cleanup (#542)'
+	fi
+
+	# The unload matters as much as the delete: removing the file
+	# alone leaves the profile loaded in the kernel, so the conflict
+	# survives until the next reboot.
+	if grep -q 'apparmor_parser -R' "$control_dir/postinst"; then
+		pass 'postinst unloads the legacy profile, not just deletes it'
+	else
+		fail 'postinst never runs apparmor_parser -R on the legacy profile'
+	fi
+
+	if sh -n "$control_dir/postinst" 2>/dev/null; then
+		pass 'postinst passes sh -n'
+	else
+		fail 'postinst fails sh -n'
+	fi
+else
+	fail 'dpkg-deb -e could not extract the control archive'
+fi
+rm -rf "$control_dir"
+
 # --- Install the package ---
 # Use --force-depends since we only care about file placement
 if sudo dpkg -i --force-depends "$deb_file"; then


### PR DESCRIPTION
Fixes the upgrade path left open by the rename, reported in #542.

## Problem

2.x installs shipped an AppArmor profile attached to the shared `/usr/bin/bwrap`. It is no longer installed, but **nothing removes it on an upgrade**: dpkg runs the *old* package's `postrm` with `upgrade`, and that cleanup arm only matches `remove|purge|abort-install`:

```sh
case "$1" in
    remove|purge|abort-install)
        for _profile in "/etc/apparmor.d/$package_name" \
            "/etc/apparmor.d/${package_name}-bwrap" \
            "/etc/apparmor.d/claude-desktop-bwrap"; do
```

`postinst` writes the new scoped profile but never touches the legacy names, so the stale file survives indefinitely on an otherwise-fixed package.

## Why it matters

On Ubuntu 25.10+ this is not cosmetic. The distro ships `bwrap-userns-restrict`, also attached to `/usr/bin/bwrap`, so two profiles claim the same path. AppArmor resolves neither:

```
apparmor="AUDIT" operation="exec" info="conflicting profile attachments"
        profile="unconfined" name="/usr/bin/bwrap" comm="gly-hdl-loader"
apparmor="DENIED" operation="capable" profile="unprivileged_userns"
        comm="bwrap" capability=8 capname="setpcap"
```

bwrap falls through to `unprivileged_userns`, which denies `setpcap`/`net_admin`. GNOME 47+ decodes **every image** through glycin inside a bwrap sandbox, so image loading fails system-wide:

- **GDM greeter unusable** — the logo texture returns null, `add_child(null)` throws inside `LoginDialog._init` (`loginDialog.js:1086`), and the constructor aborts before building the user list or background. No way to log in.
- **`gnome-terminal-server` SIGABRTs** on a GTK assertion at `gtkiconhelper.c:495`, loading the fallback `image-missing.png`.
- **gnome-keyring cannot prompt** (`gcr-prompter` fails to render), breaking passphrase-protected ssh keys and Claude Desktop's own login.

Confirmed on `claude-desktop-unofficial 1.30096.1-3.2.2`, where the correctly scoped Electron profile from #<!---->542's fix and the stale bwrap profile coexisted — the scoped one was fine, the leftover one broke the desktop. 560 bwrap denials in one boot; 0 after removing and unloading it.

## Change

Clean up both legacy names from `postinst`, gated on the same marker header already used for the Electron profile, so admin-authored files are preserved.

`apparmor_parser -R` is required **in addition to** `rm`: deleting the file leaves the profile loaded in the kernel, so the conflict persists until the next reboot. That is easy to miss — after removing the file and running `systemctl reload apparmor`, denials continued and `aa-status` still listed the profile.

## Testing

- `bash -n scripts/packaging/deb.sh` — passes
- Generated `postinst` extracted with `$package_name` expanded and syntax-checked — passes
- Marker guard exercised against a fixture pair: the marked file is removed, an admin-authored one is preserved
- Not able to run `shellcheck` locally; the addition lives inside the `<< EOF` heredoc, which shellcheck treats as data, so CI should be unaffected

Worth noting @clayg's point in #542 still stands: because these profiles are written by maintainer scripts rather than shipped as tracked package files, `dpkg -S` cannot attribute them and nothing reconciles them across a rename. Shipping via `dh_apparmor` would make this class of bug structurally impossible; this patch just closes the current gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
