### PR TITLE
docs: hand project lead to @sabiut, refresh CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,73 +2,61 @@
 #
 # Rules match top-to-bottom; the LAST matching rule wins.
 # Layout:
-#   1. Default owner
-#   2. Explicit @aaddrick assignments grouped by logical role
-#      (listed even where redundant, so the intent is visible to
-#      future collaborators scanning the file)
+#   1. Default owner (@sabiut — project lead since 2026-09)
+#   2. Explicit assignments grouped by logical role (listed even
+#      where redundant, so the intent is visible to future
+#      collaborators scanning the file)
 #   3. Cowork and Nix overrides at the bottom so they stick
 #
 # Each listed user must be a repo collaborator (Settings →
 # Collaborators) with at least read access, or GitHub silently
 # ignores them.
+#
+# @aaddrick remains the repository owner (a personal-account repo has
+# no admin role to grant) and holds the release/distribution
+# credentials — APT and DNF signing keys, the Cloudflare Worker — so
+# the publishing surfaces below carry both names.
 
-# ---- Default: aaddrick owns anything not explicitly claimed ----
-*                                       @aaddrick
+# ---- Default: @sabiut owns anything not explicitly claimed ----
+*                                       @sabiut
 
 # ---- Build orchestration ----
 # The top-level dispatcher and shared shell utilities.
-/build.sh                               @aaddrick
-/scripts/_common.sh                     @aaddrick
+/build.sh                               @sabiut
+/scripts/_common.sh                     @sabiut
 
 # ---- Setup (host detection, dependencies, upstream download) ----
-/scripts/setup/                         @aaddrick
+/scripts/setup/                         @sabiut
 
 # ---- Electron patches / minified JS ----
-# The regex-driven patches applied to the unpacked app.asar, plus
-# the frame-fix wrapper and native-binding stubs that ride along.
-/scripts/patches/_common.sh             @aaddrick
-/scripts/patches/app-asar.sh            @aaddrick
-/scripts/patches/titlebar.sh            @aaddrick
-/scripts/patches/claude-code.sh         @aaddrick
-/scripts/frame-fix-wrapper.js           @aaddrick
-/scripts/claude-native-stub.js          @aaddrick
-
-# ---- Linux desktop integration ----
-# Tray, menu bar, and quick-window behavior on Wayland/X11.
-/scripts/patches/tray.sh                @aaddrick
-/scripts/patches/quick-window.sh        @aaddrick
-
-# ---- Staging (non-cowork) ----
-# Electron copy-out, icon processing, locales, SSH helpers.
-/scripts/staging/electron.sh            @aaddrick
-/scripts/staging/icons.sh               @aaddrick
-/scripts/staging/locales.sh             @aaddrick
-/scripts/staging/ssh-helpers.sh         @aaddrick
+# The regex-driven patches applied to the unpacked app.asar.
+/scripts/patches/                       @sabiut
 
 # ---- Packaging formats (deb, rpm, AppImage) + runtime launcher ----
-/scripts/packaging/                     @aaddrick
-/scripts/launcher-common.sh             @aaddrick
+/scripts/packaging/                     @sabiut
+/scripts/launcher-common.sh             @sabiut
 
 # ---- Distribution & signing ----
-# APT/DNF repo publishing, GPG signing, release automation.
+# APT/DNF repo publishing, GPG signing, release automation, and the
+# Cloudflare Worker that fronts the binaries. Credentials live with
+# @aaddrick, so both maintainers are on these.
 # Most of this lives in workflows — gh-pages branch content isn't
 # reachable via CODEOWNERS.
-/.github/workflows/                     @aaddrick
-/scripts/resolve-download-url.py        @aaddrick
+/.github/workflows/                     @sabiut @aaddrick
+/worker/                                @sabiut @aaddrick
 
 # ---- CI / other GitHub metadata ----
-/.github/                               @aaddrick
+/.github/                               @sabiut
 
 # ---- Docs & style ----
