### PR TITLE
test(patch-anchors): pin the node-side C1 tail with a shared-chunk fixture

### DIFF
--- a/tests/patch-anchors.bats
+++ b/tests/patch-anchors.bats
@@ -318,3 +318,25 @@ $dup"
 	run grep -qF '/*cowork-bwrap-dl*/' "$BUILD/index.chunk-test.js"
 	[[ $status -ne 0 ]]
 }
+
+@test "cowork C1: binds downloadVM when startVM shares the chunk" {
+	# 1.40609.1+ ships downloadVM and startVM in the same chunk, and the
+	# two open identically: same async head, same helper-call status
+	# check. The only token that tells them apart is the
+	# `[downloadVM] Download already in progress` log literal dlSrc ends
+	# on. The shell-side resolver pins that literal via _CB_C1_TAIL, but
+	# nothing above exercises the node-side dlRe against a same-headed
+	# neighbour: drop the literal terminus from dlSrc and dlRe binds
+	# both, the exactly-1 guard warns and skips, and the build stays
+	# green with no gate installed.
+	local start_vm='async function aU(e,t){return await wB(),EB().status==="supported"&&(J.warn("[startVM] no"),!1)}'
+	_chunk 'index.chunk-test.js' "$CB_NEW
+$start_vm"
+	run patch_cowork_bwrap
+	[[ $status -eq 0 ]]
+	[[ $output != *'C1: WARNING'* ]]
+	grep -qF 'async function YU(e,t){/*cowork-bwrap-dl*/' \
+		"$BUILD/index.chunk-test.js"
+	run grep -cF '/*cowork-bwrap-dl*/' "$BUILD/index.chunk-test.js"
+	[[ $output == '1' ]]
+}


### PR DESCRIPTION
Follow-up to #829 and #838.

The shell-side resolver pins the `[downloadVM] Download already in progress` literal via `_CB_C1_TAIL`, but no fixture exercises the node-side `dlRe` against a same-headed neighbour in the same chunk. Dropping the literal terminus from `dlSrc` leaves every existing test green: `dlRe` binds both `downloadVM` and `startVM`, the exactly-1 guard warns and skips, and the build stays green with no gate installed. Same continue-on-green class as the #829 learnings entry, reached from the node side.

One test added, `cowork C1: binds downloadVM when startVM shares the chunk`. It puts the 1.46388.2 `downloadVM` fixture and a same-shaped `startVM` in one chunk and asserts exit 0, no `C1: WARNING`, and exactly one marker on `YU`.

Rebased over #838, which changed the discriminator from the `();return` tail to the log literal; the test and its rationale now describe the current anchor.

Verification on current main:

- `patch-anchors` + `cowork-bwrap-patch`: 31/31
- full suite: green
- dropping the literal terminus from `dlSrc` turns only this test red
