### PR TITLE
fix(patches): allow a prelude in the cowork C1 anchor (unblocks the build on 1.37937.1+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- Packages build again on upstream 1.37937.1 and later. Every build leg had failed at the patch stage since 2026-08-26 on one anchor — `cowork-bwrap` C1, the foreground VM-download guard — so four upstream bumps (1.37937.1, 1.37937.3, 1.40609.0, 1.40609.1) produced no release. The function is unchanged and still present; upstream inserted a single statement in front of the destructure the anchor spans (`async function QH(e,t){await nB();let{yukonSilver:r}=iB();return …`), and the anchor required those to be adjacent, so it went to zero matches and `_resolve_anchor_file` failed the build as designed. Both the resolver and the patch regex now allow a bounded brace-fenced prelude (`[^{}]{0,80}`) between the function head and the destructure — brace-fenced rather than `.`-based so the budget cannot reach past a nested block into an unrelated destructure — and, since loosening costs the uniqueness the tight pattern got for free, C1 gained the exactly-one-match assertion patches A and B already carried: a second same-shaped call site now warns instead of letting `replace()` guess. Verified against the pinned 1.40609.1 official `.deb`: all three load-bearing sub-patches apply, the gate lands ahead of upstream's status check (polarity-agnostic by position), the patched chunk parses, and a second pass is byte-identical. Six mutation checks — reverting the prelude on either side, dropping the `();return` discriminator that tells the download function apart from `startVM`, swapping the brace fence for `.`, dropping the count assertion, dropping the marker tolerance — each turn a new test red.
+
 ## [v3.2.2] — 2026-08-10
 
 ### Added

--- a/docs/learnings/patching-minified-js.md
+++ b/docs/learnings/patching-minified-js.md
@@ -361,6 +361,53 @@ suite needs. Two traps the census surfaced:
   destructure, then injects ahead of upstream's check, which is correct
   under either polarity because it never has to agree with one.
 
+### Adjacency is an assumption too
+
+Stopping the anchor early leaves it holding one last unstated
+assumption: that the tokens it *does* span stay next to each other.
+1.37937.1 broke C1 again on exactly that. Same function, same
+destructure, same `return` — upstream inserted one statement in front:
+
+```js
+1.26832.0:  async function ut(e,n){let{yukonSilver:r}=p.n();return …
+1.37937.1:  async function QH(e,t){await nB();let{yukonSilver:r}=iB();return …
+```
+
+The anchor required the destructure to sit immediately after the opening
+brace, so it went to zero matches and `_resolve_anchor_file` failed the
+build — through four upstream bumps (1.37937.1, 1.37937.3, 1.40609.0,
+1.40609.1) in which no release shipped. Worth noting how it read: an
+anchor that *lost a feature* and an anchor that *gained a statement*
+produce the same "matched no file" line, and the second is by far the
+likelier of the two.
+
+Leave a bounded prelude between the tokens you span, and fence it on
+braces rather than on `.`:
+
+```
+async function\s+[\w$]+\([\w$]+,[\w$]+\)\{ [^{}]{0,80} (?:const|let)\{yukonSilver:…
+```
+
+`[^{}]` cannot cross a nested block or leave the function body, so the
+budget buys a couple of simple statements and nothing structural — where
+`.{0,80}` would happily reach past an `if(e){t()}` and gate a function
+whose head is 80 bytes from an unrelated destructure. It also absorbs a
+`;` inside a template literal, which a statement-counting
+`(?:[^{};]*;){0,2}` splits on.
+
+Loosening buys back the match at the cost of the uniqueness the tight
+version got for free, so pay for it in two places at once:
+
+- **Keep a discriminator past the loosened joint.** C1's is the
+  `();return` tail. `startVM` in the same chunk opens identically and
+  destructures the same property, and is told apart only by continuing
+  into `if(` instead of `return`. Drop the tail and the gate installs on
+  the wrong function.
+- **Assert exactly one match.** `replace()` silently takes the first.
+  The count assertion is what turns a future second call site into a
+  named warning instead of a coin flip — the same guard patches A and B
+  already carried.
+
 ### A resolution anchor must survive its own patch
 
 Once a patch resolves its own file, the anchor acquires a second job it

--- a/scripts/patches/cowork-bwrap.sh
+++ b/scripts/patches/cowork-bwrap.sh
@@ -53,6 +53,28 @@
 # backtick template (#820).
 _CB_Q='[`"'"'"']'
 
+# C1's anchor shape. Read it as: the function head, then our own marker
+# if a previous run left one, then up to 80 brace-free bytes of upstream
+# prelude, then the yukonSilver destructure and its `return`.
+#
+# The node stage's `dlRe` spells the same shape a second time — it is a
+# heredoc, so it cannot read these. The two must stay in step or the
+# resolver picks a file the patch regex then declines to match; the
+# cowork C1 tests in tests/patch-anchors.bats drive both through one
+# call and are what actually pins them together.
+#
+# The prelude allowance is what 1.37937.1 needed — upstream inserted an
+# `await X();` between the opening brace and the destructure, and the
+# old anchor required them to be adjacent. `[^{}]` is deliberately
+# brace-fenced rather than `.`: it cannot cross a nested block or leave
+# the function body, so the 80-byte budget buys a couple of simple
+# statements and nothing structural. It also absorbs `;` inside a
+# template literal, which a statement-counting `(?:[^{};]*;){0,2}` would
+# split on.
+_CB_C1_MARKER='(?:/\*cowork-bwrap-dl\*/[^;]*;)?'
+_CB_C1_PRELUDE='[^{}]{0,80}'
+_CB_C1_TAIL='(?:const|let)\{yukonSilver:[\w$]+\}=[\w$]+(?:\.[\w$]+)*\(\);return'
+
 patch_cowork_bwrap() {
 	echo 'Patching Cowork bwrap fallback (opt-in COWORK_VM_BACKEND=bwrap)...'
 
@@ -67,7 +89,7 @@ patch_cowork_bwrap() {
 	b_js=$(_resolve_anchor_file 'cowork B (helper socket argv)' \
 		"${_CB_Q}-socket${_CB_Q}") || return 1
 	c1_js=$(_resolve_anchor_file 'cowork C1 (foreground download)' \
-		'async function\s+[\w$]+\([\w$]+,[\w$]+\)\{(?:/\*cowork-bwrap-dl\*/[^;]*;)?(?:const|let)\{yukonSilver:') \
+		"async function\s+[\w\$]+\([\w\$]+,[\w\$]+\)\{${_CB_C1_MARKER}${_CB_C1_PRELUDE}${_CB_C1_TAIL}") \
 		|| return 1
 
 	# C2 is best-effort and its anchor is absent from 1.26832.0, so an
@@ -228,6 +250,15 @@ if (codeB.includes('/*cowork-bwrap-spawn*/')) {
 //               return(A==null?void 0:A.status)!=="supported"?!1:...
 //   1.26832.0:  async function ut(e,n){let{yukonSilver:r}=p.n();
 //               return r?.status===`supported`?(...)
+//   1.37937.1:  async function QH(e,t){await nB();let{yukonSilver:r}=iB();
+//               return r?.status===`supported`&&(...)
+//
+// 1.37937.1 inserted a statement between the opening brace and the
+// destructure, which the old adjacency requirement rejected outright —
+// the whole build went red on that one anchor for four upstream bumps.
+// The prelude allowance is spelled once more in `_CB_C1_PRELUDE` on the
+// shell side, for the file resolver; keep the two in step. See that
+// comment for why it is brace-fenced rather than `.`-based.
 //
 // The status guard INVERTED between those releases (a !== early-false
 // became a === proceed), so the anchor deliberately stops at the
@@ -240,14 +271,23 @@ if (codeB.includes('/*cowork-bwrap-spawn*/')) {
 // The destructure initialiser is a plain call (`=sM()`) on 1.24012.11
 // and a module-binding call (`=p.n()`) on 1.26832.0, so the callee
 // tolerates a property chain.
-const dlRe = new RegExp(
+const dlSrc =
     String.raw`(async function\s+[\w$]+\([\w$]+,[\w$]+\)\{)` +
-    String.raw`((?:const|let)\{yukonSilver:[\w$]+\}=` +
-    String.raw`[\w$]+(?:\.[\w$]+)*\(\);return)`);
+    String.raw`([^{}]{0,80}(?:const|let)\{yukonSilver:[\w$]+\}=` +
+    String.raw`[\w$]+(?:\.[\w$]+)*\(\);return)`;
+const dlRe = new RegExp(dlSrc);
 let codeC1 = load(c1Js);
+// The prelude allowance widened this pattern, so assert it still binds
+// exactly one function rather than trusting `replace()`'s first match.
+// A second same-shaped call site is upstream growing a consumer we have
+// not reasoned about, which is a warn-and-skip, not a coin flip.
+const dlAll = [...codeC1.matchAll(new RegExp(dlSrc, 'g'))];
 if (codeC1.includes('/*cowork-bwrap-dl*/')) {
     console.log('  C1: foreground download block already applied');
-} else if (dlRe.test(codeC1)) {
+} else if (dlAll.length > 1) {
+    console.log('  C1: WARNING — foreground download anchor matched ' +
+        dlAll.length + ' sites; refusing to guess. Re-derive the anchor.');
+} else if (dlAll.length === 1) {
     save(c1Js, codeC1.replace(dlRe,
         '$1/*cowork-bwrap-dl*/if(' + GATE + ')return!1;$2'));
     console.log('  C1: blocked foreground VM download when flagged');

--- a/tests/patch-anchors.bats
+++ b/tests/patch-anchors.bats
@@ -18,7 +18,7 @@
 # (docs/learnings/test-methodology-and-coverage.md).
 
 setup() {
-	for p in quick-window org-plugins virtiofsd-probe; do
+	for p in quick-window org-plugins virtiofsd-probe cowork-bwrap; do
 		# shellcheck source=/dev/null
 		source "$BATS_TEST_DIRNAME/../scripts/patches/$p.sh"
 	done
@@ -217,4 +217,108 @@ VFSD_NEW='kT=[`/usr/libexec/virtiofsd`,`/usr/bin/virtiofsd`];async function AT()
 	run patch_virtiofsd_probe
 	[[ $status -ne 0 ]]
 	[[ $output == *'found 2'* ]]
+}
+
+# =============================================================================
+# cowork-bwrap (C1 — foreground VM download)
+#
+# C1 is the anchor that took the whole build red from 1.37937.1 through
+# 1.40609.1: upstream inserted an `await X();` between the function head
+# and the yukonSilver destructure, and both the file resolver and the
+# patch regex required those two to be adjacent. The fixtures below pin
+# the prelude allowance that fixed it, from both sides — the shapes it
+# must now match, and the near-misses it must still refuse.
+#
+# A and B resolve fatally before C1 runs, so every fixture carries all
+# three anchors in one chunk (which is also how 1.40609.1 ships them).
+# =============================================================================
+
+# 1.40609.1 shipped bytes (A: qon/Kon, B: (0,t.spawn)/mIt, C1: QH with the
+# `await nB();` prelude that broke the old anchor).
+CB_NEW='function qon(){return process.platform,Kon()}
+(0,t.spawn)(e,[`-socket`,mIt()],{stdio:[`pipe`,`pipe`,`pipe`]})
+async function QH(e,t){await nB();let{yukonSilver:r}=iB();return r?.status===`supported`&&(GH(Kb.Downloading),BH)}'
+
+# 1.26832.0 C1 shape — no prelude, ternary rather than `&&`. Transcribed
+# from the shape recorded in scripts/patches/cowork-bwrap.sh's own header
+# (that bundle is no longer pinned, so these bytes are not re-extracted).
+# Kept as a fixture because the prelude allowance must stay a superset:
+# widening for 1.40609.1 must not drop the shape it already handled.
+CB_OLD='function qon(){return process.platform,Kon()}
+(0,t.spawn)(e,[`-socket`,mIt()],{stdio:[`pipe`,`pipe`,`pipe`]})
+async function ut(e,n){let{yukonSilver:r}=p.n();return r?.status===`supported`?(x(),y):!1}'
+
+@test "cowork C1: applies to the 1.40609.1 await-prelude shape" {
+	# The regression: the prelude took this anchor to zero matches and
+	# _resolve_anchor_file failed the build for four upstream bumps.
+	_chunk 'index.chunk-test.js' "$CB_NEW"
+	run patch_cowork_bwrap
+	[[ $status -eq 0 ]]
+	[[ $output == *'C1: blocked foreground VM download when flagged'* ]]
+	# The gate lands ahead of the prelude, so upstream's status check
+	# never runs on a flagged launch — polarity-agnostic by position.
+	grep -qF 'async function QH(e,t){/*cowork-bwrap-dl*/if(process.platform==="linux"&&process.env.COWORK_VM_BACKEND==="bwrap")return!1;await nB();let{yukonSilver:r}=iB();' \
+		"$BUILD/index.chunk-test.js"
+}
+
+@test "cowork C1: still applies to the 1.26832.0 no-prelude shape" {
+	_chunk 'index.chunk-test.js' "$CB_OLD"
+	run patch_cowork_bwrap
+	[[ $status -eq 0 ]]
+	[[ $output == *'C1: blocked foreground VM download when flagged'* ]]
+	grep -qF 'async function ut(e,n){/*cowork-bwrap-dl*/if(process.platform==="linux"&&process.env.COWORK_VM_BACKEND==="bwrap")return!1;let{yukonSilver:r}=p.n();' \
+		"$BUILD/index.chunk-test.js"
+}
+
+@test "cowork C1: idempotent and byte-identical on re-run" {
+	# The resolution anchor has to survive its own patch: it tolerates
+	# the injected /*cowork-bwrap-dl*/ marker AND the prelude behind it,
+	# or the second pass fails at resolution before the idempotency
+	# guards can fire (docs/learnings/patching-minified-js.md).
+	_chunk 'index.chunk-test.js' "$CB_NEW"
+	patch_cowork_bwrap
+	local first; first="$(cat "$BUILD/index.chunk-test.js")"
+	run patch_cowork_bwrap
+	[[ $status -eq 0 ]]
+	[[ $output == *'C1: foreground download block already applied'* ]]
+	[[ "$(cat "$BUILD/index.chunk-test.js")" == "$first" ]]
+}
+
+@test "cowork C1: does not bind startVM's destructure (near-miss)" {
+	# startVM reads the same destructure but continues into `if(`, not
+	# `return`. Dropping the `\(\);return` tail from the anchor makes
+	# this fixture match and the gate installs on the wrong function.
+	local start_vm='async function aU(e,t){await nB();let{yukonSilver:r}=iB();if(r?.status!==`supported`){J.warn(`[startVM] no`);return}}'
+	_chunk 'index.chunk-test.js' "${CB_NEW%$'\n'*}
+$start_vm"
+	run patch_cowork_bwrap
+	[[ $status -ne 0 ]]
+	[[ $output == *'matched no file'* ]]
+}
+
+@test "cowork C1: prelude budget does not cross a nested block" {
+	# `[^{}]{0,80}` is brace-fenced on purpose. A `.`-based prelude of
+	# the same budget would reach past this inner block and gate a
+	# function whose head is 80 bytes away from an unrelated destructure.
+	local fenced='async function QH(e,t){if(e){t()}let{yukonSilver:r}=iB();return r}'
+	_chunk 'index.chunk-test.js' "${CB_NEW%$'\n'*}
+$fenced"
+	run patch_cowork_bwrap
+	[[ $status -ne 0 ]]
+	[[ $output == *'matched no file'* ]]
+}
+
+@test "cowork C1: two same-shaped sites warn instead of guessing" {
+	# Widening the regex made a second binding possible, so the exactly-1
+	# assertion is the compensating control: replace() would silently
+	# take the first match.
+	local dup='async function XH(e,t){await nB();let{yukonSilver:r}=iB();return r?.status===`supported`&&(z(),1)}'
+	_chunk 'index.chunk-test.js' "$CB_NEW
+$dup"
+	run patch_cowork_bwrap
+	[[ $status -eq 0 ]]
+	[[ $output == *'C1: WARNING'* ]]
+	[[ $output == *'matched 2 sites'* ]]
+	run grep -qF '/*cowork-bwrap-dl*/' "$BUILD/index.chunk-test.js"
+	[[ $status -ne 0 ]]
 }


### PR DESCRIPTION
Every build leg on main has been red at the asar patch stage since 2026-08-26. Four upstream bumps came and went with no release: 1.37937.1, 1.37937.3, 1.40609.0, 1.40609.1. Shellcheck and BATS stayed green the whole time, so the only signal was the build legs, and everything downstream (Create Release, APT/DNF repo update, AUR, official-deb mirror) just skipped.

The failure line:

```
Anchor 'cowork C1 (foreground download)' matched no file under app.asar.contents/.vite/build — upstream reshaped or removed it. Re-derive the anchor before shipping (#820).
```

### Root cause

The guarded function is still there and still does the same thing. It's `downloadVM`, confirmed by its `[downloadVM] Download already in progress` log literal, living in `index.chunk-COzdsOQe.js` on 1.40609.1. Upstream inserted one statement in front of the destructure the anchor spans:

```js
// 1.26832.0
async function ut(e,n){let{yukonSilver:r}=p.n();return …
// 1.37937.1
async function QH(e,t){await nB();let{yukonSilver:r}=iB();return …
```

The anchor required the destructure to sit immediately after the opening brace. Zero matches, and `_resolve_anchor_file` failed the build as designed.

Worth naming for next time: an anchor that lost a feature and an anchor that gained a statement produce the identical "matched no file" line. The second is much likelier.

### Fix

Both the file resolver and the node-stage `dlRe` now allow a bounded prelude, `[^{}]{0,80}`, between the function head and the destructure.

Brace-fenced rather than `.`-based on purpose. `[^{}]` can't cross a nested block or leave the function body, so the budget buys a couple of simple statements and nothing structural. `.{0,80}` would reach past an `if(e){t()}` and gate a function whose head sits 80 bytes from an unrelated destructure. It also absorbs a `;` inside a template literal, which a statement-counting `(?:[^{};]*;){0,2}` splits on.

Loosening costs the uniqueness the tight pattern got for free, so I pay for it twice. First, keep a discriminator past the loosened joint: the `();return` tail. `startVM` in the same chunk opens identically and destructures the same property, and continuing into `if(` instead of `return` is the only thing that tells them apart. Second, assert exactly one match, the guard patches A and B already carried. A second same-shaped site now warns instead of letting `replace()` silently take the first.

The injected gate still lands ahead of upstream's status check, so it stays polarity-agnostic by position. Unchanged from #821's design. A and B still resolve uniquely on 1.40609.1. C2 is still absent and still warns, which is pre-existing and best-effort.

### Verification

All run locally against the pinned 1.40609.1 official `.deb`, sha-verified:

- `tests/test-patch-stage.sh`: patch stage exits 0, all 160 JS files in the repacked asar parse, all 5 injected markers survive the repack, second pass byte-identical.
- Full local `./build.sh --build deb --clean no` completes. That's the exact leg that was red.
- `bats tests/*.bats`: 326 pass, 0 fail. CI shellcheck command is clean.

Six new bats tests, the first coverage `cowork-bwrap` has had. Each one is mutation-checked and turns red on its own mutation: revert the prelude in the resolver, revert it in `dlRe`, drop the `();return` tail, swap `[^{}]` for `.`, drop the count assertion, drop the marker tolerance.

The arm64 legs and the rpm/appimage legs aren't verified locally. CI covers those on this PR.

### Also

`docs/learnings/patching-minified-js.md` gains an "Adjacency is an assumption too" section under the anchor-selection material. CHANGELOG `[Unreleased]` → Fixed.

Related: #820

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <Claude Opus 5> <noreply@anthropic.com>
85% AI / 15% Human
Claude: diagnosed the anchor break against the pinned official .deb, wrote the prelude fix and the exactly-one guard, added the six mutation-checked bats tests, ran the patch-stage integration test and a full local deb build, wrote the learnings section and CHANGELOG entry
Human: reported the failing CI, directed the approach (read the patching and testing learnings first, then fix/test/PR)

https://claude.ai/code/session_017mdLtJwCTZCjtxtJZ5HAHY
