### PR TITLE
local: integrate PRs #833 #816 #738 #825, disable cowork-bwrap on 1.4…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — 
 
 <!-- Updated automatically by check-claude-version; will be current at release time. -->
 
+### Fixed
+
+- GPU crash recovery (`--disable-gpu`, applied on the [#583](https://github.com/aaddrick/claude-desktop-debian/issues/583) FATAL signature, on XRDP sessions, and via `CLAUDE_DISABLE_GPU=1`) no longer also passes `--disable-software-rasterizer`. Disabling both hardware GPU and the software fallback could turn the recovery path into Chromium's fatal "GPU process isn't usable" abort; keeping the software rasterizer available lets affected systems render instead of crashing. ([#583](https://github.com/aaddrick/claude-desktop-debian/issues/583), [#714](https://github.com/aaddrick/claude-desktop-debian/issues/714), [#738](https://github.com/aaddrick/claude-desktop-debian/pull/738))
+- The launcher now terminates a Claude Desktop UI whose executable was replaced underneath it by a package upgrade, so the next launch starts the newly installed build instead of silently doing nothing. When dpkg/rpm replaces the Electron binary while an instance is running, the old process keeps its deleted executable and Electron's single-instance lock; the relaunch then loses the lock to the stale process and exits without a window or an error. `cleanup_replaced_desktop_ui` (deb, rpm, and AppImage launchers) matches a live UI on the `--class` fingerprint, requires the kernel's ` (deleted)` marker on `/proc/PID/exe` before touching anything, and escalates SIGTERM → SIGKILL only for those PIDs. Detection reads the marker with plain `readlink` rather than `readlink -f`, which fails when the install directory is gone too (a package migration or layout change, not just a same-layout file replace) and would silently miss the stale UI — pinned by a mutation-checked bats case that removes the whole install directory before the cleanup runs. Verified 121/121 on `launcher-common.bats` across Ubuntu 24.04/26.04, Debian 12/13, Fedora 42, openSUSE Leap 15.6, and Arch (bash 4.4→5.3, procps-ng 3.3.17→4.0.7).
+
 ## [v3.2.3] — 2026-09-03
 
 ### Fixed

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1437,9 +1437,12 @@ _doctor_check_electron_binary() {
 # Check the chrome-sandbox helper's setuid permissions (must be 4755,
 # owned by root). Official layout: chrome-sandbox sits at the package
 # root beside the ELF (no node_modules/electron/dist tree anymore).
-# Looks at the deb install path and, when an electron path is provided,
-# the chrome-sandbox beside it; the first existing file wins. Warns
-# when none is found (expected for AppImage).
+# When an electron path is provided, ONLY the chrome-sandbox beside it
+# is judged — that is the binary actually running; falling back to the
+# deb path would validate the wrong binary when an AppImage/Nix run
+# coexists with a stale deb tree. Without an electron path, the deb
+# install location is the best guess. Warns when the relevant file is
+# missing (expected for AppImage).
 #
 # _DOCTOR_DEB_SANDBOX overrides the hardcoded deb path (test hook; the
 # default is the real install location, so production is unaffected).
@@ -1447,35 +1450,30 @@ _doctor_check_electron_binary() {
 # Usage: _doctor_check_chrome_sandbox [electron_path]
 _doctor_check_chrome_sandbox() {
 	local electron_path="${1:-}"
-	local _deb_sandbox="${_DOCTOR_DEB_SANDBOX:-}"
-	[[ -n $_deb_sandbox ]] \
-		|| _deb_sandbox='/usr/lib/claude-desktop-unofficial/chrome-sandbox'
-	local sandbox_paths=("$_deb_sandbox")
-	# Also check relative to the provided electron path
+	local sandbox_path
 	if [[ -n $electron_path ]]; then
-		local electron_dir
-		electron_dir=$(dirname "$electron_path")
-		sandbox_paths+=("$electron_dir/chrome-sandbox")
+		# A specific binary is running: only its own chrome-sandbox is
+		# relevant.
+		sandbox_path="$(dirname "$electron_path")/chrome-sandbox"
+	else
+		# No binary path known: fall back to the deb install location.
+		sandbox_path="${_DOCTOR_DEB_SANDBOX:-}"
+		[[ -n $sandbox_path ]] \
+			|| sandbox_path='/usr/lib/claude-desktop-unofficial/chrome-sandbox'
 	fi
-	local sandbox_checked=false sandbox_path
-	for sandbox_path in "${sandbox_paths[@]}"; do
-		if [[ -f $sandbox_path ]]; then
-			sandbox_checked=true
-			local sandbox_perms sandbox_owner
-			sandbox_perms=$(stat -c '%a' "$sandbox_path" 2>/dev/null) || true
-			sandbox_owner=$(stat -c '%U' "$sandbox_path" 2>/dev/null) || true
-			if [[ $sandbox_perms == '4755' && $sandbox_owner == 'root' ]]; then
-				_pass "Chrome sandbox: permissions OK ($sandbox_path)"
-			else
-				_fail "Chrome sandbox: perms=${sandbox_perms:-?},\
+	if [[ -f $sandbox_path ]]; then
+		local sandbox_perms sandbox_owner
+		sandbox_perms=$(stat -c '%a' "$sandbox_path" 2>/dev/null) || true
+		sandbox_owner=$(stat -c '%U' "$sandbox_path" 2>/dev/null) || true
+		if [[ $sandbox_perms == '4755' && $sandbox_owner == 'root' ]]; then
+			_pass "Chrome sandbox: permissions OK ($sandbox_path)"
+		else
+			_fail "Chrome sandbox: perms=${sandbox_perms:-?},\
  owner=${sandbox_owner:-?}"
-				_info "Fix: sudo chown root:root $sandbox_path"
-				_info "     sudo chmod 4755 $sandbox_path"
-			fi
-			break
+			_info "Fix: sudo chown root:root $sandbox_path"
+			_info "     sudo chmod 4755 $sandbox_path"
 		fi
-	done
-	if [[ $sandbox_checked == false ]]; then
+	else
 		_warn 'Chrome sandbox not found (expected for AppImage)'
 	fi
 }

--- a/scripts/launcher-common.sh
+++ b/scripts/launcher-common.sh
@@ -323,8 +323,10 @@ build_electron_args() {
 		log_message \
 			'Previous launch hit GPU process FATAL - disabling GPU'
 	fi
-	[[ $_disable_gpu == true ]] \
-		&& electron_args+=('--disable-gpu' '--disable-software-rasterizer')
+	# Keep Chromium's software rasterizer available. Disabling both
+	# hardware GPU and the software fallback can make Electron abort
+	# with "GPU process isn't usable" instead of recovering.
+	[[ $_disable_gpu == true ]] && electron_args+=('--disable-gpu')
 
 	# X11 session - no display-backend flags needed.
 	if [[ $is_wayland != true ]]; then
@@ -421,8 +423,11 @@ _claude_desktop_ui_cmdline_matches() {
 # is: a process whose cmdline carries our --class fingerprint (see
 # _claude_desktop_ui_cmdline_matches) and is actually runnable (not
 # stopped/zombie), excluding our own launcher bash and its parent.
-_claude_desktop_ui_is_alive() {
-	local pid cmdline state
+#
+# _claude_desktop_ui_pids prints the fingerprint-matching PIDs, one per
+# line; _claude_desktop_ui_is_alive adds the runnable check on top.
+_claude_desktop_ui_pids() {
+	local pid cmdline
 	for pid in \
 		$(pgrep -u "$(id -u)" -f -- "--class=$WM_CLASS" 2>/dev/null); do
 		# Skip our own launcher bash and its parent.
@@ -430,14 +435,103 @@ _claude_desktop_ui_is_alive() {
 		cmdline=$(tr '\0' ' ' 2>/dev/null < "/proc/$pid/cmdline") \
 			|| continue
 		_claude_desktop_ui_cmdline_matches "$cmdline" || continue
+		printf '%s\n' "$pid"
+	done
+}
+
+# Process state letter from /proc/PID/status (R, S, T, t, Z, ...).
+# Pure bash: the launchers run before any PATH sanity check, so this
+# stays independent of awk/grep availability.
+_proc_state() {
+	local key value rest
+	while read -r key value rest; do
+		if [[ $key == 'State:' ]]; then
+			printf '%s' "$value"
+			return 0
+		fi
+	done 2>/dev/null < "/proc/$1/status"
+	return 1
+}
+
+# Is a live (runnable) Claude Desktop UI running for this user?
+_claude_desktop_ui_is_alive() {
+	local pid state
+	for pid in $(_claude_desktop_ui_pids); do
 		# Skip stopped (T/t) and zombie (Z) processes — not a live UI.
-		state=$(awk '/^State:/ {print $2; exit}' \
-			"/proc/$pid/status" 2>/dev/null) || continue
+		state=$(_proc_state "$pid") || continue
 		[[ $state == T || $state == t || $state == Z ]] && continue
 		# Found a genuine live Electron UI.
 		return 0
 	done
 	return 1
+}
+
+# SIGTERM every PID, wait up to ~2s for all of them to go, then
+# escalate to SIGKILL for whatever is left.  Logs "$label (PIDs: ...)",
+# or "$label (SIGKILL, PIDs: ...)" when escalation was needed.
+_kill_pids_escalating() {
+	local label="$1"
+	shift
+	local pid alive=false waited=0
+
+	for pid in "$@"; do
+		kill "$pid" 2>/dev/null || true
+	done
+
+	while ((waited < 20)); do
+		alive=false
+		for pid in "$@"; do
+			if kill -0 "$pid" 2>/dev/null; then
+				alive=true
+				break
+			fi
+		done
+		[[ $alive == false ]] && break
+		sleep 0.1
+		((waited++))
+	done
+
+	if [[ $alive == true ]]; then
+		for pid in "$@"; do
+			kill -KILL "$pid" 2>/dev/null || true
+		done
+		log_message "$label (SIGKILL, PIDs: $*)"
+	else
+		log_message "$label (PIDs: $*)"
+	fi
+}
+
+# Was this process's executable replaced (unlinked) underneath it?
+# The kernel appends " (deleted)" to /proc/PID/exe once the binary
+# behind a running process is gone, which is exactly what dpkg/rpm do
+# when they upgrade a package while its UI is still running.
+#
+# Plain readlink, NOT readlink -f: -f canonicalizes, so it fails when
+# the install DIRECTORY is gone too (a package migration or layout
+# change, not just a file replace) and the replaced UI would be
+# silently missed. The raw link content carries the marker either way.
+_claude_desktop_ui_is_replaced() {
+	local exe_path
+
+	exe_path=$(readlink "/proc/$1/exe" 2>/dev/null) || return 1
+	[[ $exe_path == *' (deleted)' ]]
+}
+
+# Terminate a live Claude Desktop UI whose executable was replaced
+# underneath it by dpkg/rpm. If left alive, the next launcher loses
+# Electron's single-instance lock to the old process and appears to
+# do nothing instead of starting the newly-installed build.
+cleanup_replaced_desktop_ui() {
+	local pids=() pid
+	for pid in $(_claude_desktop_ui_pids); do
+		_claude_desktop_ui_is_replaced "$pid" || continue
+		pids+=("$pid")
+	done
+
+	[[ ${#pids[@]} -gt 0 ]] || return 0
+
+	_kill_pids_escalating 'Killed replaced Claude Desktop UI' \
+		"${pids[@]}"
 }
 
 # Kill orphaned cowork-vm-service daemon processes.
@@ -544,33 +638,8 @@ cleanup_stale_desktop_helpers() {
 
 	[[ ${#matched[@]} -gt 0 ]] || return 0
 
-	for pid in "${matched[@]}"; do
-		kill "$pid" 2>/dev/null || true
-	done
-
-	local wait_count=0 alive
-	while ((wait_count < 20)); do
-		alive=false
-		for pid in "${matched[@]}"; do
-			if kill -0 "$pid" 2>/dev/null; then
-				alive=true
-				break
-			fi
-		done
-		[[ $alive == false ]] && break
-		sleep 0.1
-		wait_count=$((wait_count + 1))
-	done
-
-	if [[ $alive == true ]]; then
-		for pid in "${matched[@]}"; do
-			kill -KILL "$pid" 2>/dev/null || true
-		done
-		log_message \
-			"Killed stale Claude Desktop helpers (SIGKILL, PIDs: ${matched[*]})"
-	else
-		log_message "Killed stale Claude Desktop helpers (PIDs: ${matched[*]})"
-	fi
+	_kill_pids_escalating 'Killed stale Claude Desktop helpers' \
+		"${matched[@]}"
 }
 
 # Clean up stale SingletonLock if the owning process is no longer running.

--- a/scripts/packaging/appimage.sh
+++ b/scripts/packaging/appimage.sh
@@ -82,6 +82,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 
+cleanup_replaced_desktop_ui
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock

--- a/scripts/packaging/deb.sh
+++ b/scripts/packaging/deb.sh
@@ -118,6 +118,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 
+cleanup_replaced_desktop_ui
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock
@@ -233,6 +234,31 @@ if [ -n "\$SANDBOX_PATH" ] && [ -f "\$SANDBOX_PATH" ]; then
 else
     echo "Warning: chrome-sandbox binary not found in local package at \$LOCAL_SANDBOX_PATH. Sandbox may not function correctly."
 fi
+
+# --- Remove legacy bwrap-attached AppArmor profiles (#542) ---
+# 2.x installs shipped a profile attached to the shared /usr/bin/bwrap. It is
+# no longer installed, but an upgrade never removes it: dpkg runs the *old*
+# package's postrm with "upgrade", and that cleanup arm only matches
+# remove|purge|abort-install. The stale file then collides with the distro's
+# own profile (Ubuntu ships bwrap-userns-restrict, also attached to
+# /usr/bin/bwrap); AppArmor resolves neither, bwrap falls through to
+# unprivileged_userns, and glycin's sandboxed image decoding dies -- unusable
+# GDM greeter, GTK apps aborting on icon loads, gnome-keyring unable to
+# prompt. Same marker-header rule as below: files without it were written by
+# the admin (or another package) and are preserved. apparmor_parser -R is
+# needed as well as rm -- deleting the file leaves the profile loaded in the
+# kernel, so the conflict survives until the next reboot.
+for _legacy_profile in "/etc/apparmor.d/claude-desktop-bwrap" \
+    "/etc/apparmor.d/${package_name}-bwrap"; do
+    if [ -e "\$_legacy_profile" ] \
+        && grep -q "managed by the claude-desktop" "\$_legacy_profile" 2>/dev/null; then
+        if command -v apparmor_parser >/dev/null 2>&1; then
+            apparmor_parser -R "\$_legacy_profile" >/dev/null 2>&1 || true
+        fi
+        rm -f "\$_legacy_profile" 2>/dev/null || true
+        echo "Removed legacy AppArmor profile \$_legacy_profile"
+    fi
+done
 
 # --- AppArmor profile for Chromium's user-namespace sandbox ---
 # Ubuntu 24.04+ sets kernel.apparmor_restrict_unprivileged_userns=1, which

--- a/scripts/packaging/rpm.sh
+++ b/scripts/packaging/rpm.sh
@@ -112,6 +112,7 @@ fi
 setup_logging || exit 1
 setup_electron_env
 
+cleanup_replaced_desktop_ui
 cleanup_orphaned_cowork_daemon
 cleanup_stale_desktop_helpers
 cleanup_stale_lock

--- a/scripts/patches/app-asar.sh
+++ b/scripts/patches/app-asar.sh
@@ -49,7 +49,6 @@ active_patches=(
 	patch_quick_window
 	patch_org_plugins_path
 	patch_virtiofsd_probe
-	patch_cowork_bwrap
 	patch_tray_icon_env_override
 )
 

--- a/tests/doctor.bats
+++ b/tests/doctor.bats
@@ -1699,19 +1699,19 @@ _stub_stat() {
 	[[ $output == *'not found'* ]]
 }
 
-@test "_doctor_check_chrome_sandbox: deb path wins when both sandboxes exist (single report)" {
-	# Pins probe precedence and the loop's break: with both the deb path
-	# and an electron-adjacent sandbox present, the deb path is judged
-	# and exactly ONE result line prints. Deleting the break (double
-	# report) or reordering the probe array fails this.
+@test "_doctor_check_chrome_sandbox: electron-adjacent sandbox wins when both exist (single report)" {
+	# FLIPPED from #745's deb-path-wins expectation: this fix judges
+	# ONLY the running binary's sandbox when an electron path is given,
+	# so with both files present the electron-adjacent one is reported.
+	# Still pins the single-report contract.
 	_DOCTOR_DEB_SANDBOX="$TEST_TMP/deb-sandbox"
 	: > "$TEST_TMP/deb-sandbox"
 	mkdir -p "$TEST_TMP/app"
 	: > "$TEST_TMP/app/chrome-sandbox"
 	_stub_stat '4755' 'root'
 	run _doctor_check_chrome_sandbox "$TEST_TMP/app/electron"
-	[[ $output == *"$TEST_TMP/deb-sandbox"* ]]
-	[[ $output != *"$TEST_TMP/app/chrome-sandbox"* ]]
+	[[ $output == *"$TEST_TMP/app/chrome-sandbox"* ]]
+	[[ $output != *"$TEST_TMP/deb-sandbox"* ]]
 	[[ $(grep -c 'Chrome sandbox' <<< "$output") -eq 1 ]]
 }
 
@@ -1722,4 +1722,44 @@ _stub_stat() {
 	run _doctor_check_chrome_sandbox ''
 	[[ $output == *'[PASS]'* ]]
 	[[ $output == *"$TEST_TMP/deb-sandbox"* ]]
+}
+
+@test "_doctor_check_chrome_sandbox: ignores a stale deb sandbox when an electron path is given" {
+	# Regression guard (#714-class false green): a valid deb sandbox
+	# exists, but the running binary (electron_path) has none. The old
+	# code validated the deb path and reported PASS for a sandbox that
+	# is not in use. The deb path must be ignored entirely -> WARN,
+	# never PASS.
+	_DOCTOR_DEB_SANDBOX="$TEST_TMP/deb-sandbox"
+	: > "$TEST_TMP/deb-sandbox"
+	mkdir -p "$TEST_TMP/app"
+	# No chrome-sandbox next to electron.
+	_stub_stat '4755' 'root'
+	run _doctor_check_chrome_sandbox "$TEST_TMP/app/electron"
+	[[ $output == *'[WARN]'* ]]
+	[[ $output != *'[PASS]'* ]]
+	[[ $output != *"$TEST_TMP/deb-sandbox"* ]]
+}
+
+@test "_doctor_check_chrome_sandbox: judges the electron-path sandbox, not the deb one, when both exist" {
+	# Regression guard: the running binary's sandbox has the wrong perms
+	# (0755) while a stale deb sandbox is fine (4755 root). The old code
+	# checked the deb path first and PASSed; the electron-path sandbox
+	# is the one that must be judged -> FAIL.
+	_DOCTOR_DEB_SANDBOX="$TEST_TMP/deb-sandbox"
+	: > "$TEST_TMP/deb-sandbox"
+	mkdir -p "$TEST_TMP/app"
+	: > "$TEST_TMP/app/chrome-sandbox"
+	# Path-aware stub: electron's sandbox is bad, everything else good.
+	stat() {
+		if [[ $3 == "$TEST_TMP/app/chrome-sandbox" ]]; then
+			if [[ $2 == '%a' ]]; then echo '0755'; else echo 'root'; fi
+		else
+			if [[ $2 == '%a' ]]; then echo '4755'; else echo 'root'; fi
+		fi
+	}
+	run _doctor_check_chrome_sandbox "$TEST_TMP/app/electron"
+	[[ $output == *'[FAIL]'* ]]
+	[[ $output == *'perms=0755'* ]]
+	[[ $output != *'[PASS]'* ]]
 }

--- a/tests/launcher-common.bats
+++ b/tests/launcher-common.bats
@@ -951,6 +951,75 @@ s.close()
 	[[ $status -ne 0 ]]
 }
 
+@test "cleanup_replaced_desktop_ui: kills UI with deleted executable" {
+	local stale_bin="$TEST_TMP/claude-bash"
+	local block_fifo="$TEST_TMP/block"
+	local stale_pid
+
+	mkfifo "$block_fifo"
+	cp /bin/bash "$stale_bin"
+	# fd 3 is bats' run-coordination pipe: a spawned process that
+	# inherits it keeps bats waiting for EOF if it ever survives the
+	# test, so close it in the child.
+	# shellcheck disable=SC2016  # inner shell expands $1
+	"$stale_bin" -c 'read -r _ < "$1"' \
+		claude-test "$block_fifo" --class=com.anthropic.Claude 3>&- &
+	stale_pid=$!
+	sleep 0.1
+	rm "$stale_bin"
+
+	readlink -f "/proc/$stale_pid/exe" | grep -q ' (deleted)$'
+
+	setup_logging
+	run cleanup_replaced_desktop_ui
+
+	[[ $status -eq 0 ]]
+	run timeout 2 bash -c \
+		"while kill -0 '$stale_pid' 2>/dev/null; do sleep 0.1; done"
+	[[ $status -eq 0 ]]
+	run kill -0 "$stale_pid"
+	[[ $status -ne 0 ]]
+	grep -q 'Killed replaced Claude Desktop UI' "$log_file"
+}
+
+@test "cleanup_replaced_desktop_ui: still kills when the install dir is gone" {
+	# A package migration or layout change removes the whole install
+	# directory, not just the binary. `readlink -f` fails on that shape
+	# (it canonicalizes through a now-missing parent), so this pins the
+	# plain-readlink detection: reverting it turns this red while the
+	# file-only-deleted test above stays green.
+	local stale_dir="$TEST_TMP/gone-install-dir"
+	local block_fifo="$TEST_TMP/block-dirgone"
+	local stale_pid
+
+	mkfifo "$block_fifo"
+	mkdir -p "$stale_dir"
+	cp /bin/bash "$stale_dir/claude-bash"
+	# shellcheck disable=SC2016  # inner shell expands $1 (3>&-: see the
+	# fd-3 note in the deleted-executable test above)
+	"$stale_dir/claude-bash" -c 'read -r _ < "$1"' \
+		claude-test "$block_fifo" --class=com.anthropic.Claude 3>&- &
+	stale_pid=$!
+	sleep 0.1
+	rm -rf "$stale_dir"
+
+	# The very failure mode under test: -f cannot resolve this shape.
+	run readlink -f "/proc/$stale_pid/exe"
+	[[ $status -ne 0 ]]
+	readlink "/proc/$stale_pid/exe" | grep -q ' (deleted)$'
+
+	setup_logging
+	run cleanup_replaced_desktop_ui
+
+	[[ $status -eq 0 ]]
+	run timeout 2 bash -c \
+		"while kill -0 '$stale_pid' 2>/dev/null; do sleep 0.1; done"
+	[[ $status -eq 0 ]]
+	run kill -0 "$stale_pid"
+	[[ $status -ne 0 ]]
+	grep -q 'Killed replaced Claude Desktop UI' "$log_file"
+}
+
 @test "run_electron_and_cleanup: runs cleanup after Electron exits and preserves status" {
 	local marker="$TEST_TMP/cleanup-ran"
 	local electron="$TEST_TMP/electron"

--- a/tests/launcher-disable-gpu.bats
+++ b/tests/launcher-disable-gpu.bats
@@ -4,9 +4,9 @@
 # Tests for the CLAUDE_DISABLE_GPU env var handling in
 # build_electron_args (scripts/launcher-common.sh). The var is an
 # opt-in workaround for the Chromium GPU process FATAL exhaustion
-# tracked in #583. CLAUDE_DISABLE_GPU=1 adds --disable-gpu and
-# --disable-software-rasterizer; co-occurrence with XRDP must not
-# stack duplicate flags.
+# tracked in #583. CLAUDE_DISABLE_GPU=1 adds --disable-gpu while
+# leaving Chromium's software rasterizer available; co-occurrence
+# with XRDP must not stack duplicate flags.
 #
 
 SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME}")" && pwd)"
@@ -76,7 +76,8 @@ args_count() {
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'CLAUDE_DISABLE_GPU=1' "$log_file"
 }
 
@@ -93,7 +94,7 @@ args_count() {
 	build_electron_args deb
 
 	[[ "$(args_count '--disable-gpu')" -eq 1 ]]
-	[[ "$(args_count '--disable-software-rasterizer')" -eq 1 ]]
+	[[ "$(args_count '--disable-software-rasterizer')" -eq 0 ]]
 	# Both signals should still log (independent diagnostic value),
 	# but only one set of flags should reach electron_args.
 	grep -q 'XRDP session detected' "$log_file"
@@ -154,7 +155,8 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'Previous launch hit GPU process FATAL' "$log_file"
 }
 
@@ -176,7 +178,8 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 }
 
 @test "disable-gpu: NixOS launcher header sections are detected" {
@@ -193,7 +196,8 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'Previous launch hit GPU process FATAL' "$log_file"
 }
 
@@ -256,7 +260,8 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 }
 
 @test "disable-gpu: crash signature deep in a large penultimate section is still detected" {
@@ -274,5 +279,6 @@ LOG
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 }

--- a/tests/launcher-xrdp-detection.bats
+++ b/tests/launcher-xrdp-detection.bats
@@ -103,7 +103,8 @@ args_count() {
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'XRDP session detected' "$log_file"
 }
 
@@ -114,7 +115,8 @@ args_count() {
 	build_electron_args deb
 
 	args_contain '--disable-gpu'
-	args_contain '--disable-software-rasterizer'
+	run args_contain '--disable-software-rasterizer'
+	[[ "$status" -ne 0 ]]
 	grep -q 'XRDP session detected' "$log_file"
 }
 
@@ -126,7 +128,7 @@ args_count() {
 	build_electron_args deb
 
 	[[ "$(args_count '--disable-gpu')" -eq 1 ]]
-	[[ "$(args_count '--disable-software-rasterizer')" -eq 1 ]]
+	[[ "$(args_count '--disable-software-rasterizer')" -eq 0 ]]
 	[[ "$(grep -c 'XRDP session detected' "$log_file")" -eq 1 ]]
 }
 


### PR DESCRIPTION
…6388.2

Local build integration on top of main @ 30e0e73 (OFFICIAL_DEB_VERSION 1.46388.2), used to produce the installed
claude-desktop-unofficial_1.46388.2_amd64.deb.

Integrated open PRs:
- #833 feat(launcher): kill replaced Claude Desktop UI before relaunch
- #816 fix(doctor): judge only the running binary's chrome-sandbox
- #738 fix(launcher): keep software rasterizer when disabling GPU; stale post-PR test assertions on main inverted to match (274/274 bats green: launcher-common, doctor, disable-gpu, xrdp)
- #825 fix(deb): remove legacy bwrap AppArmor profile on upgrade

Local deviation from main: patch_cowork_bwrap removed from active_patches — the 'cowork C1 (foreground download)' anchor matches no file on 1.46388.2 and aborts the patch stage (#820 follow-up needed). bwrap fallback is opt-in and unneeded on KVM hosts.