-/README.md                              @aaddrick
-/CLAUDE.md                              @aaddrick
-/AGENTS.md                              @aaddrick
-/CONTRIBUTING.md                        @aaddrick
-/CHANGELOG.md                           @aaddrick
-/RELEASING.md                           @aaddrick
-/SECURITY.md                            @aaddrick
-/docs/styleguides/                      @aaddrick
-/docs/                                  @aaddrick
+/README.md                              @sabiut
+/CLAUDE.md                              @sabiut
+/AGENTS.md                              @sabiut
+/CONTRIBUTING.md                        @sabiut
+/CHANGELOG.md                           @sabiut
+/RELEASING.md                           @sabiut @aaddrick
+/SECURITY.md                            @sabiut @aaddrick
+/docs/                                  @sabiut
 
 # ---- Testing & release quality ----
 # Integration test suite, artifact validation, flag-parsing tests,
@@ -76,15 +64,6 @@
 # @RayCharlizard via the override below.
 /tests/                                 @sabiut
 /scripts/doctor.sh                      @sabiut
-/.github/workflows/test-artifacts.yml   @sabiut
-/.github/workflows/test-flags.yml       @sabiut
-/.github/workflows/tests.yml            @sabiut
-
-# Shared review — either owner can approve.
-# troubleshooting.md is mostly the --doctor user-facing guide; lint
-# touches everything, so either maintainer can sign off.
-/docs/troubleshooting.md                @aaddrick @sabiut
-/.github/workflows/shellcheck.yml       @aaddrick @sabiut
 
 #===============================================================================
 # Overrides — listed last so their assignments stick against the
@@ -92,12 +71,11 @@
 #===============================================================================
 
 # ---- Cowork ----
-# Electron-side patching, staging, daemon, and integration tests.
-/scripts/patches/cowork.sh              @RayCharlizard
-/scripts/staging/cowork-resources.sh    @RayCharlizard
-/scripts/cowork-vm-service.js           @RayCharlizard
+# The bwrap fallback patch, its runtime helpers, and its tests/docs.
+/scripts/patches/cowork-bwrap.sh        @RayCharlizard
+/scripts/cowork-fallback/               @RayCharlizard
 /tests/cowork-*.bats                    @RayCharlizard
-/docs/cowork-*.md                       @RayCharlizard
+/docs/learnings/cowork-*.md             @RayCharlizard
 
 # ---- Nix ----
 /flake.nix                              @typedrat

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,12 +91,17 @@ CODEOWNERS auto-requests reviews; this list is for human discoverability.
   packaging, docs, `tests/`, `scripts/doctor.sh`. Final say on
   direction and releases.
 - **@aaddrick**: repository owner, so the owner-only surfaces stay here
-  — repo settings, branch protection, Actions secrets and variables
-  (`REPO_VERSION`, `CLAUDE_DESKTOP_VERSION`), and security advisories —
+  — repo settings, branch protection, Actions secrets, and security
+  advisories —
   along with the release credentials (APT/DNF signing, the Cloudflare
   Worker). Co-owner on `.github/workflows/`, `worker/`, `RELEASING.md`,
   and `SECURITY.md`. Otherwise stepped back — still around for
   questions and for pressing the buttons only an owner can press.
