### PR TITLE
feat(launcher): kill replaced Claude Desktop UI before relaunch; fix(tests): resolve a real asar in the patch-stage harness

### DIFF
--- a/docs/learnings/cowork-vm-daemon.md
+++ b/docs/learnings/cowork-vm-daemon.md
@@ -91,13 +91,20 @@ even after rolling back the AppImage to a known-good version.
 
 ### Fix (extend delete list — Patch 6b)
 
-`scripts/patches/cowork.sh` now matches the `const NAME=["rootfs.img",...]` array at
-module level and appends `"sessiondata.img"` and `"rootfs.img.zst"` if
-they're not already present. The auto-reinstall path now wipes these
-too. Trade-off: the next successful startup re-downloads/re-extracts
-these files. Acceptable because auto-reinstall only runs after startup
-has already failed — biasing toward recovery over re-download
-avoidance is correct.
+`scripts/patches/cowork.sh` supports both upstream delete-list shapes:
+the older `const NAME=["rootfs.img",...]` array and the newer generated
+list returned by `deleteVMBundle()`. It ensures the list includes
+`rootfs.img`, its origin marker, `sessiondata.img`, `rootfs.img.zst`,
+and the compressed-cache origin marker. The auto-reinstall path now
+wipes these too. Trade-off: the next successful startup
+re-downloads/re-extracts these files. Acceptable because
+auto-reinstall only runs after startup has already failed — biasing
+toward recovery over re-download avoidance is correct.
+
+As of upstream `1.12603.1`, VM downloads create `.wvm-tmp-*` directly
+under the bundle directory. Patch 8 detects that shape and reports it
+as already fixed instead of warning that the older
+`mkdtemp(join(tmpdir(), "wvm-"))` anchor is missing.
 
 Not included in the delete list: `~/.config/Claude/claude-code-vm/`.
 That's CLI-binary storage (`2.1.x/claude`), unrelated to the VM

--- a/docs/learnings/patching-minified-js.md
+++ b/docs/learnings/patching-minified-js.md
@@ -242,11 +242,13 @@ in v3.0.0, lessons stand):
   The rewrite anchors on `"pop-up-menu"` (`quick-window.sh:17`), the
   `isWindowFocused` property name (`quick-window.sh:60`), and the
   `[QuickEntry]` log strings (`quick-window.sh:88-91`).