+  `REPO_VERSION` and `CLAUDE_DESKTOP_VERSION` are Actions *variables*,
+  not secrets: any collaborator can bump them with `gh variable set`
+  even though the Settings UI page is owner-only. Upstream-triggered
+  releases need no one at all — `check-claude-version.yml` sets the
+  version and pushes the tag itself.
 - **@RayCharlizard**: Cowork (`scripts/patches/cowork-bwrap.sh`,
   `scripts/cowork-fallback/`, `tests/cowork-*.bats`).
 - **@typedrat**: Nix (`flake.nix`, `flake.lock`, `/nix/`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,8 @@ A few minutes here saves a round-trip later. Match your task to the right channe
   declined by default — see [What we accept](#what-we-accept).
 - **Security concern?** Don't file a public issue. Use
   [SECURITY.md](SECURITY.md) — GitHub Security Advisories route to
-  @aaddrick privately.
+  @aaddrick privately (owner-only on a personal-account repo); @sabiut
+  is looped in.
 
 ## Where to find what
 
@@ -86,10 +87,18 @@ Priority rule: a broken-patch upstream release beats feature work.
 
 CODEOWNERS auto-requests reviews; this list is for human discoverability.
 
-- **@aaddrick**: default. Build, non-Cowork patches, desktop, packaging, docs.
-- **@sabiut**: `tests/`, `scripts/doctor.sh`, test workflows.
-- **@RayCharlizard**: Cowork (`scripts/patches/cowork.sh`,
-  `scripts/cowork-vm-service.js`, `tests/cowork-*.bats`).
+- **@sabiut**: project lead and default owner. Build, patches, desktop,
+  packaging, docs, `tests/`, `scripts/doctor.sh`. Final say on
+  direction and releases.
+- **@aaddrick**: repository owner, so the owner-only surfaces stay here
+  — repo settings, branch protection, Actions secrets and variables
+  (`REPO_VERSION`, `CLAUDE_DESKTOP_VERSION`), and security advisories —
+  along with the release credentials (APT/DNF signing, the Cloudflare
+  Worker). Co-owner on `.github/workflows/`, `worker/`, `RELEASING.md`,
+  and `SECURITY.md`. Otherwise stepped back — still around for
+  questions and for pressing the buttons only an owner can press.
+- **@RayCharlizard**: Cowork (`scripts/patches/cowork-bwrap.sh`,
+  `scripts/cowork-fallback/`, `tests/cowork-*.bats`).
 - **@typedrat**: Nix (`flake.nix`, `flake.lock`, `/nix/`).
 
 ## Before submitting a PR

--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ The official `.deb` covers one packaging target. What it leaves out is a long ta
 
 ---
 
+## Maintainership
+
+As of September 2026, [@sabiut](https://github.com/sabiut) leads this project. I ([@aaddrick](https://github.com/aaddrick)) am stepping back to focus on other things. @sabiut has been the most consistent contributor here and has final say on direction, releases, and what lands.
+
+The repo stays where it is — `aaddrick/claude-desktop-debian`, at @sabiut's request. No transfer, no new URLs: existing APT/DNF sources, issue links, and clone remotes all keep working. I still hold the signing keys and the Cloudflare Worker credentials, so publishing surfaces list both of us in [CODEOWNERS](.github/CODEOWNERS).
+
+A repository owned by a personal account has only two access levels — owner and collaborator — so a few things can't be handed over without moving the repo: settings, branch protection, Actions secrets and variables, and security advisories. Those still land on me. Ping me and I'll press the button.
+
+I'll still be around for questions and the occasional PR.
+
+---
+
 ## Features
 
 - **Official app, extra formats**: repackages Anthropic's official Linux `.deb` into `.rpm`, AppImage, and AUR builds.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The repo stays where it is — `aaddrick/claude-desktop-debian`, at @sabiut's re
 
 A repository owned by a personal account has only two access levels — owner and collaborator — so a few things can't be handed over without moving the repo: settings, branch protection, Actions secrets and variables, and security advisories. Those still land on me. Ping me and I'll press the button.
 
-I'll still be around for questions and the occasional PR.
+I'll still be around for questions and the occasional PR — reachable on [GitHub](https://github.com/aaddrick) or [LinkedIn](https://www.linkedin.com/in/aaddrick/).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ As of September 2026, [@sabiut](https://github.com/sabiut) leads this project. I
 
 The repo stays where it is — `aaddrick/claude-desktop-debian`, at @sabiut's request. No transfer, no new URLs: existing APT/DNF sources, issue links, and clone remotes all keep working. I still hold the signing keys and the Cloudflare Worker credentials, so publishing surfaces list both of us in [CODEOWNERS](.github/CODEOWNERS).
 
-A repository owned by a personal account has only two access levels — owner and collaborator — so a few things can't be handed over without moving the repo: settings, branch protection, Actions secrets and variables, and security advisories. Those still land on me. Ping me and I'll press the button.
+A repository owned by a personal account has only two access levels — owner and collaborator — so a few things can't be handed over without moving the repo: settings, branch protection, Actions secrets, and security advisories. Those still land on me. Ping me and I'll press the button. Releases themselves are automatic, and the version variables are settable by any collaborator through `gh variable set`, so day-to-day work doesn't route through me.
 
 I'll still be around for questions and the occasional PR — reachable on [GitHub](https://github.com/aaddrick) or [LinkedIn](https://www.linkedin.com/in/aaddrick/).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,7 +28,7 @@ This project repackages an upstream Electron app. The boundary matters:
 
 ## Response
 
-GitHub Advisories notify @aaddrick. Acknowledgement is usually within a few days. Fix turnaround depends on the surface — packaging-layer bugs are usually fast; patches against minified upstream JS may need to wait for a tractable anchor in a future upstream release.
+GitHub Advisories notify @aaddrick — creating and managing advisories on a personal-account repository is owner-only, so that routing can't move. @sabiut is looped in on triage and fixes. Acknowledgement is usually within a few days. Fix turnaround depends on the surface — packaging-layer bugs are usually fast; patches against minified upstream JS may need to wait for a tractable anchor in a future upstream release.
 
 ## Disclosure history
 


### PR DESCRIPTION
@sabiut takes over as project lead. This is the docs half of the handover we agreed on, assigned to you so you can read your own job description before it lands and push back on anything that doesn't match what you signed up for.

## What changes

- **README** gains a `## Maintainership` section: you lead, I'm stepping back, final say on direction and releases is yours.
- **CODEOWNERS** default flips to `* @sabiut`. I stay co-owner only on the surfaces my credentials gate: `.github/workflows/`, `worker/`, `RELEASING.md`, `SECURITY.md`.
- **CONTRIBUTING** subsystem-owners list rewritten to match.
- **SECURITY** advisory routing stays with me, for a reason worth knowing (below).

## The repo stays where it is

At your request. No transfer, no new URLs. Existing APT/DNF sources, issue links, and clone remotes all keep working.

## The permissions catch

I went to make you an admin and there is no such thing here. A repository owned by a personal account has exactly two access levels, owner and collaborator, and ownership can't be shared ([docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/repository-access-and-collaboration/permission-levels-for-a-personal-account-repository)). The REST API doesn't even error: `PUT permission=admin` returns 204 and quietly stores `write`.

So the handover is real where it can be and honest where it can't. You already have what matters day to day: push, releases, issues, and acting as a code owner, so CODEOWNERS review-requests route to you properly. What can't move without moving the repo:

- repository settings and branch protection
- Actions **secrets**, including the `GH_PAT` that `check-claude-version.yml` uses to push release tags
- security advisories
- webhooks and deploy keys

Releases are not on that list. Upstream-triggered ones are fully automatic: `check-claude-version.yml` reads `vars.REPO_VERSION`, sets `CLAUDE_DESKTOP_VERSION`, and pushes the tag itself. And repo *variables* only need collaborator access through the API ([docs](https://docs.github.com/en/rest/actions/variables)), so `gh variable set REPO_VERSION --body X.Y.Z` works for you today even though the Settings page won't render for you. I had this wrong in my first draft of this PR and the docs are corrected in a follow-up commit.

The one thing to know: `GH_PAT` is my personal access token. If it expires, auto-release stops and only I can replace it. Worth a ping if a tag ever fails to appear after an upstream bump.

The README and CONTRIBUTING say this plainly rather than implying you have buttons you don't. Ping me and I'll press them. I'd rather that than you hitting a wall and wondering if you did something wrong.

If that friction gets annoying, the org move is the only route to giving you actual admin, and it's a different question from the transfer you declined: an org keeps the project neutrally owned rather than under either of our names. Not proposing it now, just flagging where the exit is.

## Drive-by fix

CODEOWNERS was stale enough to be misrouting reviews. It still assigned `scripts/patches/tray.sh`, `titlebar.sh`, `claude-code.sh`, `frame-fix-wrapper.js`, `scripts/staging/`, `cowork.sh`, and `cowork-vm-service.js`, none of which survived the v3.0.0 rebase. The Cowork override matched nothing at all, so @RayCharlizard hasn't been getting auto-requested on Cowork changes; they were falling through to the default owner. Repointed at `cowork-bwrap.sh`, `scripts/cowork-fallback/`, and `docs/learnings/cowork-*.md`.

Merge it when you're happy with it. It's your call now.

---
Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <Claude Opus 5> <noreply@anthropic.com>
70% AI / 30% Human
Claude: drafted the doc changes, audited CODEOWNERS against the current tree, found the personal-repo permission limitation and corrected the security-advisory claim it invalidated.
Human: negotiated the handover, decided the ownership split and what stays with the repo owner, directed scope.

https://claude.ai/code/session_01KzR5RGa78BJAFyKn4R3kMw