-- **Cowork spawn (PR #436).** Anchored on `,VAR.mountConda)`
-  (`cowork.sh:741`) — unique to the 12-arg call path, absent from the
-  10-arg one-shot. Asserts match count is exactly 1 and bails
-  otherwise (`cowork.sh:744`), so a future second caller surfaces
-  immediately.
+- **Cowork spawn (PR #436).** Anchored on the VM spawn mount field
+  (`mountSkeletonHome` on newer upstream, `mountConda` on older
+  upstream) near the end of the full call path, preserving later
+  arguments such as the OAuth token. The receiving `spawn()` method is
+  anchored separately on the stable `"spawn"` IPC method and its
+  payload object. Asserts match count is exactly 1 and bails otherwise,
+  so a future second caller surfaces immediately.
 - **Tray (PR #515).** `tray.sh:16` uses the literal `"menuBarEnabled"`
   as a *position anchor*, then captures the surrounding minified
   identifier (`\K\w+(?=\(\)\})`) as the actual patch target. Two

--- a/scripts/cowork-fallback/cowork.sh
+++ b/scripts/cowork-fallback/cowork.sh
@@ -349,6 +349,59 @@ if (!code.includes('"linux":{') && !code.includes("'linux':{") &&
     }
 }
 
+
+// ============================================================
+// Patch 4c: Treat YukonSilver as supported on Linux
+// Newer upstream gates VM download/start/cleanup on yukonSilver even
+// after the older platform gate is patched. Without this, Linux logs:
+//   [cleanupVMBundleIfUnsupported] yukonSilver not supported ...
+// and deletes the VM bundle before the local daemon can start.
+// ============================================================
+{
+    const supported = '{status:"supported"}';
+    const featureRe =
+        /yukonSilver:([\w$]+)\(\),yukonSilverGems:([\w$]+)\(\),yukonSilverGemsCache:\2\(\)/;
+    const featureMatch = code.match(featureRe);
+    if (featureMatch) {
+        const [whole, baseFn, gemsFn] = featureMatch;
+        const replacement =
+            'yukonSilver:process.platform==="linux"?' + supported + ':' +
+            baseFn + '(),yukonSilverGems:process.platform==="linux"?' +
+            supported + ':' + gemsFn + '(),yukonSilverGemsCache:' +
+            'process.platform==="linux"?' + supported + ':' + gemsFn + '()';
+        code = code.replace(whole, replacement);
+        console.log('  Patched YukonSilver feature gate for Linux');
+        patchCount++;
+    } else if (code.includes(
+        'yukonSilver:process.platform==="linux"?{status:"supported"}'
+    )) {
+        console.log('  YukonSilver Linux feature gate already patched');
+    } else {
+        console.log('  WARNING: Could not find YukonSilver feature gate');
+    }
+
+    const cleanupRe =
+        /async function ([\w$]+)\(\)\{try\{const\{yukonSilver:([\w$]+)\}=await ([\w$]+)\(\);if\(!\2\|\|\2\.status==="supported"\)return;/;
+    const cleanupMatch = code.match(cleanupRe);
+    if (cleanupMatch && !cleanupMatch[0].includes('process.platform')) {
+        const [whole, fnName, featureVar, featuresFn] = cleanupMatch;
+        const replacement = 'async function ' + fnName +
+            '(){try{if(process.platform==="linux")return;' +
+            'const{yukonSilver:' + featureVar + '}=await ' +
+            featuresFn + '();if(!' + featureVar + '||' + featureVar +
+            '.status==="supported")return;';
+        code = code.replace(whole, replacement);
+        console.log('  Patched unsupported-VM cleanup to skip Linux');
+        patchCount++;
+    } else if (code.includes(
+        'try{if(process.platform==="linux")return;const{yukonSilver:'
+    )) {
+        console.log('  Unsupported-VM cleanup already skips Linux');
+    } else {
+        console.log('  WARNING: Could not find unsupported-VM cleanup gate');
+    }
+}
+
 // ============================================================
 // Patch 5: MSIX check bypass for Linux
 // The fz() function checks: if(t==="win32"&&!ga()) for MSIX
@@ -531,7 +584,41 @@ if (serviceErrorIdx !== -1) {
             console.log('  Reinstall delete list already includes VM images');
         }
     } else {
-        console.log('  WARNING: Could not find reinstall file list array');
+        // Newer upstream derives the list from the bundle manifest:
+        // function FN(){const A=FILES().flatMap(e=>[e.name,
+        // `.${e.name}.origin`]);return ... ,A}
+        if (code.includes(
+            '"sessiondata.img","rootfs.img.zst"'
+        )) {
+            console.log('  Generated reinstall delete list already extended');
+        } else {
+            const generatedRe =
+                /function ([\w$]+)\(\)\{const ([\w$]+)=([\w$]+)\(\)\.flatMap\(([\w$]+)=>\[\4\.name,`\.\$\{\4\.name\}\.origin`\]\);return ([^{}]*?),\2\}/;
+            const generatedMatch = code.match(generatedRe);
+            if (generatedMatch) {
+                const [
+                    whole, fnName, listVar, filesFn, itemVar, returnPrefix
+                ] = generatedMatch;
+                const recoveryFiles =
+                    '["rootfs.img",".rootfs.img.origin",' +
+                    '"sessiondata.img","rootfs.img.zst",' +
+                    '".rootfs.img.zst.origin"]';
+                const additions = listVar + '.push(...' + recoveryFiles +
+                    '.filter(e=>!' + listVar + '.includes(e))),';
+                const replacement = 'function ' + fnName + '(){const ' +
+                    listVar + '=' + filesFn + '().flatMap(' + itemVar +
+                    '=>[' + itemVar + '.name,`.${' + itemVar +
+                    '.name}.origin`]);return ' + additions + returnPrefix +
+                    ',' + listVar + '}';
+                code = code.replace(whole, replacement);
+                console.log('  Extended generated reinstall delete list');
+                patchCount++;
+            } else {
+                console.log(
+                    '  WARNING: Could not find reinstall file list array'
+                );
+            }
+        }
     }
 }
 
@@ -558,39 +645,53 @@ if (serviceErrorIdx !== -1) {
 // rootfs-download path is ever re-enabled on Linux.
 // ============================================================
 {
-    // Find: MKDTEMP(PATH.join(OS.tmpdir(), "wvm-"))
-    // The bundle dir var is used in mkdir(VAR, ...) just before
-    const mkdtempRe = /([\w$]+)\.mkdtemp\(\s*([\w$]+)\.join\(\s*([\w$]+)\.tmpdir\(\)\s*,\s*"wvm-"\s*\)\s*\)/;
-    const mkdtempMatch = code.match(mkdtempRe);
-    if (mkdtempMatch) {
-        const [fullMatch, fsVar, pathVar, osVar] = mkdtempMatch;
-        // Find the bundle dir variable: mkdir(VAR, { recursive before wvm-
-        const mkdtempIdx = code.indexOf(fullMatch);
-        const searchStart = Math.max(0, mkdtempIdx - 2000);
-        const before = code.substring(searchStart, mkdtempIdx);
-        // Look for: mkdir(VARNAME, { recursive
-        const mkdirRe = /([\w$]+)\.mkdir\(\s*([\w$]+)\s*,\s*\{\s*recursive/g;
-        let bundleVar = null;
-        let lastMkdir;
-        while ((lastMkdir = mkdirRe.exec(before)) !== null) {
-            bundleVar = lastMkdir[2];
-        }
-        if (bundleVar) {
-            // Replace os.tmpdir() with the bundle dir variable
-            // On Linux, use the bundle dir; on other platforms keep tmpdir
-            const replacement =
-                `${fsVar}.mkdtemp(${pathVar}.join(` +
-                `process.platform==="linux"?${bundleVar}:${osVar}.tmpdir(),` +
-                `"wvm-"))`;
-            code = code.substring(0, mkdtempIdx) + replacement +
-                code.substring(mkdtempIdx + fullMatch.length);
-            console.log('  Patched VM download temp dir to use bundle path on Linux');
-            patchCount++;
-        } else {
-            console.log('  WARNING: Could not find bundle dir variable for tmpdir patch');
-        }
+    const bundleTmpRe =
+        /[,\s]([\w$]+)="\.wvm-tmp-"[\s\S]{0,30000}?[\w$]+\.mkdtemp\(\s*[\w$]+\.join\(\s*[\w$]+\s*,\s*\1\s*\)\s*\)/;
+    if (bundleTmpRe.test(code)) {
+        console.log('  VM download temp dir already uses bundle path');
     } else {
-        console.log('  WARNING: Could not find mkdtemp("wvm-") for tmpdir patch');
+        // Find: MKDTEMP(PATH.join(OS.tmpdir(), "wvm-"))
+        // The bundle dir var is used in mkdir(VAR, ...) just before
+        const mkdtempRe = /([\w$]+)\.mkdtemp\(\s*([\w$]+)\.join\(\s*([\w$]+)\.tmpdir\(\)\s*,\s*"wvm-"\s*\)\s*\)/;
+        const mkdtempMatch = code.match(mkdtempRe);
+        if (mkdtempMatch) {
+            const [fullMatch, fsVar, pathVar, osVar] = mkdtempMatch;
+            // Find the bundle dir variable: mkdir(VAR, { recursive before wvm-
+            const mkdtempIdx = code.indexOf(fullMatch);
+            const searchStart = Math.max(0, mkdtempIdx - 2000);
+            const before = code.substring(searchStart, mkdtempIdx);
+            // Look for: mkdir(VARNAME, { recursive
+            const mkdirRe =
+                /([\w$]+)\.mkdir\(\s*([\w$]+)\s*,\s*\{\s*recursive/g;
+            let bundleVar = null;
+            let lastMkdir;
+            while ((lastMkdir = mkdirRe.exec(before)) !== null) {
+                bundleVar = lastMkdir[2];
+            }
+            if (bundleVar) {
+                // Replace os.tmpdir() with the bundle dir variable
+                // On Linux, use the bundle dir; on other platforms keep tmpdir
+                const replacement =
+                    `${fsVar}.mkdtemp(${pathVar}.join(` +
+                    `process.platform==="linux"?${bundleVar}:` +
+                    `${osVar}.tmpdir(),"wvm-"))`;
+                code = code.substring(0, mkdtempIdx) + replacement +
+                    code.substring(mkdtempIdx + fullMatch.length);
+                console.log(
+                    '  Patched VM download temp dir to use bundle path on Linux'
+                );
+                patchCount++;
+            } else {
+                console.log(
+                    '  WARNING: Could not find bundle dir variable' +
+                    ' for tmpdir patch'
+                );
+            }
+        } else {
+            console.log(
+                '  WARNING: Could not find mkdtemp("wvm-") for tmpdir patch'
+            );
+        }
     }
 }
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -447,7 +447,7 @@ _proc_state() {
 			printf '%s' "$value"
 			return 0
 		fi
-	done < "/proc/$1/status" 2>/dev/null
+	done 2>/dev/null < "/proc/$1/status"
 	return 1
 }
 
@@ -503,10 +503,15 @@ _kill_pids_escalating() {
 # The kernel appends " (deleted)" to /proc/PID/exe once the binary
 # behind a running process is gone, which is exactly what dpkg/rpm do
 # when they upgrade a package while its UI is still running.
+#
+# Plain readlink, NOT readlink -f: -f canonicalizes, so it fails when
+# the install DIRECTORY is gone too (a package migration or layout
+# change, not just a file replace) and the replaced UI would be
+# silently missed. The raw link content carries the marker either way.
 _claude_desktop_ui_is_replaced() {
 	local exe_path
 
-	exe_path=$(readlink -f "/proc/$1/exe" 2>/dev/null) || return 1
+	exe_path=$(readlink "/proc/$1/exe" 2>/dev/null) || return 1
 	[[ $exe_path == *' (deleted)' ]]
 }
 

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -421,8 +421,11 @@ _claude_desktop_ui_cmdline_matches() {
 # is: a process whose cmdline carries our --class fingerprint (see
 # _claude_desktop_ui_cmdline_matches) and is actually runnable (not
 # stopped/zombie), excluding our own launcher bash and its parent.
-_claude_desktop_ui_is_alive() {
-	local pid cmdline state _key _rest
+#
+# _claude_desktop_ui_pids prints the fingerprint-matching PIDs, one per
+# line; _claude_desktop_ui_is_alive adds the runnable check on top.
+_claude_desktop_ui_pids() {
+	local pid cmdline
 	for pid in \
 		$(pgrep -u "$(id -u)" -f -- "--class=$WM_CLASS" 2>/dev/null); do
 		# Skip our own launcher bash and its parent.
@@ -430,12 +433,30 @@ _claude_desktop_ui_is_alive() {
 		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
 			|| continue
 		_claude_desktop_ui_cmdline_matches "$cmdline" || continue
+		printf '%s\n' "$pid"
+	done
+}
+
+# Process state letter from /proc/PID/status (R, S, T, t, Z, ...).
+# Pure bash: the launchers run before any PATH sanity check, so this
+# stays independent of awk/grep availability.
+_proc_state() {
+	local key value rest
+	while read -r key value rest; do
+		if [[ $key == 'State:' ]]; then
+			printf '%s' "$value"
+			return 0
+		fi
+	done < "/proc/$1/status" 2>/dev/null
+	return 1
+}
+
+# Is a live (runnable) Claude Desktop UI running for this user?
+_claude_desktop_ui_is_alive() {
+	local pid state
+	for pid in $(_claude_desktop_ui_pids); do
 		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
-		state=''
-		while read -r _key state _rest; do
-			[[ $_key == 'State:' ]] && break
-		done < "/proc/$pid/status" 2>/dev/null || continue
-		[[ -n ${state:-} ]] || continue
+		state=$(_proc_state "$pid") || continue
 		[[ $state == T || $state == t || $state == Z ]] && continue
 		# Found a genuine live Electron UI.
 		return 0
@@ -443,11 +464,49 @@ _claude_desktop_ui_is_alive() {
 	return 1
 }
 
+# SIGTERM every PID, wait up to ~2s for all of them to go, then
+# escalate to SIGKILL for whatever is left.  Logs "$label (PIDs: ...)",
+# or "$label (SIGKILL, PIDs: ...)" when escalation was needed.
+_kill_pids_escalating() {
+	local label="$1"
+	shift
+	local pid alive=false waited=0
+
+	for pid in "$@"; do
+		kill "$pid" 2>/dev/null || true
+	done
+
+	while ((waited < 20)); do
+		alive=false
+		for pid in "$@"; do
+			if kill -0 "$pid" 2>/dev/null; then
+				alive=true
+				break
+			fi
+		done
+		[[ $alive == false ]] && break
+		sleep 0.1
+		((waited++))
+	done
+
+	if [[ $alive == true ]]; then
+		for pid in "$@"; do
+			kill -KILL "$pid" 2>/dev/null || true
+		done
+		log_message "$label (SIGKILL, PIDs: $*)"
+	else
+		log_message "$label (PIDs: $*)"
+	fi
+}
+
+# Was this process's executable replaced (unlinked) underneath it?
+# The kernel appends " (deleted)" to /proc/PID/exe once the binary
+# behind a running process is gone, which is exactly what dpkg/rpm do
+# when they upgrade a package while its UI is still running.
 _claude_desktop_ui_is_replaced() {
-	local pid="$1"
 	local exe_path
 
-	exe_path=$(readlink -f "/proc/$pid/exe" 2>/dev/null) || return 1
+	exe_path=$(readlink -f "/proc/$1/exe" 2>/dev/null) || return 1
 	[[ $exe_path == *' (deleted)' ]]
 }
 
@@ -456,46 +515,16 @@ _claude_desktop_ui_is_replaced() {
 # Electron's single-instance lock to the old process and appears to
 # do nothing instead of starting the newly-installed build.
 cleanup_replaced_desktop_ui() {
-	local pids=() pid cmdline
-	for pid in \
-		$(pgrep -u "$(id -u)" -f -- "--class=$WM_CLASS" 2>/dev/null); do
-		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
-		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
-			|| continue
-		_claude_desktop_ui_cmdline_matches "$cmdline" || continue
+	local pids=() pid
+	for pid in $(_claude_desktop_ui_pids); do
 		_claude_desktop_ui_is_replaced "$pid" || continue
 		pids+=("$pid")
 	done
 
 	[[ ${#pids[@]} -gt 0 ]] || return 0
 
-	for pid in "${pids[@]}"; do
-		kill "$pid" 2>/dev/null || true
-	done
-
-	local wait_count=0 alive
-	while ((wait_count < 20)); do
-		alive=false
-		for pid in "${pids[@]}"; do
-			if kill -0 "$pid" 2>/dev/null; then
-				alive=true
-				break
-			fi
-		done
-		[[ $alive == false ]] && break
-		sleep 0.1
-		wait_count=$((wait_count + 1))
-	done
-
-	if [[ $alive == true ]]; then
-		for pid in "${pids[@]}"; do
-			kill -KILL "$pid" 2>/dev/null || true
-		done
-		log_message \
-			"Killed replaced Claude Desktop UI (SIGKILL, PIDs: ${pids[*]})"
-	else
-		log_message "Killed replaced Claude Desktop UI (PIDs: ${pids[*]})"
-	fi
+	_kill_pids_escalating 'Killed replaced Claude Desktop UI' \
+		"${pids[@]}"
 }
 
 # Kill orphaned cowork-vm-service daemon processes.
@@ -602,33 +631,8 @@ cleanup_stale_desktop_helpers() {
 
 	[[ ${#matched[@]} -gt 0 ]] || return 0
 
-	for pid in "${matched[@]}"; do
-		kill "$pid" 2>/dev/null || true
-	done
-
-	local wait_count=0 alive
-	while ((wait_count < 20)); do
-		alive=false
-		for pid in "${matched[@]}"; do
-			if kill -0 "$pid" 2>/dev/null; then
-				alive=true
-				break
-			fi
-		done
-		[[ $alive == false ]] && break
-		sleep 0.1
-		wait_count=$((wait_count + 1))
-	done
-
-	if [[ $alive == true ]]; then
-		for pid in "${matched[@]}"; do
-			kill -KILL "$pid" 2>/dev/null || true
-		done
-		log_message \
-			"Killed stale Claude Desktop helpers (SIGKILL, PIDs: ${matched[*]})"
-	else
-		log_message "Killed stale Claude Desktop helpers (PIDs: ${matched[*]})"
-	fi
+	_kill_pids_escalating 'Killed stale Claude Desktop helpers' \
+		"${matched[@]}"
 }
 
 # Clean up stale SingletonLock if the owning process is no longer running.

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -422,7 +422,7 @@ _claude_desktop_ui_cmdline_matches() {
 # _claude_desktop_ui_cmdline_matches) and is actually runnable (not
 # stopped/zombie), excluding our own launcher bash and its parent.
 _claude_desktop_ui_is_alive() {
-	local pid cmdline state
+	local pid cmdline state _key _rest
 	for pid in \
 		$(pgrep -u "$(id -u)" -f -- "--class=$WM_CLASS" 2>/dev/null); do
 		# Skip our own launcher bash and its parent.
@@ -431,13 +431,71 @@ _claude_desktop_ui_is_alive() {
 			|| continue
 		_claude_desktop_ui_cmdline_matches "$cmdline" || continue
 		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
-		state=$(awk '/^State:/ {print $2; exit}' \
-			"/proc/$pid/status" 2>/dev/null) || continue
+		state=''
+		while read -r _key state _rest; do
+			[[ $_key == 'State:' ]] && break
+		done < "/proc/$pid/status" 2>/dev/null || continue
+		[[ -n ${state:-} ]] || continue
 		[[ $state == T || $state == t || $state == Z ]] && continue
 		# Found a genuine live Electron UI.
 		return 0
 	done
 	return 1
+}
+
+_claude_desktop_ui_is_replaced() {
+	local pid="$1"
+	local exe_path
+
+	exe_path=$(readlink -f "/proc/$pid/exe" 2>/dev/null) || return 1
+	[[ $exe_path == *' (deleted)' ]]
+}
+
+# Terminate a live Claude Desktop UI whose executable was replaced
+# underneath it by dpkg/rpm. If left alive, the next launcher loses
+# Electron's single-instance lock to the old process and appears to
+# do nothing instead of starting the newly-installed build.
+cleanup_replaced_desktop_ui() {
+	local pids=() pid cmdline
+	for pid in \
+		$(pgrep -u "$(id -u)" -f -- "--class=$WM_CLASS" 2>/dev/null); do
+		[[ $pid == "$$" || $pid == "$PPID" ]] && continue
+		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
+			|| continue
+		_claude_desktop_ui_cmdline_matches "$cmdline" || continue
+		_claude_desktop_ui_is_replaced "$pid" || continue
+		pids+=("$pid")
+	done
+
+	[[ ${#pids[@]} -gt 0 ]] || return 0
+
+	for pid in "${pids[@]}"; do
+		kill "$pid" 2>/dev/null || true
+	done
+
+	local wait_count=0 alive
+	while ((wait_count < 20)); do
+		alive=false
+		for pid in "${pids[@]}"; do
+			if kill -0 "$pid" 2>/dev/null; then
+				alive=true
+				break
+			fi
+		done
+		[[ $alive == false ]] && break
+		sleep 0.1
+		wait_count=$((wait_count + 1))
+	done
+
+	if [[ $alive == true ]]; then
+		for pid in "${pids[@]}"; do
+			kill -KILL "$pid" 2>/dev/null || true
+		done
+		log_message \
+			"Killed replaced Claude Desktop UI (SIGKILL, PIDs: ${pids[*]})"
+	else
+		log_message "Killed replaced Claude Desktop UI (PIDs: ${pids[*]})"
+	fi
 }
 
 # Kill orphaned cowork-vm-service daemon processes.

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -82,6 +82,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 
+cleanup_replaced_desktop_ui
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -118,6 +118,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 
+cleanup_replaced_desktop_ui
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -112,6 +112,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 
+cleanup_replaced_desktop_ui
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock

--- a/scripts/patches/config.sh
+++ b/scripts/patches/config.sh
@@ -183,3 +183,198 @@ console.log('  [OK] config-write wipe guard injected before config write');
 
 	echo '##############################################################'
 }
+
+patch_asar_trusted_folder_guard() {
+	echo 'Patching addTrustedFolder to reject .asar paths...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	# Idempotency guard
+	if grep -qF 'endsWith(".asar"))return' "$index_js"; then
+		echo '  .asar guard already present (idempotent)'
+		echo '##############################################################'
+		return
+	fi
+
+	if ! node << 'ASAR_TRUSTED_FOLDER_PATCH'
+const fs = require('fs');
+const p = 'app.asar.contents/.vite/build/index.js';
+let code = fs.readFileSync(p, 'utf8');
+
+// Intent: async addTrustedFolder(PARAM){...
+// LocalAgentModeSessions.addTrustedFolder: ${PARAM}
+const headerRe =
+  /async\s+addTrustedFolder\s*\(\s*([$\w]+)\s*\)\s*\{\s*(?=[^{}]{0,300}LocalAgentModeSessions\.addTrustedFolder:\s*\$\{\1\})/;
+const match = code.match(headerRe);
+if (!match) {
+  console.error('  [FAIL] addTrustedFolder method anchor not found');
+  process.exit(1);
+}
+
+const allMatches = code.match(new RegExp(headerRe.source, 'g'));
+if (allMatches && allMatches.length > 1) {
+  console.error('  [FAIL] addTrustedFolder method anchor matched ' +
+    allMatches.length + ' times');
+  process.exit(1);
+}
+
+const F = match[1];
+console.log('  Found folder parameter: ' + F);
+const guard = 'if(' + F + '.endsWith(".asar"))return;';
+code = code.replace(match[0], match[0] + guard);
+fs.writeFileSync(p, code);
+console.log('  [OK] .asar guard injected in addTrustedFolder');
+ASAR_TRUSTED_FOLDER_PATCH
+	then
+		echo 'Failed to inject .asar trusted folder guard' >&2
+		cd "$project_root" || exit 1
+		exit 1
+	fi
+
+	echo '##############################################################'
+}
+
+# ---------------------------------------------------------------------------
+# Patch: filter .asar paths from --add-dir CLI dispatch and session restore
+#
+# PR #640 guards the directory-check helper and addTrustedFolder IPC
+# handler, but .asar paths in corrupted pre-#640 sessions survive
+# restore (existsSync passes via Electron's ASAR VFS shim) and reach
+# additionalDirectories -> --add-dir -> fatal Claude Code error.
+#
+# Fix: two sub-patches:
+#   1. Filter at the --add-dir CLI dispatch loop (the single convergence
+#      point for ALL code paths that feed additionalDirectories).
+#   2. Filter at session restore to self-heal corrupted persisted state.
+# ---------------------------------------------------------------------------
+patch_asar_additional_dirs_guard() {
+	echo 'Patching --add-dir dispatch to reject .asar paths (#649)...'
+	local index_js='app.asar.contents/.vite/build/index.js'
+
+	if ! INDEX_JS="$index_js" node << 'ASAR_ADDDIR_PATCH'
+const fs = require('fs');
+const indexJs = process.env.INDEX_JS;
+let code = fs.readFileSync(indexJs, 'utf8');
+let patchCount = 0;
+let dispatchPatchCount = 0;
+let dispatchAlreadyPresent = code.includes(
+    '.filter(_d=>!_d.endsWith(".asar"))'
+);
+
+// ================================================================
+// Sub-patch 1: Filter .asar from --add-dir loop
+//
+// Targets (one or more occurrences):
+//   for (let O of A) Y.push("--add-dir", O);
+// Fallback (if minifier uses .forEach):
+//   A.forEach(O=>Y.push("--add-dir",O))
+// ================================================================
+{
+    // Primary: for...of pattern
+    const forOfRe = /for\s*\(\s*let\s+([\w$]+)\s+of\s+([\w$]+)\s*\)\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\1\s*\)/g;
+    // Fallback: .forEach pattern
+    const forEachRe = /([\w$]+)\.forEach\(\s*([\w$]+)\s*=>\s*([\w$]+)\.push\(\s*"--add-dir"\s*,\s*\2\s*\)\s*\)/g;
+
+    let forOfCount = 0;
+    let forEachCount = 0;
+    code = code.replace(forOfRe, (match, iterVar, arrVar, pushTarget) => {
+        forOfCount++;
+        dispatchPatchCount++;
+        patchCount++;
+        return 'for(let ' + iterVar + ' of ' + arrVar +
+            '.filter(_d=>!_d.endsWith(".asar")))' +
+            pushTarget + '.push("--add-dir",' + iterVar + ')';
+    });
+    code = code.replace(forEachRe, (match, arrVar, iterVar, pushTarget) => {
+        forEachCount++;
+        dispatchPatchCount++;
+        patchCount++;
+        return arrVar +
+            '.filter(_d=>!_d.endsWith(".asar")).forEach(' +
+            iterVar + '=>' + pushTarget +
+            '.push("--add-dir",' + iterVar + '))';
+    });
+
+    if (dispatchPatchCount === 0 && !dispatchAlreadyPresent) {
+        console.error('FATAL: --add-dir dispatch loop not found.');
+        console.error('  for(let X of Y) Z.push("--add-dir", X)');
+        console.error('  Y.forEach(X=>Z.push("--add-dir", X))');
+        process.exit(1);
+    }
+
+    if (dispatchPatchCount > 0) {
+        console.log('  Filtered ' + dispatchPatchCount +
+            ' --add-dir dispatch loop(s) (for-of=' + forOfCount +
+            ', forEach=' + forEachCount + ')');
+    } else {
+        console.log('  .asar --add-dir filter already present ' +
+            '(idempotent)');
+    }
+}
+
+// ================================================================
+// Sub-patch 2: Filter .asar from session restore
+//
+// Anchor: "Filtering out deleted folder from session" (unique)
+// Target: (VAR.userSelectedFolders||[]).filter(
+// Insert: .filter(l=>!l.endsWith(".asar")) before existing .filter(
+// ================================================================
+{
+    const warn = (msg) => console.log('  WARNING: ' + msg +
+        ' (primary --add-dir filter still protects)');
+
+    const anchorIdx = code.indexOf(
+        'Filtering out deleted folder from session');
+    if (anchorIdx === -1) {
+        warn('session restore anchor not found');
+    } else {
+        const searchStart = Math.max(0, anchorIdx - 500);
+        const region = code.substring(searchStart, anchorIdx);
+        const usIdx = region.lastIndexOf('userSelectedFolders');
+        if (usIdx === -1) {
+            warn('userSelectedFolders not found near anchor');
+        } else {
+            const absUsIdx = searchStart + usIdx;
+            const afterUs = code.substring(absUsIdx, anchorIdx);
+            const bracketMatch = afterUs.match(/\|\|\s*\[\s*\]\s*\)/);
+            if (!bracketMatch) {
+                warn('||[]) pattern not found');
+            } else {
+                const insertAt = absUsIdx + bracketMatch.index +
+                    bracketMatch[0].length;
+                const peek = code.substring(insertAt, insertAt + 20);
+                if (!peek.match(/^\s*\.filter\s*\(/)) {
+                    warn('.filter( not found after ||[])');
+                } else if (code.substring(
+                    insertAt - 50, insertAt + 50
+                ).includes('!l.endsWith(".asar")')) {
+                    console.log('  Session restore filter ' +
+                        'already present');
+                } else {
+                    code = code.substring(0, insertAt) +
+                        '.filter(l=>!l.endsWith(".asar"))' +
+                        code.substring(insertAt);
+                    console.log('  Injected .asar filter in ' +
+                        'session restore');
+                    patchCount++;
+                }
+            }
+        }
+    }
+}
+
+fs.writeFileSync(indexJs, code);
+console.log('  Applied ' + patchCount +
+    ' .asar additionalDirectories patch(es)');
+if (dispatchPatchCount < 1 && !dispatchAlreadyPresent) {
+    console.error('FATAL: --add-dir filter must succeed (#649).');
+    process.exit(1);
+}
+ASAR_ADDDIR_PATCH
+	then
+		echo 'FATAL: .asar --add-dir filter patch failed' >&2
+		echo 'Local agent mode will crash without this patch (#649).' >&2
+		exit 1
+	fi
+
+	echo '##############################################################'
+}

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -951,6 +951,34 @@ s.close()
 	[[ $status -ne 0 ]]
 }
 
+@test "cleanup_replaced_desktop_ui: kills UI with deleted executable" {
+	local stale_bin="$TEST_TMP/claude-bash"
+	local block_fifo="$TEST_TMP/block"
+	local stale_pid
+
+	mkfifo "$block_fifo"
+	cp /bin/bash "$stale_bin"
+	# shellcheck disable=SC2016  # inner shell expands $1
+	"$stale_bin" -c 'read -r _ < "$1"' \
+		claude-test "$block_fifo" --class=com.anthropic.Claude &
+	stale_pid=$!
+	sleep 0.1
+	rm "$stale_bin"
+
+	readlink -f "/proc/$stale_pid/exe" | grep -q ' (deleted)$'
+
+	setup_logging
+	run cleanup_replaced_desktop_ui
+
+	[[ $status -eq 0 ]]
+	run timeout 2 bash -c \
+		"while kill -0 '$stale_pid' 2>/dev/null; do sleep 0.1; done"
+	[[ $status -eq 0 ]]
+	run kill -0 "$stale_pid"
+	[[ $status -ne 0 ]]
+	grep -q 'Killed replaced Claude Desktop UI' "$log_file"
+}
+
 @test "run_electron_and_cleanup: runs cleanup after Electron exits and preserves status" {
 	local marker="$TEST_TMP/cleanup-ran"
 	local electron="$TEST_TMP/electron"

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -958,14 +958,55 @@ s.close()
 
 	mkfifo "$block_fifo"
 	cp /bin/bash "$stale_bin"
+	# fd 3 is bats' run-coordination pipe: a spawned process that
+	# inherits it keeps bats waiting for EOF if it ever survives the
+	# test, so close it in the child.
 	# shellcheck disable=SC2016  # inner shell expands $1
 	"$stale_bin" -c 'read -r _ < "$1"' \
-		claude-test "$block_fifo" --class=com.anthropic.Claude &
+		claude-test "$block_fifo" --class=com.anthropic.Claude 3>&- &
 	stale_pid=$!
 	sleep 0.1
 	rm "$stale_bin"
 
 	readlink -f "/proc/$stale_pid/exe" | grep -q ' (deleted)$'
+
+	setup_logging
+	run cleanup_replaced_desktop_ui
+
+	[[ $status -eq 0 ]]
+	run timeout 2 bash -c \
+		"while kill -0 '$stale_pid' 2>/dev/null; do sleep 0.1; done"
+	[[ $status -eq 0 ]]
+	run kill -0 "$stale_pid"
+	[[ $status -ne 0 ]]
+	grep -q 'Killed replaced Claude Desktop UI' "$log_file"
+}
+
+@test "cleanup_replaced_desktop_ui: still kills when the install dir is gone" {
+	# A package migration or layout change removes the whole install
+	# directory, not just the binary. `readlink -f` fails on that shape
+	# (it canonicalizes through a now-missing parent), so this pins the
+	# plain-readlink detection: reverting it turns this red while the
+	# file-only-deleted test above stays green.
+	local stale_dir="$TEST_TMP/gone-install-dir"
+	local block_fifo="$TEST_TMP/block-dirgone"
+	local stale_pid
+
+	mkfifo "$block_fifo"
+	mkdir -p "$stale_dir"
+	cp /bin/bash "$stale_dir/claude-bash"
+	# shellcheck disable=SC2016  # inner shell expands $1 (3>&-: see the
+	# fd-3 note in the deleted-executable test above)
+	"$stale_dir/claude-bash" -c 'read -r _ < "$1"' \
+		claude-test "$block_fifo" --class=com.anthropic.Claude 3>&- &
+	stale_pid=$!
+	sleep 0.1
+	rm -rf "$stale_dir"
+
+	# The very failure mode under test: -f cannot resolve this shape.
+	run readlink -f "/proc/$stale_pid/exe"
+	[[ $status -ne 0 ]]
+	readlink "/proc/$stale_pid/exe" | grep -q ' (deleted)$'
 
 	setup_logging
 	run cleanup_replaced_desktop_ui

--- a/tests/test-patch-stage.sh
+++ b/tests/test-patch-stage.sh
@@ -81,6 +81,33 @@ _stage_official() {
 		"$dest/resources/" || return 1
 }
 
+# The patch stage invokes "$asar_exec" as a single word, so a bare `npx`
+# fallback silently turns `extract-file` into a PACKAGE name: npx fetches
+# an unrelated `extract-file` from the registry, package.json is never
+# extracted, and the stage fails the WM_CLASS tripwire on an empty
+# desktopName instead of on anything real. Resolve a genuine asar or stop.
+_resolve_asar() {
+	asar_exec=$(command -v asar)
+	if [[ -z $asar_exec ]]; then
+		echo 'No asar on PATH; installing @electron/asar locally...'
+		(
+			cd "$work_dir" || exit 1
+			echo '{"name":"patch-stage","version":"0.0.1","private":true}' \
+				> package.json || exit 1
+			npm install --no-save --silent @electron/asar
+		) || {
+			echo 'Failed to install @electron/asar.' >&2
+			return 1
+		}
+		asar_exec="$work_dir/node_modules/.bin/asar"
+	fi
+	if [[ ! -x $asar_exec ]]; then
+		echo "asar is not executable: $asar_exec" >&2
+		return 1
+	fi
+	echo "Using asar executable: $asar_exec"
+}
+
 main() {
 	local src="${1:-}"
 	local tmp
@@ -91,9 +118,9 @@ main() {
 	# Globals the patch stage reads.
 	work_dir="$tmp/work"
 	app_staging_dir="$tmp/staging"
-	asar_exec=$(command -v asar || command -v npx)
-	export work_dir app_staging_dir project_root asar_exec
 	mkdir -p "$work_dir" "$app_staging_dir/resources"
+	_resolve_asar || exit 1
+	export work_dir app_staging_dir project_root asar_exec
 
 	if [[ -n $src ]]; then
 		cp "$src/app.asar" "$app_staging_dir/resources/" || exit 1


### PR DESCRIPTION
Two independent changes; happy to split into separate PRs if you'd prefer.

## 1. `feat(launcher)`: kill a replaced Claude Desktop UI before relaunch

When `dpkg`/`rpm` replaces the Electron binary underneath a running
instance, the old process keeps its deleted executable **and** Electron's
single-instance lock. The next launch silently loses the lock and appears
to do nothing — no window, no error.

Adds `cleanup_replaced_desktop_ui` to `launcher-common.sh`, wired into the
deb, rpm and AppImage launchers. It matches a live UI on the `--class`
fingerprint, checks whether `/proc/PID/exe` reads `(deleted)`, and
terminates only that process — `SIGTERM`, escalating to `SIGKILL` if it
survives. The `(deleted)` check is what keeps it from touching a
legitimately running instance.

Covered by new `launcher-common.bats` cases.

Also carries local WIP that is **inert in the current build**:

- `patches/config.sh`: parked `patch_asar_trusted_folder_guard` and
  `patch_asar_additional_dirs_guard` (`config.sh` stays sourced-but-not-wired).
- `cowork-fallback/cowork.sh`: treat YukonSilver as supported on Linux so the
  bwrap fallback backend doesn't delete the VM bundle before the local daemon
  starts (fallback path, not wired into the build).
- `docs/learnings`: update the cowork-vm-daemon and patching-minified-js notes.

## 2. `fix(tests)`: resolve a real asar in the patch-stage harness

`tests/test-patch-stage.sh` invoked `"$asar_exec"` as a single word, so its
fallback could never work:

```bash
asar_exec=$(command -v asar || command -v npx)
```

The first call site is `"$asar_exec" extract-file "$asar_path" package.json`,
which under the fallback becomes `npx extract-file app.asar package.json`.
**npx reads `extract-file` as a package name**, fetches an unrelated
`extract-file@1.0.0` from the registry and runs it. `package.json` is never
extracted, `desktopName` comes back empty, and the WM_CLASS tripwire fails
the build on garbage input rather than on anything real.

Net effect: on any machine without `asar` on `PATH`, the suite reports a
patch failure that does not exist — which reads like "the patches are
broken" to anyone running it for the first time.

Replaced with `_resolve_asar`: prefer a real `asar`; else `npm install
@electron/asar` into `$work_dir` the way `scripts/setup/dependencies.sh`
already does for the build; else fail loud. No `npx` path survives.

### Verification

Against the pinned **1.40609.1** official `.deb`:

| scenario | result |
|---|---|
| `asar` on PATH | used directly, no stray local install |
| `asar` absent | installs to `$work_dir`, resolves v3.4.1 |
| absent + npm broken | `rc=1`, loud message, no silent fallback |
| mutation check | restoring the old line re-selects `/usr/bin/npx` |

End-to-end with `asar` absent from `PATH`: patch stage exits 0, all 160 JS
files parse, 5 markers survive the repack, second pass byte-identical.

The full patch stage is also green on `1.40609.1` with all five active
patches binding (`quick_window` → `jU`, `org_plugins_path`,
`virtiofsd_probe`, `cowork_bwrap` A/B/C1, `tray_icon_env_override`), AU-1 /
MB-1 / WM_CLASS tripwires clear. `patch-anchors.bats` + `app-asar.bats` (39)
and `launcher-common.bats` (120) pass. `shellcheck` clean.

The pre-existing `C2: warm download anchor not present in this bundle`
warning is unchanged — C2 is best-effort by design.


## 3. Portability audit follow-ups (`0e0a723`, `1567f6b`)

The branch was audited for anything that only holds on the development
machine. Two things came out of it:

**`readlink -f` was a works-on-one-layout special case.** The replaced-UI
detection read `/proc/PID/exe` with `readlink -f`, which canonicalizes and
therefore requires every parent directory of the link target to still
exist. That's true for a plain file replace (dpkg/rpm upgrading in the same
layout — the shape the feature was developed against) but false when the
whole install directory goes away, e.g. a package migration such as this
repo's own `claude-desktop` → `claude-desktop-unofficial` transition. On
that shape `readlink -f` exits nonzero and the stale UI silently keeps the
single-instance lock — the exact bug the cleanup exists to fix. Verified
empirically both ways; plain `readlink` returns the raw link content with
the ` (deleted)` marker in both shapes. A new mutation-checked bats case
removes the whole install directory before the cleanup runs: restoring
`readlink -f` turns it red while the file-only-deleted case stays green.

Both test spawns also close fd 3 in the child (bats' run-coordination
pipe) — without that, a failure mode that leaves the blocked child alive
hangs the entire bats run instead of reporting red. And `_proc_state` now
applies `2>/dev/null` before the input redirect, so a PID vanishing
mid-scan no longer prints to the launcher log.

**Dedup refactor.** `cleanup_replaced_desktop_ui` had arrived carrying
verbatim copies of the SIGTERM→poll→SIGKILL escalation and the
fingerprint PID scan that already existed in the file; both are now shared
helpers (`_kill_pids_escalating`, `_claude_desktop_ui_pids`) with log
strings unchanged. `cleanup_orphaned_cowork_daemon` was deliberately left
out: its poll predicate is a `pgrep` re-scan rather than `kill -0` on
captured PIDs, and a reaper's poll predicate must equal its kill
predicate.

Nothing in the diff references machine-specific paths, users, or hosts;
`WM_CLASS` remains the build-time `@@WM_CLASS@@` substitution.
`tests/launcher-common.bats`: 121/121.
